### PR TITLE
Allow nested data objects to handle there own types

### DIFF
--- a/src/Resolvers/DataFromArrayResolver.php
+++ b/src/Resolvers/DataFromArrayResolver.php
@@ -32,6 +32,10 @@ class DataFromArrayResolver
             return $value;
         }
 
+        if ($property->isData()) {
+            return $property->dataClassName()::from($value);
+        }
+
         if (! $this->shouldBeCasted($property, $value)) {
             return $value;
         }
@@ -48,13 +52,9 @@ class DataFromArrayResolver
             return $value;
         }
 
-        if ($property->isData()) {
-            return $this->execute($property->dataClassName(), $value);
-        }
-
         if ($property->isDataCollection()) {
             $items = array_map(
-                fn (array $item) => $this->execute($property->dataClassName(), $item),
+                fn ($item) => $property->dataClassName()::from($item),
                 $value
             );
 

--- a/tests/Fakes/ModelData.php
+++ b/tests/Fakes/ModelData.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Data;
+
+class ModelData extends Data
+{
+    public function __construct(
+        public int $id
+    ){
+    }
+
+    public static function fromDummyModel(DummyModel $model)
+    {
+        return new self($model->id);
+    }
+}

--- a/tests/Fakes/NestedModelCollectionData.php
+++ b/tests/Fakes/NestedModelCollectionData.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\DataCollection;
+
+class NestedModelCollectionData extends Data
+{
+    public function __construct(
+        /** @var \Spatie\LaravelData\Tests\Fakes\ModelData[] */
+        public DataCollection $models
+    ) {
+    }
+}

--- a/tests/Fakes/NestedModelData.php
+++ b/tests/Fakes/NestedModelData.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Data;
+
+class NestedModelData extends Data
+{
+    public function __construct(
+        public ModelData $model
+    ) {
+    }
+}


### PR DESCRIPTION
Currently, when creating a nested `Data` object from an array, the nested data that maps to another `Data` object either also has to be an array or has to already be that Data object.

This PR allows for those nested `Data` properties to be handled by the object itself.

**Basic Example**

Say I have the following `Data` classes:

```
class MemberData extends Data
{
    public function __construct(
        public string $name,
    ) {}

    public static function fromUser(User $user): static
    {
        return new static($user->name);
    }
}
```
and 
```
class TeamData extends Data
{
    public function __construct(
        public string     $name,
        public MemberData $leader,
    ) {}
}
```

I'm able to pass a `User` model to create the `MemberData` (`MemberData::from($user);`), however, I'm not able to do the same with the `TeamData` using an array i.e. I would have to :

```
TeamData::from([
    'name'   => 'The best team ever!',
    'leader'  => [
        'name' => $user->name
    ],
    // or 'leader'  => MemberData::from($user),
]);
```
Which means I would always have to explicitly create the nested `Data` objects or update the array structures throughout the code base whenever one of those `Data` objects changes.

This PR would allow the nested `UserData` class to make use of it's creation methods:

```
TeamData::from([
    'name'   => 'The best team ever!',
    'leader'  => $user,
]);
```



