### PR TITLE
Add CollectionOf Attribute for DataCollection

### DIFF
--- a/docs/advanced-usage/typescript.md
+++ b/docs/advanced-usage/typescript.md
@@ -19,7 +19,7 @@ class DataObject extends Data{
         public array $array,
         public Lazy|string $lazy,
         public SimpleData $simpleData,
-        /** @var \Spatie\LaravelData\Tests\Fakes\SimpleData[] */
+        #[CollectionOf(SimpleData::class)]
         public DataCollection $dataCollection,
     )
     {

--- a/docs/as-a-data-transfer-object/collections.md
+++ b/docs/as-a-data-transfer-object/collections.md
@@ -12,7 +12,7 @@ class AlbumData extends Data
 {
     public function __construct(
         public string $title,
-        /** @var SongData[] */
+        #[CollectionOf(SongData::class)]
         public DataCollection $songs,
     ) {
     }

--- a/docs/as-a-resource/from-data-to-resource.md
+++ b/docs/as-a-resource/from-data-to-resource.md
@@ -249,7 +249,7 @@ class AlbumData extends Data
 {
     public function __construct(
         public string $title,
-        /** @var SongData[] */
+        #[CollectionOf(SongData::class)]
         public DataCollection $songs,
     ) {
     }

--- a/docs/as-a-resource/lazy-properties.md
+++ b/docs/as-a-resource/lazy-properties.md
@@ -10,7 +10,7 @@ class AlbumData extends Data
 {
     public function __construct(
         public string $title,
-        /** @var SongData[] */
+        #[CollectionOf(SongData::class)]
         public DataCollection $songs,
     ) {
     }
@@ -28,7 +28,7 @@ class AlbumData extends Data
 {
     public function __construct(
         public string $title,
-        /** @var SongData[] */
+        #[CollectionOf(SongData::class)]
         public Lazy|DataCollection $songs,
     ) {
     }

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -309,7 +309,7 @@ class AuthorData extends Data
 {
     public function __construct(
         public string $name,
-        /** @var \App\Data\PostData[] */
+        #[CollectionOf(PostData::class)]
         public DataCollection $posts
     ) {
     }
@@ -512,7 +512,7 @@ class AuthorData extends Data
 {
     public function __construct(
         public string $name,
-        /** @var \App\Data\PostData[] */
+        #[CollectionOf(PostData::class)]
         public DataCollection $posts
     ) {
     }
@@ -578,7 +578,7 @@ class AuthorData extends Data
 {
     public function __construct(
         public string $name,
-        /** @var \App\Data\PostData[] */
+        #[CollectionOf(PostData::class)]
         public DataCollection|Lazy $posts
     ) {
     }

--- a/src/Attributes/CollectionOf.php
+++ b/src/Attributes/CollectionOf.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\LaravelData\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class CollectionOf
+{
+    public function __construct(
+        public string $target
+    ){}
+}

--- a/src/Support/DataProperty.php
+++ b/src/Support/DataProperty.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Str;
 use ReflectionNamedType;
 use ReflectionProperty;
 use ReflectionUnionType;
+use Spatie\LaravelData\Attributes\CollectionOf;
 use Spatie\LaravelData\Attributes\Validation\ValidationAttribute;
 use Spatie\LaravelData\Attributes\WithCast;
 use Spatie\LaravelData\Attributes\WithTransformer;
@@ -141,6 +142,14 @@ class DataProperty
         }
 
         if ($this->isDataCollection) {
+
+            $attributes = $this->property->getAttributes(CollectionOf::class)[0] ?? null;
+            $class = $attributes?->getArguments()[0] ?? null;
+
+            if (is_subclass_of($class, Data::class)) {
+                return $this->dataClassName = $class;
+            }
+
             $comment = $this->property->getDocComment();
 
             if ($comment === false) {

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Collection;
 use Spatie\LaravelData\Tests\Fakes\DefaultLazyData;
 use Spatie\LaravelData\Tests\Fakes\LazyData;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
+use Spatie\LaravelData\Tests\Fakes\SimpleDataCollectionWithAttribute;
+use Spatie\LaravelData\Tests\Fakes\SimpleDataCollectionWithComment;
 
 class DataCollectionTest extends TestCase
 {
@@ -352,5 +354,41 @@ class DataCollectionTest extends TestCase
             ]),
             SimpleData::collection(['A', 'B', 'C'])->toCollection()
         );
+    }
+
+    /** @test */
+    public function it_can_resolve_a_data_collection_with_a_comment()
+    {
+        $data =  SimpleDataCollectionWithComment::from(
+            [
+                'items' => [
+                    ['string' => 'Never gonna give you up!'],
+                    ['string' => 'Never gonna let you down!'],
+                ]
+            ]
+        );
+
+        $this->assertInstanceOf(SimpleData::class, $data->items[0]);
+        $this->assertEquals('Never gonna give you up!', $data->items[0]->string);
+        $this->assertInstanceOf(SimpleData::class, $data->items[1]);
+        $this->assertEquals('Never gonna let you down!', $data->items[1]->string);
+    }
+
+    /** @test */
+    public function it_can_resolve_a_data_collection_with_an_attribute()
+    {
+        $data =  SimpleDataCollectionWithAttribute::from(
+            [
+               'items' => [
+                   ['string' => 'Never gonna give you up!'],
+                   ['string' => 'Never gonna let you down!'],
+               ]
+            ]
+        );
+
+        $this->assertInstanceOf(SimpleData::class, $data->items[0]);
+        $this->assertEquals('Never gonna give you up!', $data->items[0]->string);
+        $this->assertInstanceOf(SimpleData::class, $data->items[1]);
+        $this->assertEquals('Never gonna let you down!', $data->items[1]->string);
     }
 }

--- a/tests/Fakes/SimpleDataCollectionWithAttribute.php
+++ b/tests/Fakes/SimpleDataCollectionWithAttribute.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Attributes\CollectionOf;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\DataCollection;
+
+class SimpleDataCollectionWithAttribute extends Data
+{
+    public function __construct(
+        #[CollectionOf(SimpleData::class)]
+        public DataCollection $items
+    ) {
+    }
+}

--- a/tests/Fakes/SimpleDataCollectionWithComment.php
+++ b/tests/Fakes/SimpleDataCollectionWithComment.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\DataCollection;
+
+class SimpleDataCollectionWithComment extends Data
+{
+    public function __construct(
+        /** @var \Spatie\LaravelData\Tests\Fakes\SimpleData[] */
+        public DataCollection $items
+    ) {
+    }
+}


### PR DESCRIPTION
Currently, the `DataCollection` comment seems to require the FQN regardless of a `use` statement.

This PR provided an alternative way to declare the type of data the `DataCollection` represents:
```
class AlbumData extends Data
{
    public function __construct(
        public string $title,
        #[CollectionOf(SongData::class)]
        public DataCollection $songs,
    ) {
    }
}
```

This should not introduce a breaking change.