### PR TITLE
Changed password rule parameter "length" to "min"

### DIFF
--- a/docs/advanced-usage/validation-attributes.md
+++ b/docs/advanced-usage/validation-attributes.md
@@ -604,7 +604,7 @@ public ?string $value;
 [Docs](https://laravel.com/docs/8.x/validation#rule-password)
 
 ```php
-#[Password(length: 12, letters: true, mixedCase: true, numbers: false, symbols: false, uncompromised: true, uncompromisedThreshold: 0)]
+#[Password(min: 12, letters: true, mixedCase: true, numbers: false, symbols: false, uncompromised: true, uncompromisedThreshold: 0)]
 public string $value; 
 ```
 


### PR DESCRIPTION
In the docs example should be "min" instead of "length"