### PR TITLE
Fixes PHP-notice

### DIFF
--- a/src/DataCollection.php
+++ b/src/DataCollection.php
@@ -101,7 +101,7 @@ class DataCollection implements Responsable, Arrayable, Jsonable, IteratorAggreg
         return new ArrayIterator($this->transform(TransformationType::withoutValueTransforming()));
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->items);
     }


### PR DESCRIPTION
Without having int as return type, we will generate notices like

```
Return type of Spatie\LaravelData\DataCollection::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/ahoi/test/vendor/spatie/laravel-data/src/DataCollection.php on line 104
```