### PR TITLE
docs: change authorize to authorized

### DIFF
--- a/docs/as-a-data-transfer-object/request-to-data-object.md
+++ b/docs/as-a-data-transfer-object/request-to-data-object.md
@@ -275,7 +275,7 @@ class SongData extends Data
     ) {
     }
 
-    public static function authorize(): bool
+    public static function authorized(): bool
     {
         return Auth::user()->name === 'Ruben';
     }

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -158,7 +158,7 @@ Since we're working with requests, wouldn't it be cool to validate the data comi
 ```php
 class PostDataRequest extends FormRequest
 {
-    public function authorize()
+    public function authorized()
     {
         return false;
     }


### PR DESCRIPTION
👋🏻

In the docs it's mentioned that you can add a static `authorize` method to the data class, just like with a form request. However this is not correct since it checks for a method called `authorized`.  This PR fixes the documentation to be aligned with the actual code.

Just wondering if it was intentional to call it `authorized`? Since Laravel's Form Requests use `authorize`?