### PR TITLE
PHP 8.1 for some validations

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -4,4 +4,4 @@ weight: 3
 ---
 
 This package requires:
-- PHP 8 or higher 
+- PHP 8.1 or higher 


### PR DESCRIPTION
In PHP 8 given rule is not working but if we try in PHP 8.1 it's working.
```
#[BeforeOrEqual(Carbon::yesterday())]
```