### PR TITLE
docs: fix typo in example

### DIFF
--- a/docs/as-a-resource/from-data-to-resource.md
+++ b/docs/as-a-resource/from-data-to-resource.md
@@ -187,7 +187,7 @@ The data object is smart enough to create a paginated response from this with li
 It is possible to change data objects in a collection:
 
 ```php
-$allSongs = Song::all());
+$allSongs = Song::all();
 
 SongData::collection($allSongs)->transform(function(SongData $song){
     $song->artist = 'Abba';


### PR DESCRIPTION
There was an extra parenthesis