### PR TITLE
🧪 Should be able to resolve a data with Enum properties

### DIFF
--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -721,20 +721,4 @@ class DataTest extends TestCase
         $this->assertInstanceOf(IntersectionTypeData::class, $data);
         $this->assertEquals($collection, $data->intersection);
     }
-
-    /** @test */
-    public function it_can_include_enum_data()
-    {
-        $this->onlyPHP81();
-
-        config(['data.casts.'.\BackedEnum::class => \Spatie\LaravelData\Casts\EnumCast::class]);
-
-        $dataClass = DataBlueprintFactory::new()->withProperty(
-            DataPropertyBlueprintFactory::new('fake')->withType(FakeEnum::class)
-        )->create();
-
-        $data = $dataClass::from(['fake' => 'a']);
-
-        $this->assertEquals(FakeEnum::Alpha, $data->fake);
-    }
 }

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -22,6 +22,7 @@ use Spatie\LaravelData\Tests\Fakes\DummyEnum;
 use Spatie\LaravelData\Tests\Fakes\DummyModel;
 use Spatie\LaravelData\Tests\Fakes\DummyModelWithCasts;
 use Spatie\LaravelData\Tests\Fakes\EmptyData;
+use Spatie\LaravelData\Tests\Fakes\FakeEnum;
 use Spatie\LaravelData\Tests\Fakes\IntersectionTypeData;
 use Spatie\LaravelData\Tests\Fakes\LazyData;
 use Spatie\LaravelData\Tests\Fakes\MultiLazyData;
@@ -719,5 +720,21 @@ class DataTest extends TestCase
 
         $this->assertInstanceOf(IntersectionTypeData::class, $data);
         $this->assertEquals($collection, $data->intersection);
+    }
+
+    /** @test */
+    public function it_can_include_enum_data()
+    {
+        $this->onlyPHP81();
+
+        config(['casts.'.\BackedEnum::class => \Spatie\LaravelData\Casts\EnumCast::class]);
+
+        $dataClass = DataBlueprintFactory::new()->withProperty(
+            DataPropertyBlueprintFactory::new('fake')->withType(FakeEnum::class)
+        )->create();
+
+        $data = $dataClass::from(['fake' => 'a']);
+
+        $this->assertEquals(FakeEnum::Alpha, $data->fake);
     }
 }

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -727,7 +727,7 @@ class DataTest extends TestCase
     {
         $this->onlyPHP81();
 
-        config(['casts.'.\BackedEnum::class => \Spatie\LaravelData\Casts\EnumCast::class]);
+        config(['data.casts.'.\BackedEnum::class => \Spatie\LaravelData\Casts\EnumCast::class]);
 
         $dataClass = DataBlueprintFactory::new()->withProperty(
             DataPropertyBlueprintFactory::new('fake')->withType(FakeEnum::class)

--- a/tests/Fakes/EnumData.php
+++ b/tests/Fakes/EnumData.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Casts\EnumCast;
+use Spatie\LaravelData\Data;
+
+class EnumData extends Data
+{
+    public function __construct(
+        public FakeEnum $enum,
+    ) {
+    }
+}

--- a/tests/Resolvers/DataFromArrayResolverTest.php
+++ b/tests/Resolvers/DataFromArrayResolverTest.php
@@ -9,6 +9,8 @@ use Spatie\LaravelData\Resolvers\DataFromArrayResolver;
 use Spatie\LaravelData\Tests\Fakes\BuiltInTypeWithCastData;
 use Spatie\LaravelData\Tests\Fakes\ComplicatedData;
 use Spatie\LaravelData\Tests\Fakes\DummyModel;
+use Spatie\LaravelData\Tests\Fakes\EnumData;
+use Spatie\LaravelData\Tests\Fakes\FakeEnum;
 use Spatie\LaravelData\Tests\Fakes\ModelData;
 use Spatie\LaravelData\Tests\Fakes\NestedLazyData;
 use Spatie\LaravelData\Tests\Fakes\NestedModelCollectionData;
@@ -221,5 +223,21 @@ class DataFromArrayResolverTest extends TestCase
 
         $this->assertIsInt($data->money);
         $this->assertEquals(314, $data->money);
+    }
+
+    /** @test */
+    public function it_allows_casting_of_enum_types()
+    {
+        $this->onlyPHP81();
+
+        config(['data.casts.'.\BackedEnum::class => \Spatie\LaravelData\Casts\EnumCast::class]);
+
+        /** @var \Spatie\LaravelData\Tests\Fakes\BuiltInTypeWithCastData $data */
+        $data = $this->action->execute(
+            EnumData::class,
+            ['enum' => 'a']
+        );
+
+        $this->assertEquals(FakeEnum::Alpha, $data->fake);
     }
 }


### PR DESCRIPTION
This PR aims to add a failing test on enum casting.

In the recent changes, `Enum` has been added as a built in type:

https://github.com/spatie/laravel-data/blob/df378da8887c5290f0972f18856c87dcb861377d/src/Support/DataProperty.php#L237-L241

https://github.com/spatie/laravel-data/blob/df378da8887c5290f0972f18856c87dcb861377d/src/Resolvers/DataFromArrayResolver.php#L44-L46

These lines prevents from casting the `Enum` type even if `WithCast` is explicitly given or `data.casts.\BackedEnum` is set.