### PR TITLE
Removes Spatie's Laravel Enums from dev requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "nunomaduro/collision": "^5.3",
         "orchestra/testbench": "^6.23",
         "phpunit/phpunit": "^9.3",
-        "spatie/laravel-enum": "^2.5",
         "spatie/laravel-typescript-transformer": "^2.0",
         "spatie/phpunit-snapshot-assertions": "^4.2",
         "spatie/test-time": "^1.2",

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -18,7 +18,6 @@ use Spatie\LaravelData\Tests\Factories\DataBlueprintFactory;
 use Spatie\LaravelData\Tests\Factories\DataPropertyBlueprintFactory;
 use Spatie\LaravelData\Tests\Fakes\DefaultLazyData;
 use Spatie\LaravelData\Tests\Fakes\DummyDto;
-use Spatie\LaravelData\Tests\Fakes\DummyEnum;
 use Spatie\LaravelData\Tests\Fakes\DummyModel;
 use Spatie\LaravelData\Tests\Fakes\DummyModelWithCasts;
 use Spatie\LaravelData\Tests\Fakes\EmptyData;
@@ -595,7 +594,6 @@ class DataTest extends TestCase
             'boolean' => true,
             'date' => CarbonImmutable::create(2020, 05, 16, 12, 00, 00),
             'nullable_date' => null,
-            'enum' => DummyEnum::published(),
         ]);
 
         $dataClass = new class () extends Data {
@@ -606,8 +604,6 @@ class DataTest extends TestCase
             public Carbon $date;
 
             public ?Carbon $nullable_date;
-
-            public DummyEnum $enum;
         };
 
         $data = $dataClass::from(DummyModel::findOrFail($model->id));
@@ -616,7 +612,6 @@ class DataTest extends TestCase
         $this->assertTrue($data->boolean);
         $this->assertTrue(CarbonImmutable::create(2020, 05, 16, 12, 00, 00)->eq($data->date));
         $this->assertNull($data->nullable_date);
-        $this->assertTrue($data->enum->equals(DummyEnum::published()));
     }
 
     /** @test */

--- a/tests/Fakes/DummyModel.php
+++ b/tests/Fakes/DummyModel.php
@@ -12,7 +12,6 @@ class DummyModel extends Model
         'date' => 'datetime',
         'nullable_date' => 'datetime',
         'boolean' => 'boolean',
-        'enum' => DummyEnum::class,
     ];
 
     public static function migrate()
@@ -24,7 +23,6 @@ class DummyModel extends Model
             $blueprint->dateTime('date');
             $blueprint->dateTime('nullable_date')->nullable();
             $blueprint->boolean('boolean');
-            $blueprint->string('enum');
 
             $blueprint->timestamps();
         });

--- a/tests/Resolvers/DataFromModelResolverTest.php
+++ b/tests/Resolvers/DataFromModelResolverTest.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Model;
 use Spatie\LaravelData\Resolvers\DataFromModelResolver;
 use Spatie\LaravelData\Tests\Factories\DataBlueprintFactory;
 use Spatie\LaravelData\Tests\Factories\DataPropertyBlueprintFactory;
-use Spatie\LaravelData\Tests\Fakes\DummyEnum;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
 use Spatie\LaravelData\Tests\TestCase;
 
@@ -39,34 +38,6 @@ class DataFromModelResolverTest extends TestCase
         );
 
         $this->assertEquals(new SimpleData('Hello'), $data);
-    }
-
-    /** @test */
-    public function it_can_get_a_data_object_from_model_with_casts()
-    {
-        $fakeModelClass = new class () extends Model {
-            protected $casts = [
-                'enum' => DummyEnum::class,
-            ];
-        };
-
-        $model = $fakeModelClass::make([
-            'enum' => DummyEnum::published(),
-        ]);
-
-        $dataClass = DataBlueprintFactory::new('DataFromModelWithCast')
-            ->withProperty(
-                DataPropertyBlueprintFactory::new('enum')
-                    ->withType(DummyEnum::class)
-            )
-            ->create();
-
-        $data = $this->resolver->execute(
-            $dataClass,
-            $model
-        );
-
-        $this->assertTrue($data->enum->equals(DummyEnum::published()));
     }
 
     /** @test */


### PR DESCRIPTION
As we look forward to Laravel 9 and ensuring this package is compatible, I have been looking at dependencies that are blocking that path. One of those is the development dependency of `spatie/laravel-enum`.

Laravel Enums are only being used in the test suite, and it does not appear they are greatly valuing the package. The tests being performed are covered elsewhere. For that reason I propose we remove the dependency requirement.