### PR TITLE
add sometimes rule & undefined concept

### DIFF
--- a/src/Attributes/Validation/Sometimes.php
+++ b/src/Attributes/Validation/Sometimes.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\LaravelData\Attributes\Validation;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Sometimes extends ValidationAttribute
+{
+    public function getRules(): array
+    {
+        return ['sometimes'];
+    }
+}

--- a/src/Resolvers/DataFromArrayResolver.php
+++ b/src/Resolvers/DataFromArrayResolver.php
@@ -8,6 +8,7 @@ use Spatie\LaravelData\DataCollection;
 use Spatie\LaravelData\Lazy;
 use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelData\Support\DataProperty;
+use Spatie\LaravelData\Undefined;
 
 class DataFromArrayResolver
 {
@@ -41,9 +42,13 @@ class DataFromArrayResolver
 
     private function resolveValue(DataProperty $property, array $values): mixed
     {
-        $value = $values[$property->name()] ?? null;
+        $value =  array_key_exists($property->name(), $values) ? $values[$property->name()] ?? null : Undefined::make();
 
         if ($value === null) {
+            return $value;
+        }
+
+        if ($value instanceof Undefined) {
             return $value;
         }
 

--- a/src/RuleInferrers/SometimesRuleInferrer.php
+++ b/src/RuleInferrers/SometimesRuleInferrer.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\LaravelData\RuleInferrers;
+
+use Spatie\LaravelData\Support\DataProperty;
+
+class SometimesRuleInferrer implements RuleInferrer
+{
+    public function handle(DataProperty $property, array $rules): array
+    {
+        if ($property->isUndefinable() && ! in_array('sometimes', $rules)) {
+            $rules[] = 'sometimes';
+        }
+
+        return $rules;
+    }
+}

--- a/src/Support/DataProperty.php
+++ b/src/Support/DataProperty.php
@@ -15,6 +15,7 @@ use Spatie\LaravelData\DataCollection;
 use Spatie\LaravelData\Exceptions\CannotFindDataTypeForProperty;
 use Spatie\LaravelData\Exceptions\InvalidDataPropertyType;
 use Spatie\LaravelData\Lazy;
+use Spatie\LaravelData\Undefined;
 use TypeError;
 
 class DataProperty
@@ -22,6 +23,8 @@ class DataProperty
     protected bool $isLazy;
 
     protected bool $isNullable;
+
+    protected bool $isUndefinable;
 
     protected bool $isData;
 
@@ -73,6 +76,11 @@ class DataProperty
     public function isNullable(): bool
     {
         return $this->isNullable;
+    }
+
+    public function isUndefinable(): bool
+    {
+        return $this->isUndefinable;
     }
 
     public function isPromoted(): bool
@@ -177,6 +185,7 @@ class DataProperty
     {
         $this->isLazy = false;
         $this->isNullable = true;
+        $this->isUndefinable = false;
         $this->isData = false;
         $this->isDataCollection = false;
         $this->types = new DataPropertyTypes();
@@ -194,6 +203,7 @@ class DataProperty
         $this->isData = is_a($name, Data::class, true);
         $this->isDataCollection = is_a($name, DataCollection::class, true);
         $this->isNullable = $type->allowsNull();
+        $this->isUndefinable = is_a($name, Undefined::class, true);
         $this->types = new DataPropertyTypes([$name]);
     }
 
@@ -201,6 +211,7 @@ class DataProperty
     {
         $this->isLazy = false;
         $this->isNullable = false;
+        $this->isUndefinable = false;
         $this->isData = false;
         $this->isDataCollection = false;
         $this->types = new DataPropertyTypes();
@@ -210,6 +221,12 @@ class DataProperty
 
             if ($name === 'null') {
                 $this->isNullable = true;
+
+                continue;
+            }
+
+            if ($name === Undefined::class) {
+                $this->isUndefinable = true;
 
                 continue;
             }

--- a/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
+++ b/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
@@ -27,6 +27,7 @@ class DataTypeScriptTransformer extends DtoTransformer
                 $this->config->getDefaultTypeReplacements()
             ),
             new RemoveLazyTypeProcessor(),
+            new RemoveUndefinedTypeProcessor(),
             new DtoCollectionTypeProcessor(),
         ];
     }

--- a/src/Support/TypeScriptTransformer/RemoveUndefinedTypeProcessor.php
+++ b/src/Support/TypeScriptTransformer/RemoveUndefinedTypeProcessor.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Spatie\LaravelData\Support\TypeScriptTransformer;
+
+use Exception;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Compound;
+use phpDocumentor\Reflection\Types\Object_;
+use ReflectionMethod;
+use ReflectionParameter;
+use ReflectionProperty;
+use Spatie\LaravelData\Lazy;
+use Spatie\LaravelData\Undefined;
+use Spatie\TypeScriptTransformer\Structures\MissingSymbolsCollection;
+use Spatie\TypeScriptTransformer\TypeProcessors\TypeProcessor;
+
+class RemoveUndefinedTypeProcessor implements TypeProcessor
+{
+    public function process(
+        Type $type,
+        ReflectionParameter | ReflectionMethod | ReflectionProperty $reflection,
+        MissingSymbolsCollection $missingSymbolsCollection
+    ): ?Type {
+        if (! $type instanceof Compound) {
+            return $type;
+        }
+
+        /** @var \Illuminate\Support\Collection $types */
+        $types = collect(iterator_to_array($type->getIterator()))
+            ->reject(function (Type $type) {
+                if (! $type instanceof Object_) {
+                    return false;
+                }
+
+                return is_a((string)$type->getFqsen(), Undefined::class, true);
+            });
+
+        if ($types->isEmpty()) {
+            throw new Exception("Type {$reflection->getDeclaringClass()->name}:{$reflection->getName()} cannot be only Undefined");
+        }
+
+        if ($types->count() === 1) {
+            return $types->first();
+        }
+
+        return new Compound($types->all());
+    }
+}

--- a/src/Transformers/DataTransformer.php
+++ b/src/Transformers/DataTransformer.php
@@ -8,6 +8,7 @@ use Spatie\LaravelData\Lazy;
 use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelData\Support\DataProperty;
 use Spatie\LaravelData\Support\TransformationType;
+use Spatie\LaravelData\Undefined;
 
 class DataTransformer
 {
@@ -71,6 +72,10 @@ class DataTransformer
         ?array $allowedIncludes,
         ?array $allowedExcludes,
     ): bool {
+        if ($value instanceof Undefined) {
+            return false;
+        }
+
         if (! $value instanceof Lazy) {
             return true;
         }

--- a/src/Undefined.php
+++ b/src/Undefined.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\LaravelData;
+
+
+class Undefined
+{
+    public static function make(): Undefined
+    {
+        return new self();
+    }
+}

--- a/tests/Attributes/Validation/RulesTest.php
+++ b/tests/Attributes/Validation/RulesTest.php
@@ -82,6 +82,7 @@ use Spatie\LaravelData\Attributes\Validation\RequiredWithoutAll;
 use Spatie\LaravelData\Attributes\Validation\Rule;
 use Spatie\LaravelData\Attributes\Validation\Same;
 use Spatie\LaravelData\Attributes\Validation\Size;
+use Spatie\LaravelData\Attributes\Validation\Sometimes;
 use Spatie\LaravelData\Attributes\Validation\StartsWith;
 use Spatie\LaravelData\Attributes\Validation\StringType;
 use Spatie\LaravelData\Attributes\Validation\Timezone;
@@ -372,6 +373,11 @@ class RulesTest extends TestCase
         yield [
             'attribute' => new Uuid(),
             'expected' => ['uuid'],
+        ];
+
+        yield [
+            'attribute' => new Sometimes(),
+            'expected' => ['sometimes'],
         ];
     }
 

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -17,6 +17,7 @@ use Spatie\LaravelData\Lazy;
 use Spatie\LaravelData\Tests\Factories\DataBlueprintFactory;
 use Spatie\LaravelData\Tests\Factories\DataPropertyBlueprintFactory;
 use Spatie\LaravelData\Tests\Fakes\DefaultLazyData;
+use Spatie\LaravelData\Tests\Fakes\DefaultUndefinedData;
 use Spatie\LaravelData\Tests\Fakes\DummyDto;
 use Spatie\LaravelData\Tests\Fakes\DummyModel;
 use Spatie\LaravelData\Tests\Fakes\DummyModelWithCasts;
@@ -772,5 +773,26 @@ class DataTest extends TestCase
         $this->assertEquals('Test Again', $data->promoted_property);
         $this->assertEquals('Test', $data->default_property);
         $this->assertEquals('Test Again', $data->default_promoted_property);
+    }
+
+
+    /** @test */
+    public function it_excludes_undefined_values_data()
+    {
+        $data = DefaultUndefinedData::from([]);
+
+        $this->assertEquals([], $data->toArray());
+    }
+
+    /** @test */
+    public function it_includes_value_if_not_undefined_data()
+    {
+        $data = DefaultUndefinedData::from([
+            'name' => 'Freek'
+        ]);
+
+        $this->assertEquals([
+            'name' => 'Freek'
+        ], $data->toArray());
     }
 }

--- a/tests/Fakes/ComplicatedData.php
+++ b/tests/Fakes/ComplicatedData.php
@@ -8,6 +8,7 @@ use Spatie\LaravelData\Attributes\WithCast;
 use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\DataCollection;
+use Spatie\LaravelData\Undefined;
 
 class ComplicatedData extends Data
 {
@@ -19,6 +20,7 @@ class ComplicatedData extends Data
         public string $string,
         public array $array,
         public ?int $nullable,
+        public int|Undefined $undefinable,
         public mixed $mixed,
         #[WithCast(DateTimeInterfaceCast::class, format: 'd-m-Y', type: CarbonImmutable::class)]
         public $explicitCast,

--- a/tests/Fakes/DefaultUndefinedData.php
+++ b/tests/Fakes/DefaultUndefinedData.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Undefined;
+
+class DefaultUndefinedData extends Data
+{
+    public function __construct(
+        public string | Undefined $name
+    ) {
+    }
+}

--- a/tests/Resolvers/DataFromArrayResolverTest.php
+++ b/tests/Resolvers/DataFromArrayResolverTest.php
@@ -19,6 +19,7 @@ use Spatie\LaravelData\Tests\Fakes\NestedModelCollectionData;
 use Spatie\LaravelData\Tests\Fakes\NestedModelData;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
 use Spatie\LaravelData\Tests\TestCase;
+use Spatie\LaravelData\Undefined;
 
 class DataFromArrayResolverTest extends TestCase
 {
@@ -69,6 +70,7 @@ class DataFromArrayResolverTest extends TestCase
         $this->assertEquals('Hello world', $data->string);
         $this->assertEquals([1, 1, 2, 3, 5, 8], $data->array);
         $this->assertNull($data->nullable);
+        $this->assertInstanceOf(Undefined::class, $data->undefinable);
         $this->assertEquals(42, $data->mixed);
         $this->assertEquals(DateTime::createFromFormat(DATE_ATOM, '1994-05-16T12:00:00+01:00'), $data->defaultCast);
         $this->assertEquals(CarbonImmutable::createFromFormat('d-m-Y', '16-06-1994'), $data->explicitCast);

--- a/tests/Resolvers/EmptyDataResolverTest.php
+++ b/tests/Resolvers/EmptyDataResolverTest.php
@@ -10,6 +10,7 @@ use Spatie\LaravelData\Lazy;
 use Spatie\LaravelData\Resolvers\EmptyDataResolver;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
 use Spatie\LaravelData\Tests\TestCase;
+use Spatie\LaravelData\Undefined;
 
 class EmptyDataResolverTest extends TestCase
 {
@@ -105,6 +106,37 @@ class EmptyDataResolverTest extends TestCase
         });
     }
 
+    public function it_will_return_the_base_type_for_lazy_types_that_can_be_undefined()
+    {
+        $this->assertEmptyPropertyValue(null, new class () {
+            public Lazy | string | Undefined $property;
+        });
+
+        $this->assertEmptyPropertyValue([], new class () {
+            public Lazy | array | Undefined $property;
+        });
+
+        $this->assertEmptyPropertyValue(['string' => null], new class () {
+            public Lazy | SimpleData | Undefined $property;
+        });
+    }
+
+    /** @test */
+    public function it_will_return_the_base_type_for_undefinable_types()
+    {
+        $this->assertEmptyPropertyValue(null, new class() {
+            public Undefined | string $property;
+        });
+
+        $this->assertEmptyPropertyValue([], new class () {
+            public Undefined | array $property;
+        });
+
+        $this->assertEmptyPropertyValue(['string' => null], new class () {
+            public Undefined | SimpleData $property;
+        });
+    }
+
     /** @test */
     public function it_cannot_have_multiple_types()
     {
@@ -132,6 +164,26 @@ class EmptyDataResolverTest extends TestCase
 
         $this->assertEmptyPropertyValue(null, new class () {
             public int | string | Lazy | null $property;
+        });
+    }
+
+    /** @test */
+    public function it_cannot_have_multiple_types_with_a_undefined()
+    {
+        $this->expectException(DataPropertyCanOnlyHaveOneType::class);
+
+        $this->assertEmptyPropertyValue(null, new class () {
+            public int | string | Undefined $property;
+        });
+    }
+
+    /** @test */
+    public function it_cannot_have_multiple_types_with_a_nullable_undefined()
+    {
+        $this->expectException(DataPropertyCanOnlyHaveOneType::class);
+
+        $this->assertEmptyPropertyValue(null, new class () {
+            public int | string | Undefined | null $property;
         });
     }
 

--- a/tests/Support/DataPropertyTest.php
+++ b/tests/Support/DataPropertyTest.php
@@ -21,6 +21,7 @@ use Spatie\LaravelData\Tests\Fakes\IntersectionTypeData;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
 use Spatie\LaravelData\Tests\TestCase;
 use Spatie\LaravelData\Transformers\DateTimeInterfaceTransformer;
+use Spatie\LaravelData\Undefined;
 
 class DataPropertyTest extends TestCase
 {
@@ -33,6 +34,7 @@ class DataPropertyTest extends TestCase
 
         $this->assertFalse($helper->isLazy());
         $this->assertTrue($helper->isNullable());
+        $this->assertFalse($helper->isUndefinable());
         $this->assertFalse($helper->isData());
         $this->assertFalse($helper->isDataCollection());
         $this->assertTrue($helper->types()->isEmpty());
@@ -83,6 +85,29 @@ class DataPropertyTest extends TestCase
 
         $this->assertTrue($helper->isNullable());
     }
+
+    /** @test */
+    public function it_can_check_if_a_property_is_undefinable()
+    {
+        $helper = $this->resolveHelper(new class () {
+            public int $property;
+        });
+
+        $this->assertFalse($helper->isUndefinable());
+
+        $helper = $this->resolveHelper(new class () {
+            public Undefined $property;
+        });
+
+        $this->assertTrue($helper->isUndefinable());
+
+        $helper = $this->resolveHelper(new class () {
+            public Undefined|int $property;
+        });
+
+        $this->assertTrue($helper->isUndefinable());
+    }
+
 
     /** @test */
     public function it_can_check_if_a_property_is_a_data_object()

--- a/tests/Support/TypeScriptTransformer/DataTypeScriptTransformerTest.php
+++ b/tests/Support/TypeScriptTransformer/DataTypeScriptTransformerTest.php
@@ -9,6 +9,7 @@ use Spatie\LaravelData\Lazy;
 use Spatie\LaravelData\Support\TypeScriptTransformer\DataTypeScriptTransformer;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
 use Spatie\LaravelData\Tests\TestCase;
+use Spatie\LaravelData\Undefined;
 use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 
 class DataTypeScriptTransformerTest extends TestCase
@@ -18,9 +19,12 @@ class DataTypeScriptTransformerTest extends TestCase
     {
         $config = TypeScriptTransformerConfig::create();
 
-        $data = new class (null, 42, true, 'Hello world', 3.14, ['the', 'meaning', 'of', 'life'], Lazy::create(fn () => 'Lazy'), SimpleData::from('Simple data'), SimpleData::collection([]), ) extends Data {
+        $data = new class (null, Undefined::make(), 42, true, 'Hello world', 3.14, ['the', 'meaning', 'of', 'life'],
+            Lazy::create(fn
+        () => 'Lazy'), SimpleData::from('Simple data'), SimpleData::collection([]), ) extends Data {
             public function __construct(
                 public null | int $nullable,
+                public Undefined | int $undefineable,
                 public int $int,
                 public bool $bool,
                 public string $string,

--- a/tests/Support/TypeScriptTransformer/__snapshots__/DataTypeScriptTransformerTest__it_can_covert_a_data_object_to_typescript__1.txt
+++ b/tests/Support/TypeScriptTransformer/__snapshots__/DataTypeScriptTransformerTest__it_can_covert_a_data_object_to_typescript__1.txt
@@ -1,5 +1,6 @@
 {
 nullable: number | null;
+undefineable: number;
 int: number;
 bool: boolean;
 string: string;


### PR DESCRIPTION
This adds the "undefined" concept from an array to the data object. It also adds the 'sometimes' rule to accompany the main use case i.e. partial updates in a form request.

```php
class ProductUpdateData extends DataTransferObject
{
    public function __construct(
        public string|Undefined $name,
        public bool|Undefined $available,
    ) {
    }
}
```

This will allow a partial data request, where either name or available can be omitted from the payload. When the data object is transformed back into an array, the keys that were not sent, will not be present.
