### PR TITLE
fix for aborting value assignment after a false boolean

### DIFF
--- a/src/Resolvers/DataFromArrayResolver.php
+++ b/src/Resolvers/DataFromArrayResolver.php
@@ -103,7 +103,9 @@ class DataFromArrayResolver
         $data = new $class(...$promotedProperties);
 
         $classProperties->each(
-            fn (mixed $value, string $name) => $data->{$name} = $value
+            function (mixed $value, string $name) use ($data) {
+                $data->{$name} = $value;
+            }
         );
 
         return $data;

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -773,4 +773,30 @@ class DataTest extends TestCase
         $this->assertEquals('Test', $data->default_property);
         $this->assertEquals('Test Again', $data->default_promoted_property);
     }
+
+    /** @test */
+    public function it_continues_value_assignment_after_a_false_boolean()
+    {
+        $dataClass = new class () extends Data {
+            public bool $false;
+
+            public bool $true;
+
+            public string $string;
+
+            public Carbon $date;
+        };
+
+        $data = $dataClass::from([
+            'false' => false,
+            'true' => true,
+            'string' => 'string',
+            'date' => Carbon::create(2020, 05, 16, 12, 00, 00),
+        ]);
+
+        $this->assertFalse($data->false);
+        $this->assertTrue($data->true);
+        $this->assertEquals('string', $data->string);
+        $this->assertTrue(Carbon::create(2020, 05, 16, 12, 00, 00)->equalTo($data->date));
+    }
 }


### PR DESCRIPTION
An arrow function was used when iterating over class properties; whenever a boolean type with value `false` was assigned, the loop would break and subsequent properties were not assigned.

Using an anonymous function without returning anything solves this.

I've added a test to proof the bug/fix.