### PR TITLE
[V2] Respect Password Defaults

### DIFF
--- a/src/Attributes/Validation/Password.php
+++ b/src/Attributes/Validation/Password.php
@@ -17,7 +17,6 @@ class Password extends ValidationAttribute
         private ?bool $uncompromised = null,
         private ?int $uncompromisedThreshold = null
     ) {
-
     }
 
     public function getRules(): array

--- a/src/Attributes/Validation/Password.php
+++ b/src/Attributes/Validation/Password.php
@@ -9,19 +9,24 @@ use Illuminate\Validation\Rules\Password as BasePassword;
 class Password extends ValidationAttribute
 {
     public function __construct(
-        private int $min = 12,
-        private bool $letters = false,
-        private bool $mixedCase = false,
-        private bool $numbers = false,
-        private bool $symbols = false,
-        private bool $uncompromised = false,
-        private int $uncompromisedThreshold = 0
+        private ?int $min = null,
+        private ?bool $letters = null,
+        private ?bool $mixedCase = null,
+        private ?bool $numbers = null,
+        private ?bool $symbols = null,
+        private ?bool $uncompromised = null,
+        private ?int $uncompromisedThreshold = null
     ) {
+
     }
 
     public function getRules(): array
     {
-        $rule = BasePassword::min($this->min);
+        if ($this->wantsDefaults()) {
+            return [ BasePassword::default() ];
+        }
+
+        $rule = BasePassword::min($this->min ?? 12);
 
         if ($this->letters) {
             $rule->letters();
@@ -40,9 +45,22 @@ class Password extends ValidationAttribute
         }
 
         if ($this->uncompromised) {
-            $rule->uncompromised($this->uncompromisedThreshold);
+            $rule->uncompromised($this->uncompromisedThreshold ?? 0);
         }
 
         return [$rule];
+    }
+
+    private function wantsDefaults(): bool
+    {
+        return (
+            is_null($this->min) &&
+            is_null($this->letters) &&
+            is_null($this->mixedCase) &&
+            is_null($this->numbers) &&
+            is_null($this->symbols) &&
+            is_null($this->uncompromised) &&
+            is_null($this->uncompromisedThreshold)
+        );
     }
 }

--- a/tests/Attributes/Validation/RulesTest.php
+++ b/tests/Attributes/Validation/RulesTest.php
@@ -721,8 +721,32 @@ class RulesTest extends TestCase
 
     public function passwordAttributesDataProvider(): Generator
     {
+        BasePassword::defaults(
+            fn() => BasePassword::min(23)
+                ->symbols()
+                ->mixedCase()
+                ->numbers()
+                ->uncompromised(0)
+        );
+
         yield [
             'attribute' => new Password(),
+            'expected' => [
+                BasePassword::min(23)
+                    ->symbols()
+                    ->mixedCase()
+                    ->numbers()
+                    ->uncompromised(0)
+            ]
+        ];
+
+        yield [
+            'attribute' => new Password(),
+            'expected' => [ BasePassword::default() ]
+        ];
+
+        yield [
+            'attribute' => new Password(min: 12),
             'expected' => [new BasePassword(12)],
         ];
 

--- a/tests/Attributes/Validation/RulesTest.php
+++ b/tests/Attributes/Validation/RulesTest.php
@@ -722,7 +722,7 @@ class RulesTest extends TestCase
     public function passwordAttributesDataProvider(): Generator
     {
         BasePassword::defaults(
-            fn() => BasePassword::min(23)
+            fn () => BasePassword::min(23)
                 ->symbols()
                 ->mixedCase()
                 ->numbers()
@@ -736,13 +736,13 @@ class RulesTest extends TestCase
                     ->symbols()
                     ->mixedCase()
                     ->numbers()
-                    ->uncompromised(0)
-            ]
+                    ->uncompromised(0),
+            ],
         ];
 
         yield [
             'attribute' => new Password(),
-            'expected' => [ BasePassword::default() ]
+            'expected' => [ BasePassword::default() ],
         ];
 
         yield [


### PR DESCRIPTION
This would clearly be a v2 feature since it is breaking, but the proposal here is that the `Password` validation attribute uses default password rules if no parameters are set.