### PR TITLE
Allow using default password config

### DIFF
--- a/src/Attributes/Validation/Password.php
+++ b/src/Attributes/Validation/Password.php
@@ -15,12 +15,17 @@ class Password extends ValidationAttribute
         private bool $numbers = false,
         private bool $symbols = false,
         private bool $uncompromised = false,
-        private int $uncompromisedThreshold = 0
+        private int $uncompromisedThreshold = 0,
+        private bool $default = false,
     ) {
     }
 
     public function getRules(): array
     {
+        if ($this->default) {
+            return [BasePassword::default()];
+        }
+
         $rule = BasePassword::min($this->min);
 
         if ($this->letters) {

--- a/tests/Attributes/Validation/PasswordTest.php
+++ b/tests/Attributes/Validation/PasswordTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Attributes\Validation;
+
+use Generator;
+use Illuminate\Validation\Rules\Password as ValidationPassword;
+use ReflectionClass;
+use Spatie\LaravelData\Attributes\Validation\Password;
+use Spatie\LaravelData\Tests\TestCase;
+
+class PasswordTest extends TestCase
+{
+    /**
+     * @dataProvider preconfiguredPasswordValidationsProvider
+     */
+    public function testPasswordRuleReturnsPreconfiguredPasswordValidations(callable $setDefaults, array $expectedConfig): void
+    {
+        ValidationPassword::$defaultCallback = null;
+        $setDefaults();
+
+        [$rule] = (new Password(default: true))->getRules();
+        $clazz = new ReflectionClass($rule);
+
+        foreach ($expectedConfig as $key => $expected) {
+            $prop = $clazz->getProperty($key);
+            $actual = $prop->getValue($rule);
+
+            $this->assertSame($expected, $actual);
+        }
+    }
+
+    public function preconfiguredPasswordValidationsProvider(): Generator
+    {
+        yield 'min length set to 42' => [
+            'setDefaults' => fn () => ValidationPassword::defaults(fn () => ValidationPassword::min(42)),
+            'expectedConfig' => [
+                'min' => 42,
+            ],
+        ];
+
+        yield 'unconfigured' => [
+            'setDefaults' => fn () => null,
+            'expectedConfig' => [
+                'min' => 8,
+            ],
+        ];
+
+        yield 'uncompromised' => [
+            'setDefaults' => fn() => ValidationPassword::defaults(fn () => ValidationPassword::min(69)->uncompromised(7)),
+            'expectedConfig' => [
+                'min' => 69,
+                'uncompromised' => true,
+                'compromisedThreshold' => 7,
+            ],
+        ];
+    }
+}

--- a/tests/Attributes/Validation/PasswordTest.php
+++ b/tests/Attributes/Validation/PasswordTest.php
@@ -23,6 +23,7 @@ class PasswordTest extends TestCase
 
         foreach ($expectedConfig as $key => $expected) {
             $prop = $clazz->getProperty($key);
+            $prop->setAccessible(true);
             $actual = $prop->getValue($rule);
 
             $this->assertSame($expected, $actual);


### PR DESCRIPTION
https://laravel.com/docs/9.x/validation#defining-default-password-rules

The Password validation rules allows one to set a default configuration by providing a callback that returns a configured password class.

This PR allows using this default validation config.
