### PR TITLE
Add support for stdClass payload casting

### DIFF
--- a/src/Resolvers/DataFromSomethingResolver.php
+++ b/src/Resolvers/DataFromSomethingResolver.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Exceptions\CannotCreateDataFromValue;
 use Spatie\LaravelData\Support\DataConfig;
+use stdClass;
 
 class DataFromSomethingResolver
 {
@@ -41,6 +42,10 @@ class DataFromSomethingResolver
 
         if ($value instanceof Arrayable) {
             return $this->dataFromArrayResolver->execute($class, $value->toArray());
+        }
+
+        if ($value instanceof stdClass) {
+            $value = (array) $value;
         }
 
         if (is_array($value)) {

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -633,6 +633,35 @@ class DataTest extends TestCase
     }
 
     /** @test */
+    public function it_can_create_a_data_object_from_a_stdClass_object()
+    {
+        $object = (object) [
+            'string' => 'test',
+            'boolean' => true,
+            'date' => CarbonImmutable::create(2020, 05, 16, 12, 00, 00),
+            'nullable_date' => null,
+        ];
+
+        $dataClass = new class () extends Data {
+            public string $string;
+
+            public bool $boolean;
+
+            public CarbonImmutable $date;
+
+            public ?Carbon $nullable_date;
+        };
+
+        $data = $dataClass::from($object);
+
+        $this->assertEquals('test', $data->string);
+        $this->assertTrue($data->boolean);
+        $this->assertTrue(CarbonImmutable::create(2020, 05, 16, 12, 00, 00)->eq($data->date));
+        $this->assertNull($data->nullable_date);
+    }
+
+
+    /** @test */
     public function it_can_add_the_with_data_trait_to_a_request()
     {
         $formRequest = new class () extends FormRequest {


### PR DESCRIPTION
In the previous version trying to create a Data object from a stdClass object would error out.

This PR adds support for stdClass objects by simply casting it to an array before proceeding with the DataFromArrayResolver.

This is particularly useful for casting nested objects which, in my use case, are returned from a document model database.