### PR TITLE
Add Dependency Injection for `rules`, `messages`, and `attributes` methods

### DIFF
--- a/docs/as-a-data-transfer-object/request-to-data-object.md
+++ b/docs/as-a-data-transfer-object/request-to-data-object.md
@@ -126,6 +126,28 @@ class SongData extends Data
 ```
 Rules defined within the `rules` method will always overwrite automatically generated rules.
 
+You can even add dependencies to be automatically injected:
+```php
+use SongSettingsRepository;
+
+class SongData extends Data
+{
+    public function __construct(
+        public string $title,
+        public string $artist,
+    ) {
+    }
+    
+    public static function rules(SongSettingsRepository $settings): array
+    {
+        return [
+            'title' => [new RequiredIf($settings->forUser(auth()->user())->title_required), new StringType()],
+            'artist' => [new Required(), new StringType()],
+        ];
+    }
+}
+```
+
 ## Mapping a request onto a data object
 
 By default, the package will do a one to one mapping from request to the data object, which means that for each property within the data object, a value with the same key will be searched within the request values.
@@ -297,6 +319,28 @@ class SongData extends Data
     }
 }
 ```
+You can also provide dependencies to be injected:
+
+```php
+use SongSettingsRepository;
+
+class SongData extends Data
+{
+    public function __construct(
+        public string $title,
+        public string $artist,
+    ) {
+    }
+
+    public static function messages(SongSettingsRepository $repository): array
+    {
+        return [
+            'title.required' => 'A '. $repository->forUser(auth()->user())->title_word .' is required',
+            'artist.required' => 'An artist is required',
+        ];
+    }
+}
+```
 
 ### Overwriting attributes
 
@@ -317,6 +361,28 @@ class SongData extends Data
             'title' => 'titel',
             'artist' => 'artiest',
         ];
+    }
+}
+```
+
+You can also provide dependencies to be injected:
+
+```php
+use SongSettingsRepository;
+class SongData extends Data
+{
+    public function __construct(
+        public string $title,
+        public string $artist,
+    ) {
+    }
+
+    public static function attributes(SongSettingsRepository $repository): array
+    {
+        return [
+            'title' => 'titel',
+            'artist' => 'artiest',
+        ] + $repository->getAttributes();
     }
 }
 ```

--- a/src/Concerns/ValidateableData.php
+++ b/src/Concerns/ValidateableData.php
@@ -6,6 +6,11 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Validation\Validator;
 use Spatie\LaravelData\Resolvers\DataValidatorResolver;
 
+/**
+ * @method static array rules(...$args)
+ * @method static array messages(...$args)
+ * @method static array attributes(...$args)
+ */
 trait ValidateableData
 {
     public static function validate(Arrayable|array $payload): static
@@ -15,21 +20,6 @@ trait ValidateableData
         $validator->validate();
 
         return static::from($payload);
-    }
-
-    public static function rules(): array
-    {
-        return [];
-    }
-
-    public static function messages(): array
-    {
-        return [];
-    }
-
-    public static function attributes(): array
-    {
-        return [];
     }
 
     public static function withValidator(Validator $validator): void

--- a/src/Resolvers/DataValidationRulesResolver.php
+++ b/src/Resolvers/DataValidationRulesResolver.php
@@ -16,8 +16,11 @@ class DataValidationRulesResolver
     {
         $resolver = app(DataPropertyValidationRulesResolver::class);
 
+        $overWrittenRules = [];
         /** @var class-string<\Spatie\LaravelData\Data> $class */
-        $overWrittenRules = $class::rules();
+        if(method_exists($class, 'rules')) {
+            $overWrittenRules = app()->call([$class, 'rules']);
+        }
 
         return $this->dataConfig->getDataClass($class)
             ->properties()

--- a/src/Resolvers/DataValidatorResolver.php
+++ b/src/Resolvers/DataValidatorResolver.php
@@ -22,8 +22,8 @@ class DataValidatorResolver
         $validator = ValidatorFacade::make(
             $payload instanceof Arrayable ? $payload->toArray() : $payload,
             $rules,
-            $dataClass::messages(),
-            $dataClass::attributes()
+            method_exists($dataClass, 'messages') ? app()->call([$dataClass, 'messages']) : [],
+            method_exists($dataClass, 'attributes') ? app()->call([$dataClass, 'attributes']) : []
         );
 
         $dataClass::withValidator($validator);

--- a/tests/Resolvers/DataValidationRulesResolverTest.php
+++ b/tests/Resolvers/DataValidationRulesResolverTest.php
@@ -3,7 +3,6 @@
 namespace Spatie\LaravelData\Tests\Resolvers;
 
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rule;
 use Spatie\LaravelData\Attributes\WithoutValidation;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\DataCollection;

--- a/tests/Resolvers/DataValidationRulesResolverTest.php
+++ b/tests/Resolvers/DataValidationRulesResolverTest.php
@@ -109,8 +109,9 @@ class DataValidationRulesResolverTest extends TestCase
             'age' => ['numeric', 'nullable'],
         ], $this->resolver->execute($data::class)->all());
     }
+
     /** @test */
-    public function it_can_resolve_dependencies_when_calling_methods()
+    public function it_can_resolve_dependencies_when_calling_rules()
     {
         $requestMock = $this->mock(Request::class);
         $requestMock->expects('input')->andReturns('value');


### PR DESCRIPTION
This PR aims to add dependency injection for the `rules()`, `messages()`, and `attributes()` methods. This will allow users to add parameters to any of these methods that will inject useful classes like the current Request object to make more fine-tuned rules, messages, and attributes. Of course, anything could be injected that does not rely on the current request as well, so that the data object can still use `SongData::validate(['title' => 'Never gonna give you up', 'artist' => 'Rick Astley']);` without throwing an error about it not being able to resolve the request from the container.

Examples:
```php
use \Illuminate\Http\Request;
class SongData extends Data
{
    public function __construct(
        public string $title,
        public string $artist,
    ) {
    }
    
    public static function rules(Request $request): array
    {
        return [
            'title' => [new RequiredIf($request->input('new_title_required')), new StringType()],
            'artist' => [new Required(), new StringType()],
        ];
    }
}
```