### PR TITLE
feat: `except` and `includeWhen`

### DIFF
--- a/docs/as-a-resource/from-data-to-resource.md
+++ b/docs/as-a-resource/from-data-to-resource.md
@@ -351,3 +351,33 @@ Now each transformed data object contains an `endpoints` key with all the endpoi
     }
 }
 ```
+
+## Omitting properties
+
+It is possible to conditionnaly omit properties, which can be useful when not wanting to expose certain properties. 
+
+To achieve this, you can extend `excludeWhen` method, which should return an array. In the following example, `id` will be excluded from the resource unless the authenticated user is an administrator.
+
+```php
+class UserData extends Data
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+    ) {
+    }
+    
+    public function excludeWhen(): array
+    {
+        return [
+          'id' => !auth()->user()?->is_admin
+        ];
+    }
+}
+```
+
+Alternatively, you can use the `except` method to omit properties at runtime:
+
+```php
+UserData::from($user)->exclude('id', 'password');
+```

--- a/src/Concerns/ExcludeableData.php
+++ b/src/Concerns/ExcludeableData.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Spatie\LaravelData\Concerns;
+
+trait ExcludeableData
+{
+    protected array $except = [];
+
+    public function excludeWhen(): array
+    {
+        return [];
+    }
+
+    public function except(...$except): static
+    {
+        $this->except = array_merge($this->except, $except);
+
+        return $this;
+    }
+
+    public function getExcludedData(): array
+    {
+        $exclusions = array_keys(array_filter($this->excludeWhen(), function ($value) {
+            $value = $value instanceof \Closure
+                ? ($value)($this)
+                : $value;
+
+            return $value;
+        }));
+
+        return array_merge($exclusions, $this->except);
+    }
+}

--- a/src/Concerns/ExcludeableData.php
+++ b/src/Concerns/ExcludeableData.php
@@ -20,13 +20,12 @@ trait ExcludeableData
 
     public function getExcludedData(): array
     {
-        $exclusions = array_keys(array_filter($this->excludeWhen(), function ($value) {
-            $value = $value instanceof \Closure
+        $exclusions = array_keys(array_filter(
+            $this->excludeWhen(),
+            fn ($value) => $value instanceof \Closure
                 ? ($value)($this)
-                : $value;
-
-            return $value;
-        }));
+                : $value
+        ));
 
         return array_merge($exclusions, $this->except);
     }

--- a/src/Data.php
+++ b/src/Data.php
@@ -12,6 +12,7 @@ use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Enumerable;
 use JsonSerializable;
 use Spatie\LaravelData\Concerns\AppendableData;
+use Spatie\LaravelData\Concerns\ExcludeableData;
 use Spatie\LaravelData\Concerns\IncludeableData;
 use Spatie\LaravelData\Concerns\ResponsableData;
 use Spatie\LaravelData\Concerns\ValidateableData;
@@ -25,6 +26,7 @@ abstract class Data implements Arrayable, Responsable, Jsonable, EloquentCastabl
 {
     use ResponsableData;
     use IncludeableData;
+    use ExcludeableData;
     use AppendableData;
     use ValidateableData;
 

--- a/src/Transformers/DataTransformer.php
+++ b/src/Transformers/DataTransformer.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelData\Transformers;
 
+use Illuminate\Support\Arr;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\DataCollection;
 use Spatie\LaravelData\Lazy;
@@ -25,10 +26,10 @@ class DataTransformer
 
     public function transform(Data $data): array
     {
-        return array_merge(
+        return Arr::except(array_merge(
             $this->resolvePayload($data),
             $data->getAdditionalData()
-        );
+        ), $data->getExcludedData());
     }
 
     protected function resolvePayload(Data $data): array


### PR DESCRIPTION
This PR adds support for conditionally omitting properties from a DTO. Please refer to https://github.com/spatie/laravel-data/discussions/111 for the context. It also partially addresses https://github.com/spatie/laravel-data/discussions/5, and https://github.com/spatie/laravel-data/discussions/84 (v2) since it's on the "consider" list.

An `excludeWhen` and an `except` method have been added through a trait, which makes it possible to either define how to exclude properties conditionnally, or to exclude them at runtime.

The documentation has been updated too.

## Examples

**Omitting properties conditionally:**
```php
class UserData extends Data
{
    public function __construct(
        public int $id,
        public string $name,
    ) {
    }
    
    public function excludeWhen(): array
    {
        return [
          'id' => !auth()->user()?->is_admin
        ];
    }
}
```

**Omitting properties at runtime:**
```php
UserData::from($user)->exclude('id', 'password');
```