### PR TITLE
feat: make nullable properties optional

### DIFF
--- a/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
+++ b/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
@@ -56,7 +56,7 @@ class DataTypeScriptTransformer extends DtoTransformer
                     $property->getDeclaringClass()->getName()
                 );
 
-                return $this->isPropertyLazy($property)
+                return $this->shouldBeOptional($property)
                     ? "{$carry}{$property->getName()}?: {$transformed};" . PHP_EOL
                     : "{$carry}{$property->getName()}: {$transformed};" . PHP_EOL;
             },
@@ -64,9 +64,13 @@ class DataTypeScriptTransformer extends DtoTransformer
         );
     }
 
-    protected function isPropertyLazy(ReflectionProperty $property): bool
+    protected function shouldBeOptional(ReflectionProperty $property): bool
     {
         $type = $property->getType();
+
+        if ($type->allowsNull()) {
+            return true;
+        }
 
         if ($type === null || $type instanceof ReflectionNamedType) {
             return false;

--- a/tests/Support/TypeScriptTransformer/__snapshots__/DataCollectionTypeProcessorTest__it_uses_the_correct_types_for_data_collection_of_attributes__1.txt
+++ b/tests/Support/TypeScriptTransformer/__snapshots__/DataCollectionTypeProcessorTest__it_uses_the_correct_types_for_data_collection_of_attributes__1.txt
@@ -1,5 +1,5 @@
 {
 dataCollection: { [key: number]: {%Spatie\LaravelData\Tests\Fakes\SimpleData%} };
-dataCollectionWithNull: { [key: number]: {%Spatie\LaravelData\Tests\Fakes\SimpleData%} } | null;
-dataCollectionWithNullable: { [key: number]: {%Spatie\LaravelData\Tests\Fakes\SimpleData%} } | null;
+dataCollectionWithNull?: { [key: number]: {%Spatie\LaravelData\Tests\Fakes\SimpleData%} } | null;
+dataCollectionWithNullable?: { [key: number]: {%Spatie\LaravelData\Tests\Fakes\SimpleData%} } | null;
 }

--- a/tests/Support/TypeScriptTransformer/__snapshots__/DataTypeScriptTransformerTest__it_can_covert_a_data_object_to_typescript__1.txt
+++ b/tests/Support/TypeScriptTransformer/__snapshots__/DataTypeScriptTransformerTest__it_can_covert_a_data_object_to_typescript__1.txt
@@ -1,5 +1,5 @@
 {
-nullable: number | null;
+nullable?: number | null;
 int: number;
 bool: boolean;
 string: string;


### PR DESCRIPTION
This PR makes nullable properties optional, just like `Lazy` already does. The rationale behind this is that in TypeScript, we almost never want to have actual `null` types. We prefer `undefined` because properties can then be omitted, and most operations return `undefined`, not `null` (eg. [`find`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find), [`pop`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop), etc...).

I talked about it a bit in this issue: https://github.com/spatie/typescript-transformer/issues/23

I think this should also be addressed in `typescript-transformer` but the only place I can see it being used is in `DtoTransformer`. I can PR there too if this one is accepted.