### PR TITLE
feat: support multiple date formats

### DIFF
--- a/config/data.php
+++ b/config/data.php
@@ -4,7 +4,11 @@ return [
     /*
      * The package will use this date format when working with dates through the app
      */
-    'date_format' => DATE_ATOM,
+    'date_format' => [
+        DATE_ATOM,
+        DATE_ISO8601,
+        'Y-m-d H:i:s',
+    ],
 
     /*
      * Global transformers will take complex types and transform them into simple

--- a/docs/as-a-data-transfer-object/casts.md
+++ b/docs/as-a-data-transfer-object/casts.md
@@ -87,7 +87,7 @@ public Format $format
 
 ### Casting dates
 
-By default, the package ships with a `DateTimeInterface` cast to transform a date string into a date object. You can define the format used to parse the date in the `data.php` config file. By default, it is the `DATE_ATOM` format.
+By default, the package ships with a `DateTimeInterface` cast to transform a date string into a date object. You can define the formats used to parse the date in the `data.php` config file. By default, the `DATE_ATOM` and the `DATE_ISO8601` formats are supported, with or without period.
 
 It is also possible to manually set the format on the cast:
 
@@ -106,7 +106,6 @@ public Carbon $date
 You can even manually specify the type the date string should be cast to:
 
 ```php
-
 #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class)]
 public $date
 ```
@@ -146,4 +145,3 @@ class SongData extends Data
 ## Creating your own casts
 
 It is possible to create your casts. You can read more about this in the [advanced chapter](/docs/laravel-data/v1/advanced-usage/creating-a-cast).
-

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -22,7 +22,11 @@ return [
     /*
      * The date format to be used when converting a DateTimeInterface from and to json
      */
-    'date_format' => DATE_ATOM,
+    'date_format' => [
+        DATE_ATOM,
+        DATE_ISO8601,
+        'Y-m-d H:i:s',
+    ],
 
     /*
      * Transformers will take properties within your data objects and transform
@@ -52,4 +56,3 @@ return [
     ],
 ];
 ```
-

--- a/src/Exceptions/CannotCastDate.php
+++ b/src/Exceptions/CannotCastDate.php
@@ -6,8 +6,8 @@ use Exception;
 
 class CannotCastDate extends Exception
 {
-    public static function create(string $format, string $type, mixed $value): self
+    public static function create(array $formats, string $type, mixed $value): self
     {
-        return new self("Could not cast date: `{$value}` into a `{$type}` using format {$format}");
+        return new self("Could not cast date: `{$value}` into a `{$type}` using formats: ".implode(', ', $formats));
     }
 }

--- a/src/Transformers/DateTimeInterfaceTransformer.php
+++ b/src/Transformers/DateTimeInterfaceTransformer.php
@@ -12,9 +12,8 @@ class DateTimeInterfaceTransformer implements Transformer
 
     public function transform(DataProperty $property, mixed $value): string
     {
-        $format = $this->format ?? config('data.date_format');
-
-        /** @var \DateTimeInterface $value */
-        return $value->format($format);
+        return collect($this->format ?? config('data.date_format'))
+            ->map(fn (string $format) => rescue(fn () => $value->format($format)))
+            ->first(fn ($value) => (bool) $value, '');
     }
 }

--- a/tests/Casts/DateTimeInterfaceCastTest.php
+++ b/tests/Casts/DateTimeInterfaceCastTest.php
@@ -54,7 +54,7 @@ class DateTimeInterfaceCastTest extends TestCase
     /** @test */
     public function it_fails_when_it_cannot_cast_a_date_into_the_correct_format()
     {
-        $caster = new DateTimeInterfaceCast('d-m-Y H:i:s');
+        $caster = new DateTimeInterfaceCast(\DATE_RFC822);
 
         $class = new class () {
             public DateTime $carbon;


### PR DESCRIPTION
This PR adds support for multiple date formats, instead of just one. When working with multiple applications (web front-end, APIs, etc), it's easier to accept multiple instead of requiring a specific one.

This change is fully backwards-compatible, but allows the `date_format` configuration option to be an array. 

The `DateTimeInterfaceCast` will now loop through the configured formats and use the first one that doesn't fail. If all of them fail, it will throw as usual.

Additionnally, I added the most-commonly used formats as the defaults: `ATOM`, `ISO8601`, and `Y-m-d H:i:s` (the same but without the period).

Partially related: https://github.com/php/php-src/pull/8322