### PR TITLE
Change `DataConfig` to scoped binding (instead of singleton)

### DIFF
--- a/src/LaravelDataServiceProvider.php
+++ b/src/LaravelDataServiceProvider.php
@@ -17,7 +17,7 @@ class LaravelDataServiceProvider extends PackageServiceProvider
 
     public function packageRegistered()
     {
-        $this->app->singleton(
+        $this->app->scoped(
             DataConfig::class,
             fn () => new DataConfig(config('data'))
         );


### PR DESCRIPTION
Prevents accidentally contaminating subsequent requests if the `DataConfig` should get changed somewhere in the request