### PR TITLE
feat(rules): support `$payload` as a dependency

### DIFF
--- a/docs/as-a-data-transfer-object/request-to-data-object.md
+++ b/docs/as-a-data-transfer-object/request-to-data-object.md
@@ -148,6 +148,27 @@ class SongData extends Data
 }
 ```
 
+Additionally, if you need to access the data payload, you can use `$payload` parameter:
+
+```php
+class PaymentData extends Data
+{
+    public function __construct(
+        public string $payment_method,
+        public ?string $paypal_email,
+    ) {
+    }
+    
+    public static function rules(array $payload): array
+    {
+        return [
+            'payment_method' => ['required'],
+            'paypal_email' => Rule::requiredIf($payload['payment_method'] === 'paypal'),
+        ];
+    }
+}
+```
+
 ## Mapping a request onto a data object
 
 By default, the package will do a one to one mapping from request to the data object, which means that for each property within the data object, a value with the same key will be searched within the request values.

--- a/src/Resolvers/DataPropertyValidationRulesResolver.php
+++ b/src/Resolvers/DataPropertyValidationRulesResolver.php
@@ -16,16 +16,16 @@ class DataPropertyValidationRulesResolver
     ) {
     }
 
-    public function execute(DataProperty $property, bool $nullable = false): Collection
+    public function execute(DataProperty $property, array $payload = [], bool $nullable = false): Collection
     {
         if ($property->isData() || $property->isDataCollection()) {
-            return $this->getNestedRules($property, $nullable);
+            return $this->getNestedRules($property, $payload, $nullable);
         }
 
         return collect([$property->name() => $this->getRulesForProperty($property, $nullable)]);
     }
 
-    private function getNestedRules(DataProperty $property, bool $nullable): Collection
+    private function getNestedRules(DataProperty $property, array $payload = [], bool $nullable): Collection
     {
         $prefix = match (true) {
             $property->isData() => "{$property->name()}.",
@@ -45,6 +45,7 @@ class DataPropertyValidationRulesResolver
         return $this->dataValidationRulesResolver
             ->execute(
                 $property->dataClassName(),
+                $payload,
                 $nullable || ($property->isData() && $property->isNullable())
             )
             ->mapWithKeys(fn (array $rules, string $name) => [

--- a/src/Resolvers/DataValidationRulesResolver.php
+++ b/src/Resolvers/DataValidationRulesResolver.php
@@ -12,20 +12,22 @@ class DataValidationRulesResolver
     {
     }
 
-    public function execute(string $class, bool $nullable = false): Collection
+    public function execute(string $class, array $payload = [], bool $nullable = false): Collection
     {
         $resolver = app(DataPropertyValidationRulesResolver::class);
 
         $overWrittenRules = [];
         /** @var class-string<\Spatie\LaravelData\Data> $class */
         if (method_exists($class, 'rules')) {
-            $overWrittenRules = app()->call([$class, 'rules']);
+            $overWrittenRules = app()->call([$class, 'rules'], [
+                'payload' => $payload,
+            ]);
         }
 
         return $this->dataConfig->getDataClass($class)
             ->properties()
             ->reject(fn (DataProperty $property) => array_key_exists($property->name(), $overWrittenRules) || ! $property->shouldValidateProperty())
-            ->mapWithKeys(fn (DataProperty $property) => $resolver->execute($property, $nullable))
+            ->mapWithKeys(fn (DataProperty $property) => $resolver->execute($property, $payload, $nullable))
             ->merge($overWrittenRules);
     }
 }

--- a/src/Resolvers/DataValidatorResolver.php
+++ b/src/Resolvers/DataValidatorResolver.php
@@ -15,12 +15,13 @@ class DataValidatorResolver
     /** @param class-string<\Spatie\LaravelData\Data> $dataClass */
     public function execute(string $dataClass, Arrayable|array $payload): Validator
     {
+        $payload = $payload instanceof Arrayable ? $payload->toArray() : $payload;
         $rules = app(DataValidationRulesResolver::class)
-            ->execute($dataClass)
+            ->execute($dataClass, $payload)
             ->toArray();
 
         $validator = ValidatorFacade::make(
-            $payload instanceof Arrayable ? $payload->toArray() : $payload,
+            $payload,
             $rules,
             method_exists($dataClass, 'messages') ? app()->call([$dataClass, 'messages']) : [],
             method_exists($dataClass, 'attributes') ? app()->call([$dataClass, 'attributes']) : []

--- a/tests/Resolvers/DataValidationRulesResolverTest.php
+++ b/tests/Resolvers/DataValidationRulesResolverTest.php
@@ -132,4 +132,23 @@ class DataValidationRulesResolverTest extends TestCase
             'name' => ['required'],
         ], $this->resolver->execute($data::class)->all());
     }
+
+    /** @test */
+    public function it_can_resolve_payload_when_calling_rules()
+    {
+        $data = new class () extends Data {
+            public string $name;
+
+            public static function rules(array $payload): array
+            {
+                return [
+                    'name' => $payload['name'] === 'foo' ? ['required'] : ['sometimes'],
+                ];
+            }
+        };
+
+        $this->assertEquals([
+            'name' => ['required'],
+        ], $this->resolver->execute($data::class, ['name' => 'foo'])->all());
+    }
 }


### PR DESCRIPTION
This PR allows passing `$payload` as a parameter to the static `rules` method from a `Data` object.

This is very useful when needing to conditionally apply rules based on the data you get. This is already possible by injecting `Request` in the method, but this only works when working in the context of the request. 

For instance, when using `SongData::validate(['name' => 'Wasted Youth'])`, a `Request` object will not contain the `name`.

Instead, you can now do the following:

```php
class PaymentData extends Data
{
    public function __construct(
        public string $payment_method,
        public ?string $paypal_email,
    ) {
    }
    
    public static function rules(array $payload): array
    {
        return [
            'payment_method' => ['required'],
            'paypal_email' => Rule::requiredIf($payload['payment_method'] === 'paypal'),
        ];
    }
}
```

Note that the `$payload` variable name is important, it's a named parameter. It can obviously be omitted too.