### PR TITLE
feat: `includeWhen` and `excludeWhen`

### DIFF
--- a/src/Transformers/DataTransformer.php
+++ b/src/Transformers/DataTransformer.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelData\Transformers;
 
+use Illuminate\Support\Arr;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\DataCollection;
 use Spatie\LaravelData\Lazy;
@@ -166,6 +167,14 @@ class DataTransformer
 
         if ($value === null) {
             return null;
+        }
+
+        if (is_array($value) && ! empty($trees->only)) {
+            $value = Arr::only($value, array_keys($trees->only));
+        }
+
+        if (is_array($value) && ! empty($trees->except)) {
+            $value = Arr::except($value, array_keys($trees->except));
         }
 
         if ($transformer = $this->resolveTransformerForValue($property, $value)) {

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -1391,6 +1391,254 @@ class DataTest extends TestCase
         ]);
     }
 
+    /** @test */
+    public function it_can_conditionally_include_properties()
+    {
+        $data = new class () extends Data {
+            public function __construct(
+                public ?int $id = null,
+                public ?string $name = null,
+            ) {
+            }
+
+            public function includeWhen(): array
+            {
+                return [
+                    'id' => false,
+                    'name' => true,
+                ];
+            }
+        };
+
+        $this->assertEquals([
+            'name' => 'Taylor',
+        ], $data::from([
+            'id' => 1,
+            'name' => 'Taylor',
+        ])->toArray());
+    }
+
+    /** @test */
+    public function exclusions_have_priority_over_inclusions()
+    {
+        $data = new class () extends Data {
+            public function __construct(
+                public ?int $id = null,
+                public ?string $name = null,
+            ) {
+            }
+
+            public function includeWhen(): array
+            {
+                return [
+                    'name' => true,
+                ];
+            }
+
+            public function excludeWhen(): array
+            {
+                return [
+                    'name' => true,
+                ];
+            }
+        };
+
+        $this->assertEquals([
+            'id' => 1,
+        ], $data::from([
+            'id' => 1,
+            'name' => 'Taylor',
+        ])->toArray());
+    }
+
+    /** @test */
+    public function it_can_conditionally_exclude_properties()
+    {
+        $data = new class () extends Data {
+            public function __construct(
+                public ?int $id = null,
+                public ?string $name = null,
+            ) {
+            }
+
+            public function excludeWhen(): array
+            {
+                return [
+                    'id' => true,
+                    'name' => false,
+                ];
+            }
+        };
+
+        $this->assertEquals([
+            'name' => 'Taylor',
+        ], $data::from([
+            'id' => 1,
+            'name' => 'Taylor',
+        ])->toArray());
+    }
+
+    /** @test */
+    public function it_can_conditionally_exclude_properties_with_a_callback()
+    {
+        $data = new class () extends Data {
+            public function __construct(
+                public ?int $id = null,
+                public ?string $name = null,
+            ) {
+            }
+
+            public function excludeWhen(): array
+            {
+                return [
+                    'id' => fn () => $this->name === 'Taylor',
+                ];
+            }
+        };
+
+        $this->assertEquals([
+            'name' => 'Taylor',
+        ], $data::from([
+            'id' => 1,
+            'name' => 'Taylor',
+        ])->toArray());
+
+        $this->assertEquals([
+            'id' => 1,
+            'name' => 'Freek',
+        ], $data::from([
+            'id' => 1,
+            'name' => 'Freek',
+        ])->toArray());
+    }
+
+    /** @test */
+    public function it_can_exclude_properties_at_runtime()
+    {
+        $data = new class () extends Data {
+            public function __construct(
+                public ?int $id = null,
+                public ?string $name = null,
+            ) {
+            }
+        };
+
+        $this->assertEquals([
+            'name' => 'Taylor',
+        ], $data::from([
+            'id' => 1,
+            'name' => 'Taylor',
+        ])->except('id')->toArray());
+    }
+
+    /** @test */
+    public function it_can_include_nested_array_properties()
+    {
+        $data = new class () extends Data {
+            public function __construct(
+                public ?int $id = null,
+                public ?string $name = null,
+                public ?array $more = null
+            ) {
+            }
+        };
+
+        $this->assertEquals([
+            'id' => 1,
+            'more' => [
+                'twitter_verified' => false,
+            ],
+        ], $data::from([
+            'id' => 1,
+            'name' => 'Taylor',
+            'more' => [
+                'last_name' => 'Otwell',
+                'twitter_verified' => false,
+            ],
+        ])->only('id', 'more.twitter_verified')->toArray());
+    }
+
+    /** @test */
+    public function it_can_exclude_nested_array_properties()
+    {
+        $data = new class () extends Data {
+            public function __construct(
+                public ?int $id = null,
+                public ?string $name = null,
+                public ?array $more = null
+            ) {
+            }
+        };
+
+        $this->assertEquals([
+            'name' => 'Taylor',
+            'more' => [
+                'last_name' => 'Otwell',
+            ],
+        ], $data::from([
+            'id' => 1,
+            'name' => 'Taylor',
+            'more' => [
+                'last_name' => 'Otwell',
+                'twitter_verified' => false,
+            ],
+        ])->except('id', 'more.twitter_verified')->toArray());
+    }
+
+    /** @test */
+    public function it_can_include_nested_data_properties()
+    {
+        $more = new class ('Otwell', false) extends Data {
+            public function __construct(
+                public string $last_name,
+                public bool $twitter_verified,
+            ) {
+            }
+        };
+
+        $data = new class ('Taylor', $more) extends Data {
+            public function __construct(
+                public string $name,
+                public Data $more,
+            ) {
+            }
+        };
+
+        $this->assertEquals([
+            'name' => 'Taylor',
+            'more' => [
+                'last_name' => 'Otwell',
+            ],
+        ], $data->only('name', 'more.last_name')->toArray());
+    }
+
+    /** @test */
+    public function it_can_exclude_nested_data_properties()
+    {
+        $more = new class ('Otwell', false) extends Data {
+            public function __construct(
+                public string $last_name,
+                public bool $twitter_verified,
+            ) {
+            }
+        };
+
+        $data = new class ('Taylor', $more) extends Data {
+            public function __construct(
+                public string $name,
+                public Data $more,
+            ) {
+            }
+        };
+
+        $this->assertEquals([
+            'name' => 'Taylor',
+            'more' => [
+                'last_name' => 'Otwell',
+            ],
+        ], $data->except('id', 'more.twitter_verified')->toArray());
+    }
+
     /**
      * @test
      * @dataProvider onlyInclusionDataProvider


### PR DESCRIPTION
This PR is a follow-up of https://github.com/spatie/laravel-data/pull/115, as asked in the comments. 

Its purpose is to have an in-DTO way of conditionally excluding or including data:

```php
class UserData extends Data
{
    public function __construct(
        public int $id,
        public string $name,
    ) {
    }
    
    public function excludeWhen(): array
    {
        return [
          'id' => !auth()->user()?->is_admin
        ];
    }
}
```

Note: this PR also adds support for `includeWhen`, since the implementation was similar - but I'm unsure of the naming for this one, it is kind of confusing, any input there?