### PR TITLE
feat: support multiple date formats

### DIFF
--- a/config/data.php
+++ b/config/data.php
@@ -2,7 +2,9 @@
 
 return [
     /*
-     * The package will use this date format when working with dates through the app
+     * The package will use this format when working with dates. If this option
+     * is an array, it will try to convert from the first format that works,
+     * and will serialize dates using the first format from the array.
      */
     'date_format' => DATE_ATOM,
 

--- a/docs/as-a-data-transfer-object/casts.md
+++ b/docs/as-a-data-transfer-object/casts.md
@@ -146,4 +146,3 @@ class SongData extends Data
 ## Creating your own casts
 
 It is possible to create your casts. You can read more about this in the [advanced chapter](/docs/laravel-data/v1/advanced-usage/creating-a-cast).
-

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -20,7 +20,9 @@ This is the contents of the published config file:
 ```php
 return [
     /*
-     * The date format to be used when converting a DateTimeInterface from and to json
+     * The package will use this format when working with dates. If this option
+     * is an array, it will try to convert from the first format that works,
+     * and will serialize dates using the first format from the array.
      */
     'date_format' => DATE_ATOM,
 
@@ -52,4 +54,3 @@ return [
     ],
 ];
 ```
-

--- a/src/Casts/DateTimeInterfaceCast.php
+++ b/src/Casts/DateTimeInterfaceCast.php
@@ -5,19 +5,18 @@ namespace Spatie\LaravelData\Casts;
 use DateTimeInterface;
 use Spatie\LaravelData\Exceptions\CannotCastDate;
 use Spatie\LaravelData\Support\DataProperty;
-use Throwable;
 
 class DateTimeInterfaceCast implements Cast
 {
     public function __construct(
-        protected ?string $format = null,
+        protected null|string|array $format = null,
         protected ?string $type = null
     ) {
     }
 
     public function cast(DataProperty $property, mixed $value, array $context): DateTimeInterface | Uncastable
     {
-        $format = $this->format ?? config('data.date_format');
+        $formats = collect($this->format ?? config('data.date_format'));
 
         $type = $this->type ?? $property->type->findAcceptedTypeForBaseType(DateTimeInterface::class);
 
@@ -25,15 +24,12 @@ class DateTimeInterfaceCast implements Cast
             return Uncastable::create();
         }
 
-        /** @var class-string<\DateTime|\DateTimeImmutable> $type */
-        try {
-            $datetime = $type::createFromFormat($format, $value);
-        } catch (Throwable $e) {
-            $datetime = false;
-        }
+        $datetime = $formats
+            ->map(fn (string $format) => rescue(fn () => $type::createFromFormat($format, $value)))
+            ->first(fn ($value) => (bool) $value);
 
-        if ($datetime === false) {
-            throw CannotCastDate::create($format, $type, $value);
+        if (! $datetime) {
+            throw CannotCastDate::create($formats->toArray(), $type, $value);
         }
 
         return $datetime;

--- a/src/Exceptions/CannotCastDate.php
+++ b/src/Exceptions/CannotCastDate.php
@@ -6,8 +6,8 @@ use Exception;
 
 class CannotCastDate extends Exception
 {
-    public static function create(string $format, string $type, mixed $value): self
+    public static function create(array $formats, string $type, mixed $value): self
     {
-        return new self("Could not cast date: `{$value}` into a `{$type}` using format {$format}");
+        return new self("Could not cast date `{$value}` into a `{$type}` using formats: ".implode(', ', $formats));
     }
 }

--- a/src/Transformers/DateTimeInterfaceTransformer.php
+++ b/src/Transformers/DateTimeInterfaceTransformer.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelData\Transformers;
 
+use Illuminate\Support\Arr;
 use Spatie\LaravelData\Support\DataProperty;
 
 class DateTimeInterfaceTransformer implements Transformer
@@ -12,7 +13,7 @@ class DateTimeInterfaceTransformer implements Transformer
 
     public function transform(DataProperty $property, mixed $value): string
     {
-        $format = $this->format ?? config('data.date_format');
+        [$format] = Arr::wrap($this->format ?? config('data.date_format'));
 
         /** @var \DateTimeInterface $value */
         return $value->format($format);

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -16,6 +16,7 @@ use Spatie\LaravelData\Attributes\MapOutputName;
 use Spatie\LaravelData\Attributes\Validation\In;
 use Spatie\LaravelData\Attributes\WithCast;
 use Spatie\LaravelData\Attributes\WithTransformer;
+use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\DataCollection;
 use Spatie\LaravelData\DataPipeline;
@@ -2057,5 +2058,20 @@ class DataTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    /** @test */
+    public function it_supports_conversion_from_multiple_date_formats()
+    {
+        $data = new class () extends Data {
+            public function __construct(
+                #[WithCast(DateTimeInterfaceCast::class, ['Y-m-d\TH:i:sP', 'Y-m-d H:i:s'])]
+                public ?DateTime $date = null
+            ) {
+            }
+        };
+
+        $this->assertEquals(['date' => '2022-05-16T14:37:56+00:00'], $data::from(['date' => '2022-05-16T14:37:56+00:00'])->toArray());
+        $this->assertEquals(['date' => '2022-05-16T17:00:00+00:00'], $data::from(['date' => '2022-05-16 17:00:00'])->toArray());
     }
 }


### PR DESCRIPTION
This PR is the same as https://github.com/spatie/laravel-data/pull/120, except it targets the `v2` branch and makes a breaking change by updating the configuration format. 

I realized that when serializing a date, having multiple formats didn't make sense. So I updated the configuration to have a `from` and `to` option, where `from` is an array of supported input date formats, and `to` the format to which a date will be serialized into.

---

Initial PR text:

> This PR adds support for multiple date formats, instead of just one. When working with multiple applications (web front-end, APIs, etc), it's easier to accept multiple instead of requiring a specific one.
>
> This change is fully backwards-compatible, but allows the `date_format` configuration option to be an array. 
>
> The `DateTimeInterfaceCast` will now loop through the configured formats and use the first one that doesn't fail. If all of them fail, it will throw as usual.
>
> Additionnally, I added the most-commonly used formats as the defaults: `ATOM`, `ISO8601`, and `Y-m-d H:i:s` (the same but without the period).
>
> Partially related: https://github.com/php/php-src/pull/8322