### PR TITLE
Use protected properties everywhere 

### DIFF
--- a/src/DataCollection.php
+++ b/src/DataCollection.php
@@ -30,14 +30,14 @@ class DataCollection implements Responsable, Arrayable, Jsonable, JsonSerializab
     use ResponsableData;
     use IncludeableData;
 
-    private ?Closure $through = null;
+    protected ?Closure $through = null;
 
-    private ?Closure $filter = null;
+    protected ?Closure $filter = null;
 
-    private Enumerable|CursorPaginator|Paginator $items;
+    protected Enumerable|CursorPaginator|Paginator $items;
 
     public function __construct(
-        private string $dataClass,
+        protected string $dataClass,
         Enumerable|array|CursorPaginator|Paginator|DataCollection $items
     ) {
         $this->items = match (true) {

--- a/src/Lazy.php
+++ b/src/Lazy.php
@@ -7,12 +7,12 @@ use Illuminate\Database\Eloquent\Model;
 
 class Lazy
 {
-    private ?Closure $condition = null;
+    protected ?Closure $condition = null;
 
-    private ?bool $defaultIncluded = null;
+    protected ?bool $defaultIncluded = null;
 
     protected function __construct(
-        private Closure $value
+        protected Closure $value
     ) {
     }
 

--- a/src/Resolvers/DataFromModelResolver.php
+++ b/src/Resolvers/DataFromModelResolver.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Str;
 class DataFromModelResolver
 {
     public function __construct(
-        private DataFromArrayResolver $dataFromArrayResolver
+        protected DataFromArrayResolver $dataFromArrayResolver
     ) {
     }
 

--- a/src/Support/TransformationType.php
+++ b/src/Support/TransformationType.php
@@ -4,9 +4,9 @@ namespace Spatie\LaravelData\Support;
 
 class TransformationType
 {
-    private const FULL = 'full';
-    private const REQUEST = 'request';
-    private const WITHOUT_VALUE_TRANSFORMING = 'without_value_transforming';
+    protected const FULL = 'full';
+    protected const REQUEST = 'request';
+    protected const WITHOUT_VALUE_TRANSFORMING = 'without_value_transforming';
 
     private function __construct(protected string $type)
     {


### PR DESCRIPTION
This PR changes the last `private` properties to be `protected` properties. This is incredibly useful when people need to override a class or sth. In addition, there were already quite some places where the `protected` visibility was already used, so this makes it consistent. 

My use case was that I wanted to override the `transform()` method on the `DataCollection` class, because I needed to use an overrided `DataCollectionTransformer`. The regular `DataCollectionTransformer` uses a custom array structure for paginated JSON responses, which is not the same as the default Laravel paginated array structure. We don't want to release breaking changes to our API-users, so I had to override `DataCollectionTransformer` class.

However, when all the properties are `private`, overriding is almost impossible. 

It would be greatly appreciated if this could be merged faster than later. Thanks a lot! 