### PR TITLE
fix(ts): use mapped property names in generated types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     },
     "scripts": {
         "analyse": "vendor/bin/phpstan analyse",
-        "test": "./vendor/bin/paratest --no-coverage",
+        "test": "./vendor/bin/phpunit --no-coverage",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
         "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes"
     },

--- a/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
+++ b/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
@@ -67,9 +67,11 @@ class DataTypeScriptTransformer extends DtoTransformer
                     $property->getDeclaringClass()->getName()
                 );
 
+                $propertyName = $dataProperty->outputMappedName ?? $dataProperty->name;
+
                 return $dataProperty->type->isLazy || $dataProperty->type->isOptional
-                    ? "{$carry}{$property->getName()}?: {$transformed};" . PHP_EOL
-                    : "{$carry}{$property->getName()}: {$transformed};" . PHP_EOL;
+                    ? "{$carry}{$propertyName}?: {$transformed};" . PHP_EOL
+                    : "{$carry}{$propertyName}: {$transformed};" . PHP_EOL;
             },
             ''
         );

--- a/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
+++ b/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
@@ -38,7 +38,6 @@ class DataTypeScriptTransformer extends DtoTransformer
             ),
             new RemoveLazyTypeProcessor(),
             new RemoveOptionalTypeProcessor(),
-            new RemoveOptionalTypeProcessor(),
             new DtoCollectionTypeProcessor(),
         ];
     }

--- a/tests/Support/TypeScriptTransformer/DataTypeScriptTransformerTest.php
+++ b/tests/Support/TypeScriptTransformer/DataTypeScriptTransformerTest.php
@@ -6,10 +6,12 @@ use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use ReflectionClass;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Attributes\MapOutputName;
 use Spatie\LaravelData\CursorPaginatedDataCollection;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\DataCollection;
 use Spatie\LaravelData\Lazy;
+use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 use Spatie\LaravelData\Optional;
 use Spatie\LaravelData\PaginatedDataCollection;
 use Spatie\LaravelData\Support\TypeScriptTransformer\DataTypeScriptTransformer;
@@ -153,6 +155,26 @@ class DataTypeScriptTransformerTest extends TestCase
 
         $transformer = new DataTypeScriptTransformer($config);
 
+        $reflection = new ReflectionClass($data);
+
+        $this->assertTrue($transformer->canTransform($reflection));
+        $this->assertMatchesSnapshot($transformer->transform($reflection, 'DataObject')->transformed);
+    }
+
+    /** @test */
+    public function it_outputs_types_with_properties_using_their_mapped_name()
+    {
+        $config = TypeScriptTransformerConfig::create();
+
+        $data = new class ('Good job Ruben') extends Data {
+            public function __construct(
+                #[MapOutputName(SnakeCaseMapper::class)]
+                public string $someCamelCaseProperty,
+            ) {
+            }
+        };
+
+        $transformer = new DataTypeScriptTransformer($config);
         $reflection = new ReflectionClass($data);
 
         $this->assertTrue($transformer->canTransform($reflection));

--- a/tests/Support/TypeScriptTransformer/__snapshots__/DataTypeScriptTransformerTest__it_outputs_types_with_properties_using_their_mapped_name__1.txt
+++ b/tests/Support/TypeScriptTransformer/__snapshots__/DataTypeScriptTransformerTest__it_outputs_types_with_properties_using_their_mapped_name__1.txt
@@ -1,0 +1,3 @@
+{
+some_camel_case_property: string;
+}


### PR DESCRIPTION
This PR fixes the generated TypeScript types not properly using the defined mapped property names.

For instance:

```php
#[MapOutputName(SnakeCaseMapper::class)]
class ContractData extends Data
{
    public function __construct(
        public string $name,
        public string $recordCompany,
    ) {
    }
}
```

Would output:

```ts
interface ContractData {
  name: string
  recordCompany: string
}
```

After this PR, the correct interface is generated:

```ts
interface ContractData {
  name: string
  record_company: string
}
```