### PR TITLE
feat: support in-class exclusions

### DIFF
--- a/src/Concerns/IncludeableData.php
+++ b/src/Concerns/IncludeableData.php
@@ -80,11 +80,25 @@ trait IncludeableData
         return $this;
     }
 
+    protected function exclusions(): array
+    {
+        return [];
+    }
+
+    protected function processExclusions(): void
+    {
+        foreach ($this->exclusions() as $key => $condition) {
+            $this->exceptWhen($key, $condition);
+        }
+    }
+
     public function getPartialTrees(): PartialTrees
     {
         if ($this->partialTrees) {
             return $this->partialTrees;
         }
+
+        $this->processExclusions();
 
         return new PartialTrees(
             (new PartialsParser())->execute($this->includes),

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -1435,6 +1435,76 @@ class DataTest extends TestCase
     }
 
     /** @test */
+    public function it_can_filter_nested_array_properties_inside_the_data_class()
+    {
+        $data = new class () extends Data {
+            public function __construct(
+                public ?int $id = null,
+                public ?string $name = null,
+                public ?array $more = null
+            ) {
+            }
+
+            protected function exclusions(): array
+            {
+                return [
+                    'id' => true,
+                    'more.twitter_verified' => true,
+                ];
+            }
+        };
+
+        $this->assertEquals([
+            'name' => 'Taylor',
+            'more' => [
+                'last_name' => 'Otwell',
+            ],
+        ], $data::from([
+            'id' => 1,
+            'name' => 'Taylor',
+            'more' => [
+                'last_name' => 'Otwell',
+                'twitter_verified' => false,
+            ],
+        ])->toArray());
+    }
+
+    /** @test */
+    public function it_can_filter_nested_data_properties_inside_the_data_class()
+    {
+        $more = new class ('Otwell', false) extends Data {
+            public function __construct(
+                public string $last_name,
+                public bool $twitter_verified,
+            ) {
+            }
+        };
+
+        $data = new class ('Taylor', $more) extends Data {
+            public function __construct(
+                public string $name,
+                public Data $more,
+            ) {
+            }
+
+            protected function exclusions(): array
+            {
+                return [
+                    'id' => true,
+                    'more.twitter_verified' => true,
+                ];
+            }
+        };
+
+        $this->assertEquals([
+            'name' => 'Taylor',
+            'more' => [
+                'last_name' => 'Otwell',
+            ],
+        ], $data->toArray());
+    }
+
+    /** @test */
     public function it_can_conditionally_include_properties()
     {
         $data = new class () extends Data {

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -1405,6 +1405,36 @@ class DataTest extends TestCase
     }
 
     /** @test */
+    public function it_can_filter_properties_inside_the_data_class()
+    {
+        $data = new class () extends Data {
+            public function __construct(
+                public ?int $id = null,
+                public ?string $first_name = null,
+                public ?string $last_name = null,
+            ) {
+            }
+
+            protected function exclusions(): array
+            {
+                return [
+                    'id' => true,
+                    'first_name' => false,
+                    'last_name' => fn () => true,
+                ];
+            }
+        };
+
+        $this->assertEquals([
+            'first_name' => 'Taylor',
+        ], $data::from([
+            'id' => 1,
+            'first_name' => 'Taylor',
+            'last_name' => 'Otwell',
+        ])->toArray());
+    }
+
+    /** @test */
     public function it_can_conditionally_include_properties()
     {
         $data = new class () extends Data {


### PR DESCRIPTION
In https://github.com/spatie/laravel-data/pull/126, I added a feature that was meant to make it easy to conditionally include or exclude data depending on a condition, inside the data class itself.

Unfortunately, during the v2 refactor, it seems that the purpose of that feature got lost, because now we can only call `->onlyWhen` or `->exceptWhen` when creating the DTO.

The purpose of the feature was, in fact, to be able to filter the data to avoid sending some information. For instance, I use `laravel-data` in conjunction with Inertia, and I don't want to send some restricted data depending on the level of permission. 

With this PR, I will be able to do the following:

```php
class UserData extends Data
{
    public function __construct(
        public int $id,
        public string $name,
    ) {
    }
    
    public function exclusions(): array
    {
        return [
          'id' => !auth()->user()?->is_admin
        ];
    }
}
```

Currently, I would need to call `->exceptWhen` everywhere the `UserData` class is used.