### PR TITLE
feat: add `make:data` artisan command

### DIFF
--- a/src/Commands/DataMakeCommand.php
+++ b/src/Commands/DataMakeCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Spatie\LaravelData\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+
+class DataMakeCommand extends GeneratorCommand
+{
+    protected $name = 'make:data';
+    protected $description = 'Create a new data class';
+    protected $type = 'Data';
+
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/data.stub');
+    }
+
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.'/../..'.$stub;
+    }
+
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Data';
+    }
+
+    protected function qualifyClass($name)
+    {
+        if (! Str::endsWith($name, 'Data')) {
+            $name = $name.'Data';
+        }
+
+        return parent::qualifyClass($name);
+    }
+}

--- a/src/LaravelDataServiceProvider.php
+++ b/src/LaravelDataServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelData;
 
+use Spatie\LaravelData\Commands\DataMakeCommand;
 use Spatie\LaravelData\Contracts\BaseData;
 use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelPackageTools\Package;
@@ -13,6 +14,7 @@ class LaravelDataServiceProvider extends PackageServiceProvider
     {
         $package
             ->name('laravel-data')
+            ->hasCommand(DataMakeCommand::class)
             ->hasConfigFile();
     }
 

--- a/stubs/data.stub
+++ b/stubs/data.stub
@@ -1,0 +1,12 @@
+<?php
+
+namespace {{ namespace }};
+
+use Spatie\LaravelData\Data;
+
+class {{ class }} extends Data
+{
+    public function __construct(
+      //
+    ) {}
+}


### PR DESCRIPTION
I often reach for it but it doesn't exist, so this PR adds a `make:data` artisan command. Nothing special there, a simple generator command with a stub.