### PR TITLE
Allow arrays in query parameters for partials

### DIFF
--- a/docs/as-a-resource/lazy-properties.md
+++ b/docs/as-a-resource/lazy-properties.md
@@ -272,6 +272,18 @@ https://spatie.be/my-account?include=favorite_song
 }
 ```
 
+We can also include multiple properties by separating them with a comma:
+
+```
+https://spatie.be/my-account?include=favorite_song,favorite_movie
+```
+
+Or by using a group input:
+
+```
+https://spatie.be/my-account?include[]=favorite_song&include[]=favorite_movie
+```
+
 Including properties works for data objects and data collections.
 
 ### Allowing includes by query string

--- a/src/Resolvers/PartialsTreeFromRequestResolver.php
+++ b/src/Resolvers/PartialsTreeFromRequestResolver.php
@@ -26,7 +26,7 @@ class PartialsTreeFromRequestResolver
         Request $request,
     ): PartialTrees {
         $requestedIncludesTree = $this->partialsParser->execute(
-            $request->has('include') ? $this->arrayFromRequest($request, 'includes') : []
+            $request->has('include') ? $this->arrayFromRequest($request, 'include') : []
         );
         $requestedExcludesTree = $this->partialsParser->execute(
             $request->has('exclude') ? $this->arrayFromRequest($request, 'exclude') : []

--- a/src/Resolvers/PartialsTreeFromRequestResolver.php
+++ b/src/Resolvers/PartialsTreeFromRequestResolver.php
@@ -26,16 +26,16 @@ class PartialsTreeFromRequestResolver
         Request $request,
     ): PartialTrees {
         $requestedIncludesTree = $this->partialsParser->execute(
-            $request->has('include') ? explode(',', $request->get('include')) : []
+            $request->has('include') ? $this->arrayFromRequest($request, 'includes') : []
         );
         $requestedExcludesTree = $this->partialsParser->execute(
-            $request->has('exclude') ? explode(',', $request->get('exclude')) : []
+            $request->has('exclude') ? $this->arrayFromRequest($request, 'exclude') : []
         );
         $requestedOnlyTree = $this->partialsParser->execute(
-            $request->has('only') ? explode(',', $request->get('only')) : []
+            $request->has('only') ? $this->arrayFromRequest($request, 'only') : []
         );
         $requestedExceptTree = $this->partialsParser->execute(
-            $request->has('except') ? explode(',', $request->get('except')) : []
+            $request->has('except') ? $this->arrayFromRequest($request, 'except') : []
         );
 
         $dataClass = match (true) {
@@ -57,5 +57,12 @@ class PartialsTreeFromRequestResolver
             $partialTrees->only->merge($requestedOnlyTree->intersect($allowedRequestOnlyTree)),
             $partialTrees->except->merge($requestedExceptTree->intersect($allowedRequestExceptTree))
         );
+    }
+
+    private function arrayFromRequest(Request $request, string $key): array
+    {
+        $value = $request->get($key);
+
+        return is_array($value) ? $value : explode(',', $value);
     }
 }

--- a/tests/Resolvers/PartialsTreeFromRequestResolverTest.php
+++ b/tests/Resolvers/PartialsTreeFromRequestResolverTest.php
@@ -207,4 +207,44 @@ class PartialsTreeFromRequestResolverTest extends TestCase
             'name' => 'Never gonna give you up',
         ], $data);
     }
+
+    /**
+     * @test
+     * @dataProvider requestInputProvider
+     */
+    public function it_handles_parsing_includes_from_request(array $input, array $expected)
+    {
+        $dataclass = new class (
+            Lazy::create(fn () => 'Rick Astley'),
+            Lazy::create(fn () => 'Never gonna give you up'),
+            Lazy::create(fn () => 1986),
+        ) extends MultiLazyData {
+            public static function allowedRequestIncludes(): ?array
+            {
+                return ['*'];
+            }
+        };
+
+        $request = request()->merge($input);
+
+        $data = $dataclass->toResponse($request)->getData(assoc: true);
+
+        $this->assertEquals(
+            array_keys($data),
+            $expected,
+        );
+    }
+
+    protected function requestInputProvider()
+    {
+        yield 'input as array' => [
+            'input' => ['include' => ['artist', 'name']],
+            'expected' => ['artist', 'name'],
+        ];
+
+        yield 'input as comma separated' => [
+            'input' => ['include' => 'artist,name'],
+            'expected' => ['artist', 'name'],
+        ];
+    }
 }


### PR DESCRIPTION
When building the partials tree from the query parameters the only supported syntax is comma separated: `?include=foo,bar`

In a project I'm working on we're already using that key, but with array syntax: `?include[]=foo&include[]=bar`

This PR add support for both syntaxes.