### PR TITLE
Caching data classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ testbench.yaml
 vendor
 node_modules
 .php-cs-fixer.cache
+.fleet

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,13 @@
             "role": "Developer"
         }
     ],
+    "repositories" : [{"type" : "path", "url" : "../laravel-auto-discoverer"}],
     "require": {
         "php": "^8.1",
         "illuminate/contracts": "^8.71|^9.18",
         "phpdocumentor/type-resolver": "^1.5",
-        "spatie/laravel-package-tools": "^1.9.0"
+        "spatie/laravel-package-tools": "^1.9.0",
+        "spatie/laravel-auto-discoverer": "@dev"
     },
     "require-dev": {
         "fakerphp/faker": "^1.14",

--- a/config/data.php
+++ b/config/data.php
@@ -53,6 +53,6 @@ return [
      * information for the data objects.
      */
     'data_paths' => [
-        app_path()
+
     ]
 ];

--- a/config/data.php
+++ b/config/data.php
@@ -46,4 +46,13 @@ return [
      * `null` if you want to disable wrapping.
      */
     'wrap' => null,
+
+
+    /*
+     * Paths where data objects can be found, will be used for caching reflection
+     * information for the data objects.
+     */
+    'data_paths' => [
+        app_path()
+    ]
 ];

--- a/src/LaravelDataServiceProvider.php
+++ b/src/LaravelDataServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelData;
 
+use Illuminate\Support\Collection;
 use Spatie\LaravelAutoDiscoverer\Discover;
 use Spatie\LaravelData\Commands\DataMakeCommand;
 use Spatie\LaravelData\Contracts\BaseData;
@@ -32,7 +33,7 @@ class LaravelDataServiceProvider extends PackageServiceProvider
             ->within(...app(DataConfig::class)->getDataPaths())
             ->extending(DataObject::class)
             ->returnReflection()
-            ->get(fn (array $classes) => app(DataCacheManager::class)->initialize($classes));
+            ->get(fn (Collection $classes) => app(DataCacheManager::class)->initialize($classes));
 
         /** @psalm-suppress UndefinedInterfaceMethod */
         $this->app->beforeResolving(BaseData::class, function ($class, $parameters, $app) {

--- a/src/LaravelDataServiceProvider.php
+++ b/src/LaravelDataServiceProvider.php
@@ -2,8 +2,12 @@
 
 namespace Spatie\LaravelData;
 
+use Illuminate\Support\Collection;
+use Spatie\LaravelAutoDiscoverer\Discover;
 use Spatie\LaravelData\Commands\DataMakeCommand;
 use Spatie\LaravelData\Contracts\BaseData;
+use Spatie\LaravelData\Contracts\DataObject;
+use Spatie\LaravelData\Support\Cache\DataCacheManager;
 use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -24,6 +28,12 @@ class LaravelDataServiceProvider extends PackageServiceProvider
             DataConfig::class,
             fn () => new DataConfig(config('data'))
         );
+
+        Discover::classes('laravel-data')
+            ->within(...app(DataConfig::class)->getDataPaths())
+            ->extending(DataObject::class)
+            ->returnReflection()
+            ->get(fn(array $classes) => app(DataCacheManager::class)->initialize($classes));
 
         /** @psalm-suppress UndefinedInterfaceMethod */
         $this->app->beforeResolving(BaseData::class, function ($class, $parameters, $app) {

--- a/src/LaravelDataServiceProvider.php
+++ b/src/LaravelDataServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\LaravelData;
 
-use Illuminate\Support\Collection;
 use Spatie\LaravelAutoDiscoverer\Discover;
 use Spatie\LaravelData\Commands\DataMakeCommand;
 use Spatie\LaravelData\Contracts\BaseData;
@@ -33,7 +32,7 @@ class LaravelDataServiceProvider extends PackageServiceProvider
             ->within(...app(DataConfig::class)->getDataPaths())
             ->extending(DataObject::class)
             ->returnReflection()
-            ->get(fn(array $classes) => app(DataCacheManager::class)->initialize($classes));
+            ->get(fn (array $classes) => app(DataCacheManager::class)->initialize($classes));
 
         /** @psalm-suppress UndefinedInterfaceMethod */
         $this->app->beforeResolving(BaseData::class, function ($class, $parameters, $app) {

--- a/src/Support/Cache/DataCacheManager.php
+++ b/src/Support/Cache/DataCacheManager.php
@@ -5,7 +5,6 @@ namespace Spatie\LaravelData\Support\Cache;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Collection;
 use ReflectionClass;
-use Spatie\LaravelData\Contracts\DataObject;
 use Spatie\LaravelData\Support\DataClass;
 use Spatie\LaravelData\Support\DataConfig;
 use Throwable;
@@ -22,22 +21,22 @@ class DataCacheManager
         /** @var Collection<string> $cachedClasses */
         /** @var Collection<ReflectionClass|string> $uncachedClasses */
         [$cachedClasses, $uncachedClasses] = collect($classes)
-            ->partition(fn(ReflectionClass|string $class) => $this->hasClass($class));
+            ->partition(fn (ReflectionClass|string $class) => $this->hasClass($class));
 
         $cachedClasses
-            ->map(fn(string $class) => $this->getClass($class))
-            ->pipe(fn(Collection $dataClasses) => $this->dataConfig->intializeCachedDataClasses(...$dataClasses->all()));
+            ->map(fn (string $class) => $this->getClass($class))
+            ->pipe(fn (Collection $dataClasses) => $this->dataConfig->intializeCachedDataClasses(...$dataClasses->all()));
 
         $uncachedClasses
-            ->map(fn(ReflectionClass|string $class) => $this->createClass($class))
-            ->pipe(fn(Collection $dataClasses) => $this->dataConfig->intializeCachedDataClasses(...$dataClasses->all()));
+            ->map(fn (ReflectionClass|string $class) => $this->createClass($class))
+            ->pipe(fn (Collection $dataClasses) => $this->dataConfig->intializeCachedDataClasses(...$dataClasses->all()));
     }
 
     public function cache(array $classes)
     {
         collect($classes)
-            ->map(fn(string $class) => $this->createClass($class))
-            ->each(fn(DataClass $dataClass) => $this->putClass($dataClass));
+            ->map(fn (string $class) => $this->createClass($class))
+            ->each(fn (DataClass $dataClass) => $this->putClass($dataClass));
     }
 
     protected function hasClass(string|ReflectionClass $class): bool

--- a/src/Support/Cache/DataCacheManager.php
+++ b/src/Support/Cache/DataCacheManager.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Spatie\LaravelData\Support\Cache;
+
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Collection;
+use ReflectionClass;
+use Spatie\LaravelData\Contracts\DataObject;
+use Spatie\LaravelData\Support\DataClass;
+use Spatie\LaravelData\Support\DataConfig;
+use Throwable;
+
+class DataCacheManager
+{
+    public function __construct(
+        protected DataConfig $dataConfig,
+    ) {
+    }
+
+    public function initialize(array $classes)
+    {
+        /** @var Collection<string> $cachedClasses */
+        /** @var Collection<ReflectionClass|string> $uncachedClasses */
+        [$cachedClasses, $uncachedClasses] = collect($classes)
+            ->partition(fn(ReflectionClass|string $class) => $this->hasClass($class));
+
+        $cachedClasses
+            ->map(fn(string $class) => $this->getClass($class))
+            ->pipe(fn(Collection $dataClasses) => $this->dataConfig->intializeCachedDataClasses(...$dataClasses->all()));
+
+        $uncachedClasses
+            ->map(fn(ReflectionClass|string $class) => $this->createClass($class))
+            ->pipe(fn(Collection $dataClasses) => $this->dataConfig->intializeCachedDataClasses(...$dataClasses->all()));
+    }
+
+    public function cache(array $classes)
+    {
+        collect($classes)
+            ->map(fn(string $class) => $this->createClass($class))
+            ->each(fn(DataClass $dataClass) => $this->putClass($dataClass));
+    }
+
+    protected function hasClass(string|ReflectionClass $class): bool
+    {
+        return $this->getCache()->has($this->getCacheKey($class));
+    }
+
+    protected function getClass(string|ReflectionClass $class): DataClass
+    {
+        try {
+            return unserialize($this->getCache()->get($this->getCacheKey($class)));
+        } catch (Throwable) {
+            return DataClass::create($class);
+        }
+    }
+
+    protected function putClass(DataClass $dataClass): void
+    {
+        $this->getCache()->put($this->getCacheKey($dataClass->name), $dataClass);
+    }
+
+    protected function createClass(string|ReflectionClass $class): DataClass
+    {
+        return DataClass::create(
+            $class instanceof ReflectionClass ? $class : new ReflectionClass($class)
+        );
+    }
+
+    protected function cacheClass(DataClass $class): string
+    {
+        return serialize($class);
+    }
+
+    protected function getCacheKey(string|ReflectionClass $class): string
+    {
+        return 'laravel-data.' . $class instanceof ReflectionClass ? $class->name : $class;
+    }
+
+    protected function getCache(): Repository
+    {
+        return cache()->driver();
+    }
+}

--- a/src/Support/Cache/DataCacheManager.php
+++ b/src/Support/Cache/DataCacheManager.php
@@ -16,11 +16,11 @@ class DataCacheManager
     ) {
     }
 
-    public function initialize(array $classes)
+    public function initialize(Collection $classes)
     {
         /** @var Collection<string> $cachedClasses */
         /** @var Collection<ReflectionClass|string> $uncachedClasses */
-        [$cachedClasses, $uncachedClasses] = collect($classes)
+        [$cachedClasses, $uncachedClasses] = $classes
             ->partition(fn (ReflectionClass|string $class) => $this->hasClass($class));
 
         $cachedClasses

--- a/src/Support/DataConfig.php
+++ b/src/Support/DataConfig.php
@@ -26,7 +26,7 @@ class DataConfig
     public function __construct(array $config)
     {
         $this->ruleInferrers = array_map(
-            fn(string $ruleInferrerClass) => app($ruleInferrerClass),
+            fn (string $ruleInferrerClass) => app($ruleInferrerClass),
             $config['rule_inferrers'] ?? []
         );
 

--- a/src/Support/DataConfig.php
+++ b/src/Support/DataConfig.php
@@ -20,10 +20,13 @@ class DataConfig
     /** @var \Spatie\LaravelData\RuleInferrers\RuleInferrer[] */
     protected array $ruleInferrers;
 
+    /** @var array<string> */
+    protected array $dataPaths;
+
     public function __construct(array $config)
     {
         $this->ruleInferrers = array_map(
-            fn (string $ruleInferrerClass) => app($ruleInferrerClass),
+            fn(string $ruleInferrerClass) => app($ruleInferrerClass),
             $config['rule_inferrers'] ?? []
         );
 
@@ -34,6 +37,8 @@ class DataConfig
         foreach ($config['casts'] ?? [] as $castable => $cast) {
             $this->casts[ltrim($castable, ' \\')] = app($cast);
         }
+
+        $this->dataPaths = $config['data_paths'] ?? [];
     }
 
     public function getDataClass(string $class): DataClass
@@ -77,8 +82,26 @@ class DataConfig
         return null;
     }
 
+    public function intializeCachedDataClasses(
+        DataClass ...$classes,
+    ): void {
+        foreach ($classes as $class) {
+            $this->dataClasses[$class->name] = $class;
+        }
+    }
+
     public function getRuleInferrers(): array
     {
         return $this->ruleInferrers;
+    }
+
+    public function getDataPaths(): array
+    {
+        return $this->dataPaths;
+    }
+
+    public function getDataClasses(): array
+    {
+        return $this->dataClasses;
     }
 }

--- a/tests/Support/Cache/DataCacheManagerTest.php
+++ b/tests/Support/Cache/DataCacheManagerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Support\Cache;
+
+use ReflectionClass;
+use Spatie\LaravelAutoDiscoverer\Discover;
+use Spatie\LaravelAutoDiscoverer\DiscoverProfile;
+use Spatie\LaravelData\Support\Cache\DataCacheManager;
+use Spatie\LaravelData\Support\DataClass;
+use Spatie\LaravelData\Support\DataConfig;
+use Spatie\LaravelData\Tests\Fakes\SimpleData;
+use Spatie\LaravelData\Tests\TestCase;
+
+class DataCacheManagerTest extends TestCase
+{
+    /** @test */
+    public function it_can_cache_classes()
+    {
+        Discover::update('laravel-data', function (DiscoverProfile $profile) {
+            $profile
+                ->directories(__DIR__ . '/../../Fakes/')
+                ->basePath(__DIR__ . '/../../Fakes')
+                ->rootNamespace('Spatie\LaravelData\Tests\Fakes');
+        });
+
+        Discover::run();
+
+        $dataClasses = app(DataConfig::class)->getDataClasses();
+
+        $this->assertNotEmpty($dataClasses);
+        $this->assertEquals(DataClass::create(new ReflectionClass(SimpleData::class)), $dataClasses[SimpleData::class]);
+    }
+}

--- a/tests/Support/Cache/DataCacheManagerTest.php
+++ b/tests/Support/Cache/DataCacheManagerTest.php
@@ -5,7 +5,6 @@ namespace Spatie\LaravelData\Tests\Support\Cache;
 use ReflectionClass;
 use Spatie\LaravelAutoDiscoverer\Discover;
 use Spatie\LaravelAutoDiscoverer\DiscoverProfile;
-use Spatie\LaravelData\Support\Cache\DataCacheManager;
 use Spatie\LaravelData\Support\DataClass;
 use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;

--- a/tests/Support/Cache/DataCacheManagerTest.php
+++ b/tests/Support/Cache/DataCacheManagerTest.php
@@ -4,7 +4,8 @@ namespace Spatie\LaravelData\Tests\Support\Cache;
 
 use ReflectionClass;
 use Spatie\LaravelAutoDiscoverer\Discover;
-use Spatie\LaravelAutoDiscoverer\DiscoverProfile;
+use Spatie\LaravelAutoDiscoverer\ValueObjects\DiscoverProfile;
+use Spatie\LaravelAutoDiscoverer\ValueObjects\DiscoverProfileConfig;
 use Spatie\LaravelData\Support\DataClass;
 use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
@@ -15,11 +16,12 @@ class DataCacheManagerTest extends TestCase
     /** @test */
     public function it_can_cache_classes()
     {
-        Discover::update('laravel-data', function (DiscoverProfile $profile) {
+        Discover::update('laravel-data', function (DiscoverProfileConfig $profile) {
             $profile
-                ->directories(__DIR__ . '/../../Fakes/')
                 ->basePath(__DIR__ . '/../../Fakes')
                 ->rootNamespace('Spatie\LaravelData\Tests\Fakes');
+
+            $profile->directories = [__DIR__ . '/../../Fakes/'];
         });
 
         Discover::run();

--- a/tests/Support/Cache/DataCacheManagerTest.php
+++ b/tests/Support/Cache/DataCacheManagerTest.php
@@ -4,7 +4,6 @@ namespace Spatie\LaravelData\Tests\Support\Cache;
 
 use ReflectionClass;
 use Spatie\LaravelAutoDiscoverer\Discover;
-use Spatie\LaravelAutoDiscoverer\ValueObjects\DiscoverProfile;
 use Spatie\LaravelAutoDiscoverer\ValueObjects\DiscoverProfileConfig;
 use Spatie\LaravelData\Support\DataClass;
 use Spatie\LaravelData\Support\DataConfig;


### PR DESCRIPTION
This feature allows caching all data classes and their properties, eliminating the need for Reflection which should speed up the process quite a bit.

It is still a work in progresss:

- [ ] remove dev dependency Laravel-auto-discoverer
- [ ] add commands for caching
- [ ] tesing, testing, testing