### PR TITLE
Conditional return types for collections

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,6 +6,7 @@ parameters:
     paths:
         - src
         - config
+        - types
     tmpDir: build/phpstan
     reportUnmatchedIgnoredErrors: true
     checkOctaneCompatibility: true

--- a/src/Contracts/BaseData.php
+++ b/src/Contracts/BaseData.php
@@ -30,7 +30,7 @@ interface BaseData
     /**
      * @param \Illuminate\Support\Enumerable|array|\Illuminate\Pagination\AbstractPaginator|\Illuminate\Contracts\Pagination\Paginator|\Illuminate\Pagination\AbstractCursorPaginator|\Illuminate\Contracts\Pagination\CursorPaginator|\Spatie\LaravelData\DataCollection $items
      *
-     * @return \Spatie\LaravelData\DataCollection|\Spatie\LaravelData\CursorPaginatedDataCollection|\Spatie\LaravelData\PaginatedDataCollection
+     * @return ($items is \Illuminate\Pagination\AbstractCursorPaginator|\Illuminate\Pagination\CursorPaginator ? \Spatie\LaravelData\CursorPaginatedDataCollection : ($items is \Illuminate\Pagination\Paginator|\Illuminate\Pagination\AbstractPaginator ? \Spatie\LaravelData\PaginatedDataCollection : \Spatie\LaravelData\DataCollection))
      */
     public static function collection(Enumerable|array|AbstractPaginator|Paginator|AbstractCursorPaginator|CursorPaginator|DataCollection $items): DataCollection|CursorPaginatedDataCollection|PaginatedDataCollection;
 

--- a/types/Collection.php
+++ b/types/Collection.php
@@ -1,0 +1,47 @@
+<?php
+
+/** @noinspection PhpExpressionResultUnusedInspection */
+
+use Illuminate\Pagination\CursorPaginator;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+
+use Spatie\LaravelData\CursorPaginatedDataCollection;
+use function PHPStan\dumpType;
+use function PHPStan\Testing\assertType;
+
+use Spatie\LaravelData\DataCollection;
+use Spatie\LaravelData\PaginatedDataCollection;
+use Spatie\LaravelData\Tests\Fakes\SimpleData;
+
+// Regular collections
+$collection = SimpleData::collection(['A', 'B']);
+assertType(DataCollection::class, $collection);
+$collection = SimpleData::collection(collect(['A', 'B']));
+assertType(DataCollection::class, $collection);
+
+
+// PaginatedDataCollection
+$items = Collection::times(100, fn (int $index) => "Item {$index}");
+
+$paginator = new LengthAwarePaginator(
+    $items->forPage(1, 15),
+    100,
+    15
+);
+
+$collection = SimpleData::collection($paginator);
+
+assertType(PaginatedDataCollection::class, $collection);
+
+// CursorPaginatedDataCollection
+$items = Collection::times(100, fn (int $index) => "Item {$index}");
+
+$paginator = new CursorPaginator(
+    $items,
+    15,
+);
+
+$collection = SimpleData::collection($paginator);
+
+assertType(CursorPaginatedDataCollection::class, $collection);


### PR DESCRIPTION
Resolves #158 

This adds conditional return types for collections so that `phpstan` knows which collection type is being returned (`DataCollection`, `PaginatedDataCollection`, `CursorPaginatedDataCollection`)

There is [an issue](https://github.com/phpstan/phpstan/issues/7740) and that is that it doesn't seem to properly work with interfaces, so (for now) it checks for the `CursorPaginator` and `Paginator` classes rather than interfaces.
Once that bug has been fixed we can update the conditional return type to check for the contracts, but it still might be worth getting this in before that.