### PR TITLE
Cast lazy condition result to bool

### DIFF
--- a/src/Support/Lazy/ConditionalLazy.php
+++ b/src/Support/Lazy/ConditionalLazy.php
@@ -20,6 +20,6 @@ class ConditionalLazy extends Lazy
 
     public function shouldBeIncluded(): bool
     {
-        return ($this->condition)();
+        return (bool) ($this->condition)();
     }
 }


### PR DESCRIPTION
When using `ConditionableLazy`, you must always return a `bool` value in the condition closure. If you don't, a `TypeError` is thrown:

```
TypeError: Spatie\LaravelData\Support\Lazy\ConditionalLazy::shouldBeIncluded(): Return value must be of type bool, null returned in ...
```

In the following example I have to manually cast to a `bool`, or use a function like `filled` to avoid the error.

```php
/** @var ?string $value */
$value = null;

Lazy::when(fn () => $value, fn () => ...); // TypeError

Lazy::when(fn () => filled($value), fn () => ...); // ok
Lazy::when(fn () => (bool) $value, fn () => ...); // ok
```

With this PR, you don't have to manually cast to a bool anymore.