### PR TITLE
feat: make normalizers globally configurable

### DIFF
--- a/config/data.php
+++ b/config/data.php
@@ -40,6 +40,18 @@ return [
         Spatie\LaravelData\RuleInferrers\RequiredRuleInferrer::class,
     ],
 
+    /**
+     * Normalizers return an array representation of the payload, or null if
+     * it cannot normalize the payload. The normalizers below are used for
+     * every data object, unless overriden in a specific data object class.
+     */
+    'normalizers' => [
+         Spatie\LaravelData\Normalizers\ModelNormalizer::class,
+         Spatie\LaravelData\Normalizers\ArraybleNormalizer::class,
+         Spatie\LaravelData\Normalizers\ObjectNormalizer::class,
+         Spatie\LaravelData\Normalizers\ArrayNormalizer::class,
+    ],
+
     /*
      * Data objects can be wrapped into a key like 'data' when used as a resource,
      * this key can be set globally here for all data objects. You can pass in

--- a/docs/advanced-usage/normalizers.md
+++ b/docs/advanced-usage/normalizers.md
@@ -10,7 +10,7 @@ eloquent model to create a data object like this:
 SongData::from(Song::findOrFail($id));
 ```
 
-A `Normalizer` will take a payload like a model and transforms it into an array so it can be used in the pipeline (see further).
+A `Normalizer` will take a payload like a model and will transform it into an array so it can be used in the pipeline (see further).
 
 By default, there are four normalizers for each data object:
 
@@ -19,7 +19,7 @@ By default, there are four normalizers for each data object:
 - **ObjectNormalizer** will cast `stdObject`'s
 - **ArrayNormalizer** will cast arrays
 
-Normalizers are defined in the data object `normalizers` method and can be overwritten on an individual data object:
+Normalizers can be globally configured in `config/data.php`, and can be configured on a specific data object by overriding the `normalizers` method.
 
 ```php
 class SongData extends Data
@@ -41,7 +41,7 @@ class SongData extends Data
 }
 ```
 
-A normalizer implements the `Normalizer` interface and should return an array representation of the payload or null if it cannot normalize the payload:
+A normalizer implements the `Normalizer` interface and should return an array representation of the payload, or null if it cannot normalize the payload:
 
 ```php
 class ArraybleNormalizer implements Normalizer
@@ -58,5 +58,3 @@ class ArraybleNormalizer implements Normalizer
 ```
 
 Normalizers are executed the order as they are defined in the `normalize` method. The first normalizer not returning null will be used to normalize the payload. Magical creation methods always have precedence on normalizers.
-
-

--- a/src/Concerns/BaseData.php
+++ b/src/Concerns/BaseData.php
@@ -15,10 +15,6 @@ use Spatie\LaravelData\DataPipes\CastPropertiesDataPipe;
 use Spatie\LaravelData\DataPipes\DefaultValuesDataPipe;
 use Spatie\LaravelData\DataPipes\MapPropertiesDataPipe;
 use Spatie\LaravelData\DataPipes\ValidatePropertiesDataPipe;
-use Spatie\LaravelData\Normalizers\ArraybleNormalizer;
-use Spatie\LaravelData\Normalizers\ArrayNormalizer;
-use Spatie\LaravelData\Normalizers\ModelNormalizer;
-use Spatie\LaravelData\Normalizers\ObjectNormalizer;
 use Spatie\LaravelData\PaginatedDataCollection;
 use Spatie\LaravelData\Resolvers\DataFromSomethingResolver;
 use Spatie\LaravelData\Resolvers\EmptyDataResolver;
@@ -58,12 +54,7 @@ trait BaseData
 
     public static function normalizers(): array
     {
-        return [
-            ModelNormalizer::class,
-            ArraybleNormalizer::class,
-            ObjectNormalizer::class,
-            ArrayNormalizer::class,
-        ];
+        return config('data.normalizers');
     }
 
     public static function pipeline(): DataPipeline


### PR DESCRIPTION
This PR makes normalizers globally configurable, via `config/data.php`. Currently, I have to add a trait to all my data objects I want specific normalizers on. 