### PR TITLE
feat: allow direct pipeline call

### DIFF
--- a/docs/advanced-usage/pipeline.md
+++ b/docs/advanced-usage/pipeline.md
@@ -60,4 +60,4 @@ The `handle` method has several arguments:
 
 When using a magic creation methods, the pipeline is not being used (since you manually overwrite how a data object is
 constructed). Only when you pass in a request object a minimal version of the pipeline is used to authorize and validate
-the request.
+the request. If you need to ignore the custom creation methods, you can call `throughPipeline` on the data object.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,6 +61,11 @@ parameters:
 			path: src/Data.php
 
 		-
+			message: "#^Method Spatie\\\\LaravelData\\\\Data\\:\\:throughPipeline\\(\\) should return static\\(Spatie\\\\LaravelData\\\\Data\\) but returns Spatie\\\\LaravelData\\\\Contracts\\\\BaseData\\.$#"
+			count: 1
+			path: src/Data.php
+
+		-
 			message: "#^PHPDoc tag @return with type Spatie\\\\LaravelData\\\\DataCollection\\<int, mixed\\> is not subtype of native type static\\(Spatie\\\\LaravelData\\\\DataCollection\\<TKey of \\(int\\|string\\), TValue\\>\\)\\.$#"
 			count: 1
 			path: src/DataCollection.php
@@ -124,4 +129,3 @@ parameters:
 			message: "#^Match arm comparison between true and false is always false\\.$#"
 			count: 1
 			path: src/Support/Validation/RulesMapper.php
-

--- a/src/Concerns/BaseData.php
+++ b/src/Concerns/BaseData.php
@@ -56,6 +56,14 @@ trait BaseData
         );
     }
 
+    public static function throughPipeline(mixed ...$payloads): static
+    {
+        return app(DataFromSomethingResolver::class)->executeThroughPipeline(
+            static::class,
+            ...$payloads
+        );
+    }
+
     public static function normalizers(): array
     {
         return [

--- a/src/Resolvers/DataFromSomethingResolver.php
+++ b/src/Resolvers/DataFromSomethingResolver.php
@@ -27,6 +27,11 @@ class DataFromSomethingResolver
             return $data;
         }
 
+        return $this->executeThroughPipeline($class, ...$payloads);
+    }
+
+    public function executeThroughPipeline(string $class, mixed ...$payloads): BaseData
+    {
         $properties = array_reduce(
             $payloads,
             function (Collection $carry, mixed $payload) use ($class) {


### PR DESCRIPTION
This PR adds a way to transform something into a DTO without using the custom transform methods. 

I often need to transform models but modify some of their properties during the process. For instance, a model using HashIDs should not have its `id` used in the DTO, but its HashID. 

Currently, I use a custom `from` method, and I call `toArray()` on the model:

```php
public static function fromDummyModel(DummyModel $model): static
{
    return static::from([
        ...$model->toArray(),
        'id' => $model->getRouteKey()
    ]);
}
```

The issue is that this will not take nested DTOs into account. If my model has a relation, and that relation is setup as a DTO, the custom creation methods for these nested DTOs are never called, because the relations are serialized in the first `toArray` call. 

To fix that, this PR adds a `throughPipeline` method that will pass the given value through the transform pipeline while ignoring custom transform methods. This method can be called inside a custom transform method, fixing the issues above.

```php
public static function fromDummyModel(DummyModel $model)
{
    return static::from([
        ...self::throughPipeline($model)->toArray(),
        'id' => $model->getRouteKey(),
    ]);
}
```

If you have a better name than `throughPipeline`, feel free to change it. I couldn't come up with a better idea. 😅 