### PR TITLE
refactor(var-dumper): use `AbstractCloner` instead of reflection

### DIFF
--- a/src/Support/VarDumper/VarDumperManager.php
+++ b/src/Support/VarDumper/VarDumperManager.php
@@ -2,35 +2,15 @@
 
 namespace Spatie\LaravelData\Support\VarDumper;
 
-use ReflectionMethod;
-use ReflectionProperty;
 use Spatie\LaravelData\Contracts\DataCollectable;
 use Spatie\LaravelData\Contracts\DataObject;
-use Symfony\Component\VarDumper\Cloner\VarCloner;
-use Symfony\Component\VarDumper\VarDumper;
+use Symfony\Component\VarDumper\Cloner\AbstractCloner;
 
 class VarDumperManager
 {
     public function initialize(): void
     {
-        $reflectionProperty = new ReflectionProperty(VarDumper::class, 'handler');
-        $reflectionProperty->setAccessible(true);
-        $handler = $reflectionProperty->getValue();
-
-        if (! $handler) {
-            $reflectionMethod = new ReflectionMethod(VarDumper::class, 'register');
-            $reflectionMethod->setAccessible(true);
-            $reflectionMethod->invoke(null);
-        }
-
-        $handler = $reflectionProperty->getValue();
-
-        /** @var VarCloner $cloner */
-        $cloner = (new \ReflectionFunction($handler))->getClosureUsedVariables()['cloner'];
-
-        $cloner->addCasters([
-            DataObject::class => [DataVarDumperCaster::class, 'castDataObject'],
-            DataCollectable::class => [DataVarDumperCaster::class, 'castDataCollectable'],
-        ]);
+        AbstractCloner::$defaultCasters[DataObject::class] = [DataVarDumperCaster::class, 'castDataObject'];
+        AbstractCloner::$defaultCasters[DataCollectable::class] = [DataVarDumperCaster::class, 'castDataCollectable'];
     }
 }


### PR DESCRIPTION
The current implementation does not work sometimes when the handler isn't the one you expect and does not have the `cloner`:

<img width="616" alt="image" src="https://user-images.githubusercontent.com/16060559/185404222-20f6a250-8b26-4914-8b47-d308942d9c17.png">

![image](https://user-images.githubusercontent.com/16060559/185404487-733fdf14-8fcd-4118-88c0-28c0de161e68.png)

My whole test suit fails right now. This PR updates the implementation to simply use the `AbstractCloner`.

