### PR TITLE
Fix: Validators can be applied for nested data

### DIFF
--- a/src/Resolvers/DataPropertyValidationRulesResolver.php
+++ b/src/Resolvers/DataPropertyValidationRulesResolver.php
@@ -18,8 +18,10 @@ class DataPropertyValidationRulesResolver
 
     public function execute(DataProperty $property, array $payload = [], bool $nullable = false): Collection
     {
-        if ($property->isData() || $property->isDataCollection()) {
-            return $this->getNestedRules($property, $payload, $nullable);
+         if ($property->isData() || $property->isDataCollection()){
+            $current = collect([$property->name() => $this->getRulesForProperty($property, $nullable)]);
+            $nested = $this->getNestedRules($property, $payload, $nullable);
+            return $nested->mergeRecursive($current);
         }
 
         return collect([$property->name() => $this->getRulesForProperty($property, $nullable)]);


### PR DESCRIPTION
Attribute validators cannot be applies to Data and Collections - there are defaults that are used instead. This fix will get the validators from the basic property and merge any tested validators with them