### PR TITLE
Propagate generics to traits on collection classes

### DIFF
--- a/src/CursorPaginatedDataCollection.php
+++ b/src/CursorPaginatedDataCollection.php
@@ -26,6 +26,8 @@ class CursorPaginatedDataCollection implements DataCollectable
     use IncludeableData;
     use WrappableData;
     use TransformableData;
+
+    /** @use \Spatie\LaravelData\Concerns\BaseDataCollectable<TKey, TValue> */
     use BaseDataCollectable;
 
     /** @var CursorPaginator<TValue> */

--- a/src/DataCollection.php
+++ b/src/DataCollection.php
@@ -26,11 +26,14 @@ use Spatie\LaravelData\Support\EloquentCasts\DataCollectionEloquentCast;
  */
 class DataCollection implements DataCollectable, ArrayAccess
 {
+    /** @use \Spatie\LaravelData\Concerns\BaseDataCollectable<TKey, TValue> */
     use BaseDataCollectable;
     use ResponsableData;
     use IncludeableData;
     use WrappableData;
     use TransformableData;
+
+    /** @use \Spatie\LaravelData\Concerns\EnumerableMethods<TKey, TValue> */
     use EnumerableMethods;
 
     /** @var Enumerable<TKey, TValue> */

--- a/src/PaginatedDataCollection.php
+++ b/src/PaginatedDataCollection.php
@@ -26,6 +26,8 @@ class PaginatedDataCollection implements DataCollectable
     use IncludeableData;
     use WrappableData;
     use TransformableData;
+
+    /** @use \Spatie\LaravelData\Concerns\BaseDataCollectable<TKey, TValue> */
     use BaseDataCollectable;
 
     protected Paginator $items;


### PR DESCRIPTION
Hey Folks,

using PHPStan/Larastan on level 9 currently reports issues regarding the generics on the collection classes.

For example the following code gives an error:

```php
/** @var DataCollection<int, TestData> $collection */
$collection = \App\DataObjects\TestData::collection([]);

$collection->each(function (\App\DataObjects\TestData $data) {
    echo $data->id;
});
```

PHPStan reports an error for the callback of the `each` method:

```
Parameter #1 $callback of method Spatie\LaravelData\DataCollection<int,App\DataObjects\TestData>::each() expects callable(mixed, (int|string)): mixed, Closure(App\DataObjects\TestData): void given.
```

This PR fixes these problems by annotating the used traits and by that propagate the types down to them.
It mimics how Laravel does the same thing for the Collection class.

Thank you for this and all the other great packages you provide!