### PR TITLE
feat: Use generics with `Data::collection`

### DIFF
--- a/src/Contracts/BaseData.php
+++ b/src/Contracts/BaseData.php
@@ -13,29 +13,20 @@ use Spatie\LaravelData\DataPipeline;
 use Spatie\LaravelData\PaginatedDataCollection;
 
 /**
- * @template TValue of object
+ * @template TValue
  */
 interface BaseData
 {
-    /**
-     * @return TValue|null
-     */
-    public static function optional(mixed ...$payloads): ?object;
+    public static function optional(mixed ...$payloads): ?static;
+
+    public static function from(mixed ...$payloads): static;
+
+    public static function withoutMagicalCreationFrom(mixed ...$payloads): static;
 
     /**
-     * @return TValue
-     */
-    public static function from(mixed ...$payloads): object;
-
-    /**
-     * @return TValue
-     */
-    public static function withoutMagicalCreationFrom(mixed ...$payloads): object;
-
-    /**
-     * @param \Illuminate\Support\Enumerable|array|\Illuminate\Pagination\AbstractPaginator|\Illuminate\Contracts\Pagination\Paginator|\Illuminate\Pagination\AbstractCursorPaginator|\Illuminate\Contracts\Pagination\CursorPaginator|\Spatie\LaravelData\DataCollection $items
+     * @param \Illuminate\Support\Enumerable<array-key, TValue>|TValue[]|\Illuminate\Pagination\AbstractPaginator|\Illuminate\Contracts\Pagination\Paginator|\Illuminate\Pagination\AbstractCursorPaginator|\Illuminate\Contracts\Pagination\CursorPaginator|\Spatie\LaravelData\DataCollection<array-key, TValue> $items
      *
-     * @return ($items is \Illuminate\Pagination\AbstractCursorPaginator|\Illuminate\Pagination\CursorPaginator ? \Spatie\LaravelData\CursorPaginatedDataCollection : ($items is \Illuminate\Pagination\Paginator|\Illuminate\Pagination\AbstractPaginator ? \Spatie\LaravelData\PaginatedDataCollection : \Spatie\LaravelData\DataCollection))
+     * @return ($items is \Illuminate\Pagination\AbstractCursorPaginator|\Illuminate\Pagination\CursorPaginator ? \Spatie\LaravelData\CursorPaginatedDataCollection<array-key, static> : ($items is \Illuminate\Pagination\Paginator|\Illuminate\Pagination\AbstractPaginator ? \Spatie\LaravelData\PaginatedDataCollection<array-key, static> : \Spatie\LaravelData\DataCollection<array-key, static>))
      */
     public static function collection(Enumerable|array|AbstractPaginator|Paginator|AbstractCursorPaginator|CursorPaginator|DataCollection $items): DataCollection|CursorPaginatedDataCollection|PaginatedDataCollection;
 

--- a/types/Collection.php
+++ b/types/Collection.php
@@ -2,10 +2,6 @@
 
 /** @noinspection PhpExpressionResultUnusedInspection */
 
-use Illuminate\Pagination\CursorPaginator;
-use Illuminate\Pagination\LengthAwarePaginator;
-use Illuminate\Support\Collection;
-
 use function PHPStan\Testing\assertType;
 
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
@@ -17,25 +13,14 @@ $collection = SimpleData::collection(collect(['A', 'B']));
 assertType('Spatie\LaravelData\DataCollection<(int|string), Spatie\LaravelData\Tests\Fakes\SimpleData>', $collection);
 
 // PaginatedDataCollection
-$items = Collection::times(100, fn (int $index) => "Item {$index}");
-
-$paginator = new LengthAwarePaginator(
-    $items->forPage(1, 15),
-    100,
-    15
-);
+$paginator = \Illuminate\Database\Eloquent\Model::query()->paginate();
 
 $collection = SimpleData::collection($paginator);
 
 assertType('Spatie\LaravelData\PaginatedDataCollection<(int|string), Spatie\LaravelData\Tests\Fakes\SimpleData>', $collection);
 
 // CursorPaginatedDataCollection
-$items = Collection::times(100, fn (int $index) => "Item {$index}");
-
-$paginator = new CursorPaginator(
-    $items,
-    15,
-);
+$paginator = \Illuminate\Database\Eloquent\Model::query()->cursorPaginate();
 
 $collection = SimpleData::collection($paginator);
 

--- a/types/Collection.php
+++ b/types/Collection.php
@@ -6,20 +6,15 @@ use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 
-use Spatie\LaravelData\CursorPaginatedDataCollection;
-use function PHPStan\dumpType;
 use function PHPStan\Testing\assertType;
 
-use Spatie\LaravelData\DataCollection;
-use Spatie\LaravelData\PaginatedDataCollection;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
 
 // Regular collections
 $collection = SimpleData::collection(['A', 'B']);
-assertType(DataCollection::class, $collection);
+assertType('Spatie\LaravelData\DataCollection<(int|string), Spatie\LaravelData\Tests\Fakes\SimpleData>', $collection);
 $collection = SimpleData::collection(collect(['A', 'B']));
-assertType(DataCollection::class, $collection);
-
+assertType('Spatie\LaravelData\DataCollection<(int|string), Spatie\LaravelData\Tests\Fakes\SimpleData>', $collection);
 
 // PaginatedDataCollection
 $items = Collection::times(100, fn (int $index) => "Item {$index}");
@@ -32,7 +27,7 @@ $paginator = new LengthAwarePaginator(
 
 $collection = SimpleData::collection($paginator);
 
-assertType(PaginatedDataCollection::class, $collection);
+assertType('Spatie\LaravelData\PaginatedDataCollection<(int|string), Spatie\LaravelData\Tests\Fakes\SimpleData>', $collection);
 
 // CursorPaginatedDataCollection
 $items = Collection::times(100, fn (int $index) => "Item {$index}");
@@ -44,4 +39,4 @@ $paginator = new CursorPaginator(
 
 $collection = SimpleData::collection($paginator);
 
-assertType(CursorPaginatedDataCollection::class, $collection);
+assertType('Spatie\LaravelData\CursorPaginatedDataCollection<(int|string), Spatie\LaravelData\Tests\Fakes\SimpleData>', $collection);


### PR DESCRIPTION
As shown in the `types/Collection.php` tests, this PR ensures that the return types of `Data::collection` use generics.

Before, `SimpleData::collection($items)` would return a plain `DataCollection`.
Now, it returns `DataCollection<array-key, SimpleData>`.

Building upon #184, and makes sure that the correct generic types are returned when passing paginators.

```php
$users = User::paginate();
$collection = UserData::collection($users); // PaginatedDataCollection<array-key, UserData>

$users = User::cursorPaginate();
$collection = UserData::collection($users); // CursorPaginatedDataCollection<array-key, UserData>
```

This allows you to make stricter assertions in your project.