### PR TITLE
Improve pattern matching in DataCollectionAnnotationReader

### DIFF
--- a/src/Support/DataCollectionAnnotationReader.php
+++ b/src/Support/DataCollectionAnnotationReader.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelData\Support;
 
+use Illuminate\Support\Str;
 use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\Types\ContextFactory;
 use ReflectionProperty;
@@ -18,13 +19,13 @@ class DataCollectionAnnotationReader
             return null;
         }
 
-        preg_match(
-            '/\??(?<array>[\\\\A-Za-z0-9]*)\[\]|([\\\\A-Za-z0-9?]*)<(?<collection>[\\\\A-Za-z0-9]*)>/',
-            $comment,
-            $matches,
-        );
+        $fqsenPattern = '[\\\\a-z0-9_]+';
+        $keyPattern = 'int|string|\(int\|string\)|array-key';
 
-        $class = $matches['collection'] ?? $matches['array'] ?? null;
+        $array = fn () => Str::of($comment)->match("/{$fqsenPattern}\[\]/i")->toString();
+        $collection = fn () => Str::of($comment)->match("/{$fqsenPattern}<(?:{$keyPattern},\s*)({$fqsenPattern})>/i")->toString();
+
+        $class = $collection() ?: $array() ?: null;
 
         if ($class === null) {
             return null;

--- a/tests/Support/DataTypeTest.php
+++ b/tests/Support/DataTypeTest.php
@@ -271,6 +271,25 @@ class DataTypeTest extends TestCase
     }
 
     /** @test */
+    public function it_can_deduce_a_data_collection_from_annotation()
+    {
+        $type = $this->resolveDataType(new class () {
+            /** @var DataCollection<array-key, \Spatie\LaravelData\Tests\Fakes\SimpleData> */
+            public DataCollection $property;
+        });
+
+        $this->assertFalse($type->isNullable);
+        $this->assertFalse($type->isMixed);
+        $this->assertFalse($type->isLazy);
+        $this->assertFalse($type->isOptional);
+        $this->assertFalse($type->isDataObject);
+        $this->assertTrue($type->isDataCollectable);
+        $this->assertEquals(DataCollectableType::Default, $type->dataCollectableType);
+        $this->assertEquals(SimpleData::class, $type->dataClass);
+        $this->assertEquals([DataCollection::class], array_keys($type->acceptedTypes));
+    }
+
+    /** @test */
     public function it_can_deduce_a_data_collection_union_type()
     {
         $type = $this->resolveDataType(new class () {


### PR DESCRIPTION
This PR fixes the `DataCollectionAnnotationReader` where it doesn't work with `@var` annotations that use the correct `DataCollection<TKey, TValue>` format.

I've also made the pattern matching a bit more readable by extracting repeated patterns and splitting it in two separate match calls.