### PR TITLE
fix: first and last page url are never null

### DIFF
--- a/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
+++ b/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
@@ -120,10 +120,10 @@ class DataTypeScriptTransformer extends DtoTransformer
             ])),
             'meta' => new StructType([
                 'current_page' => new Integer(),
-                'first_page_url' => new Nullable(new String_()),
+                'first_page_url' => new String_(),
                 'from' => new Nullable(new Integer()),
                 'last_page' => new Integer(),
-                'last_page_url' => new Nullable(new String_()),
+                'last_page_url' => new String_(),
                 'next_page_url' => new Nullable(new String_()),
                 'path' => new String_(),
                 'per_page' => new Integer(),


### PR DESCRIPTION
The `first_page_url` is always `string` for the SimplePaginator (1) and LengthAwarePaginator (2). `last_page_url` doesn't exist on `SimplePaginator`, but does exist on `LengthAwarePaginator` and is always `int`.

1: https://github.com/laravel/framework/blob/9.x/src/Illuminate/Pagination/Paginator.php#L146
2: https://github.com/laravel/framework/blob/9.x/src/Illuminate/Pagination/LengthAwarePaginator.php#L197