### PR TITLE
Improved pattern matching in DataCollectionAnnotationReader

### DIFF
--- a/src/Support/DataCollectionAnnotationReader.php
+++ b/src/Support/DataCollectionAnnotationReader.php
@@ -22,8 +22,8 @@ class DataCollectionAnnotationReader
         $fqsenPattern = '[\\\\a-z0-9_]+';
         $keyPattern = '(?:int|string|\(int\|string\)|array-key)';
 
-        $array = fn () => Str::of($comment)->match("/({$fqsenPattern})\[\]/i")->toString();
-        $collection = fn () => Str::of($comment)->match("/{$fqsenPattern}<(?:{$keyPattern},\s*)?({$fqsenPattern})>/i")->toString();
+        $array = fn () => (string) Str::of($comment)->match("/({$fqsenPattern})\[\]/i");
+        $collection = fn () => (string) Str::of($comment)->match("/{$fqsenPattern}<(?:{$keyPattern},\s*)?({$fqsenPattern})>/i");
 
         $class = $collection() ?: $array() ?: null;
 

--- a/src/Support/DataCollectionAnnotationReader.php
+++ b/src/Support/DataCollectionAnnotationReader.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelData\Support;
 
+use Illuminate\Support\Str;
 use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\Types\ContextFactory;
 use ReflectionProperty;
@@ -18,13 +19,13 @@ class DataCollectionAnnotationReader
             return null;
         }
 
-        preg_match(
-            '/\??(?<array>[\\\\A-Za-z0-9]*)\[\]|([\\\\A-Za-z0-9?]*)<(?<collection>[\\\\A-Za-z0-9]*)>/',
-            $comment,
-            $matches,
-        );
+        $fqsenPattern = '[\\\\a-z0-9_]+';
+        $keyPattern = '(?:int|string|\(int\|string\)|array-key)';
 
-        $class = $matches['collection'] ?? $matches['array'] ?? null;
+        $array = fn () => Str::of($comment)->match("/({$fqsenPattern})\[\]/i")->toString();
+        $collection = fn () => Str::of($comment)->match("/{$fqsenPattern}<(?:{$keyPattern},\s*)?({$fqsenPattern})>/i")->toString();
+
+        $class = $collection() ?: $array() ?: null;
 
         if ($class === null) {
             return null;


### PR DESCRIPTION
Second attempt at #214.

It's now backwards compatible with the generic notation without `TKey`.
