### PR TITLE
improve getValidationRules to also retrieve wildcard rules

### DIFF
--- a/src/Concerns/ValidateableData.php
+++ b/src/Concerns/ValidateableData.php
@@ -5,6 +5,7 @@ namespace Spatie\LaravelData\Concerns;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
+use Spatie\LaravelData\Resolvers\DataClassValidationRulesResolver;
 use Spatie\LaravelData\Resolvers\DataValidatorResolver;
 
 /**
@@ -18,7 +19,7 @@ use Spatie\LaravelData\Resolvers\DataValidatorResolver;
  */
 trait ValidateableData
 {
-    public static function validate(Arrayable|array $payload): Arrayable|array
+    public static function validate(Arrayable | array $payload): Arrayable | array
     {
         $validator = app(DataValidatorResolver::class)->execute(static::class, $payload);
 
@@ -43,7 +44,7 @@ trait ValidateableData
         return $validator->validated();
     }
 
-    public static function validateAndCreate(Arrayable|array $payload): static
+    public static function validateAndCreate(Arrayable | array $payload): static
     {
         return static::from(static::validate($payload));
     }
@@ -57,7 +58,9 @@ trait ValidateableData
         array $fields = [],
         array $payload = []
     ): array {
-        $rules = app(DataValidatorResolver::class)->execute(static::class, $payload)->getRules();
+        $rules = app(DataClassValidationRulesResolver::class)
+            ->execute(static::class, $payload)
+            ->toArray();
 
         if (count($fields) === 0) {
             return $rules;

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -40,6 +40,7 @@ use Spatie\LaravelData\Support\PartialTrees;
 use Spatie\LaravelData\Support\TreeNodes\ExcludedTreeNode;
 use Spatie\LaravelData\Tests\Factories\DataBlueprintFactory;
 use Spatie\LaravelData\Tests\Factories\DataPropertyBlueprintFactory;
+use Spatie\LaravelData\Tests\Fakes\AttributeRulesWithStaticFunctionRulesData;
 use Spatie\LaravelData\Tests\Fakes\Casts\ConfidentialDataCast;
 use Spatie\LaravelData\Tests\Fakes\Casts\ConfidentialDataCollectionCast;
 use Spatie\LaravelData\Tests\Fakes\Casts\ContextAwareCast;
@@ -2410,5 +2411,15 @@ class DataTest extends TestCase
         $this->assertSame([
             'first' => ['string', 'required'],
         ], MultiData::getValidationRules(fields: ['first']));
+    }
+
+
+    /** @test */
+    public function it_can_add_wildcard_rules_for_arrays()
+    {
+        $this->assertEquals([
+            'emails' => ['array', 'min:1', 'max:5', 'required'],
+            'emails.*' => ['email'],
+        ], AttributeRulesWithStaticFunctionRulesData::getValidationRules());
     }
 }

--- a/tests/Fakes/AttributeRulesWithStaticFunctionRulesData.php
+++ b/tests/Fakes/AttributeRulesWithStaticFunctionRulesData.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Attributes\Validation\Max;
+use Spatie\LaravelData\Attributes\Validation\Min;
+use Spatie\LaravelData\Data;
+
+class AttributeRulesWithStaticFunctionRulesData extends Data
+{
+    public function __construct(
+        #[Min(1)]
+        #[Max(5)]
+        public readonly array $emails,
+    ) {
+    }
+
+    public static function rules(): array
+    {
+        return [
+            'emails.*' => ['email'],
+        ];
+    }
+}


### PR DESCRIPTION
Previously wildcard rules such as `myarray.*` or `myarray.*.id` were discarded when retrieving the rules, this has been addressed so that all defined rules are not retrieved. 
