### PR TITLE
accept 'float' as data type

### DIFF
--- a/src/Support/DataType.php
+++ b/src/Support/DataType.php
@@ -168,6 +168,7 @@ class DataType implements Countable
         $type = match ($type) {
             'integer' => 'int',
             'boolean' => 'bool',
+            'double' => 'float',
             'object' => $value::class,
             default => $type,
         };


### PR DESCRIPTION
If you use custom creation method with *float* argument, it never gets called, because *gettype* returns 'double' for *float*  (see [official PHP docs](https://www.php.net/manual/en/function.gettype.php))