### PR TITLE
Fix typo in mime type validation rule

### DIFF
--- a/src/Attributes/Validation/MimeTypes.php
+++ b/src/Attributes/Validation/MimeTypes.php
@@ -17,7 +17,7 @@ class MimeTypes extends StringValidationAttribute
 
     public static function keyword(): string
     {
-        return 'mimestypes';
+        return 'mimetypes';
     }
 
     public function parameters(): array

--- a/tests/Attributes/Validation/RulesTest.php
+++ b/tests/Attributes/Validation/RulesTest.php
@@ -714,17 +714,17 @@ class RulesTest extends TestCase
     {
         yield $this->fixature(
             attribute: new MimeTypes('video/quicktime'),
-            expected: 'mimestypes:video/quicktime',
+            expected: 'mimetypes:video/quicktime',
         );
 
         yield $this->fixature(
             attribute: new MimeTypes(['video/quicktime', 'video/avi']),
-            expected: 'mimestypes:video/quicktime,video/avi',
+            expected: 'mimetypes:video/quicktime,video/avi',
         );
 
         yield $this->fixature(
             attribute: new MimeTypes('video/quicktime', 'video/avi'),
-            expected: 'mimestypes:video/quicktime,video/avi',
+            expected: 'mimetypes:video/quicktime,video/avi',
         );
     }
 


### PR DESCRIPTION
Currently you get `BadMethodCallException: Method Illuminate\Validation\Validator::validateMimestypes does not exist.` when using the MimeTypes validation attribute since the method is called validateMimetypes without the additional "s". 

This PR fixes the typo