### PR TITLE
Add ability to modify properties before the data pipeline

### DIFF
--- a/docs/as-a-data-transfer-object/creating-a-data-object.md
+++ b/docs/as-a-data-transfer-object/creating-a-data-object.md
@@ -227,6 +227,51 @@ This list can be extended using extra normalizers, find more about it [here](htt
 When a data object cannot be created using magical methods or the default methods, a `CannotCreateDataFromValue`
 exception will be thrown.
 
+## Preparing Data
+
+Sometimes you may need to handle situations where the *structure* of the data needs to be normalized. 
+
+In these cases, you may use the static `prepareForPipeline` method on your data object. This method allows you to modify your properties after the payload has been normalized, but before they are sent into the data pipeline (i.e.: before being casted, mapped, and so forth).
+
+A typical example would be breaking a flat structure (such as an imported csv) into a nested structure:
+
+```php
+class SongMetadata
+{
+    public function __construct(
+        public string $releaseYear,
+        public string $producer,
+    ) {}
+}
+
+class Song extends Data
+{
+    public function __construct(
+        public string $title,
+        public SongMetadata $metadata,
+    ) {}
+    
+    public static function prepareForPipeline(Collection $properties) : Collection
+    {
+        $properties->put('metadata', $properties->only(['release_year', 'producer']));
+        
+        return $properties;
+    }
+}
+```
+
+This flat incoming data will be converted into the nested structure we just codified:
+
+```php
+$song = Song::from([
+    'title' => 'Never gonna give you up',
+    'release_year' => '1987',
+    'producer' => 'Stock Aitken Waterman',
+]);
+
+$song->toArray(); // ['title' => '...', 'songMetadata' => ['release_year' => '...', 'producer' => '...']]
+```
+
 ## Optional creation
 
 It is impossible to return `null` from a data object's `from` method since we always expect a data object when

--- a/src/Concerns/DataTrait.php
+++ b/src/Concerns/DataTrait.php
@@ -7,6 +7,7 @@ trait DataTrait
     use ResponsableData;
     use IncludeableData;
     use AppendableData;
+    use PrepareableData;
     use ValidateableData;
     use WrappableData;
     use TransformableData;

--- a/src/Concerns/PrepareableData.php
+++ b/src/Concerns/PrepareableData.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\LaravelData\Concerns;
+
+use Illuminate\Support\Collection;
+
+trait PrepareableData
+{
+    public static function prepareForPipeline(Collection $properties): Collection
+    {
+        return $properties;
+    }
+}

--- a/src/Contracts/DataObject.php
+++ b/src/Contracts/DataObject.php
@@ -4,6 +4,6 @@ namespace Spatie\LaravelData\Contracts;
 
 use Illuminate\Contracts\Support\Responsable;
 
-interface DataObject extends Responsable, AppendableData, BaseData, TransformableData, IncludeableData, ResponsableData, ValidateableData, WrappableData
+interface DataObject extends Responsable, AppendableData, BaseData, TransformableData, IncludeableData, ResponsableData, ValidateableData, WrappableData, PrepareableData
 {
 }

--- a/src/Contracts/PrepareableData.php
+++ b/src/Contracts/PrepareableData.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\LaravelData\Contracts;
+
+interface PrepareableData
+{
+    public static function prepareForPipeline(\Illuminate\Support\Collection $properties): \Illuminate\Support\Collection;
+}

--- a/src/DataPipeline.php
+++ b/src/DataPipeline.php
@@ -87,6 +87,8 @@ class DataPipeline
 
         $class = $this->dataConfig->getDataClass($this->classString);
 
+        $properties = ($class->name)::prepareForPipeline($properties);
+
         foreach ($pipes as $pipe) {
             $piped = $pipe->handle($this->value, $class, $properties);
 

--- a/tests/Support/DataTypeTest.php
+++ b/tests/Support/DataTypeTest.php
@@ -19,6 +19,7 @@ use Spatie\LaravelData\Contracts\AppendableData;
 use Spatie\LaravelData\Contracts\BaseData;
 use Spatie\LaravelData\Contracts\DataObject;
 use Spatie\LaravelData\Contracts\IncludeableData;
+use Spatie\LaravelData\Contracts\PrepareableData;
 use Spatie\LaravelData\Contracts\ResponsableData;
 use Spatie\LaravelData\Contracts\TransformableData;
 use Spatie\LaravelData\Contracts\ValidateableData;
@@ -458,6 +459,7 @@ class DataTypeTest extends TestCase
                     Arrayable::class,
                     DataObject::class,
                     AppendableData::class,
+                    PrepareableData::class,
                     BaseData::class,
                     IncludeableData::class,
                     ResponsableData::class,


### PR DESCRIPTION
Adds the ability for package users to inject logic into the process of their data object being created. More specifically, between normalization and the data pipeline.

The motivation for this is so that users may normalize the structure of their data. 

Personally, we've had situations where data coming in from an API has a different structure than data coming in from a csv import, but they both need to be massaged into the same DTO. 

This PR enables a natural way to do that *without having to override the magic creation methods*, which breaks all of the wonderful data pipeline functionality (mapping, casting, etc.) that makes this package so useful.