### PR TITLE
Add support for withoutTrashed to exists validation attribute

### DIFF
--- a/docs/advanced-usage/validation-attributes.md
+++ b/docs/advanced-usage/validation-attributes.md
@@ -381,6 +381,9 @@ public string $value;
 
 #[Exists('users', 'email', connection: 'tenant')]
 public string $value;
+
+#[Exists('users', 'email', withoutTrashed: true)]
+public string $value;
 ```
 
 ### File

--- a/src/Attributes/Validation/Exists.php
+++ b/src/Attributes/Validation/Exists.php
@@ -16,6 +16,8 @@ class Exists extends ValidationAttribute
         ?string $table = null,
         ?string $column = 'NULL',
         ?string $connection = null,
+        bool $withoutTrashed = false,
+        string $deletedAtColumn = 'deleted_at',
         ?Closure $where = null,
         ?BaseExists $rule = null,
     ) {
@@ -27,6 +29,10 @@ class Exists extends ValidationAttribute
             $connection ? "{$connection}.{$table}" : $table,
             $column
         );
+
+        if ($withoutTrashed) {
+            $rule->withoutTrashed($deletedAtColumn);
+        }
 
         if ($where) {
             $rule->where($where);

--- a/tests/Attributes/Validation/RulesTest.php
+++ b/tests/Attributes/Validation/RulesTest.php
@@ -680,6 +680,18 @@ class RulesTest extends TestCase
             expectCreatedAttribute: new Exists(rule: new BaseExists('tenant.users', 'email'))
         );
 
+        yield $this->fixature(
+            attribute: new Exists('users', 'email', withoutTrashed: true),
+            expected: (new BaseExists('users', 'email'))->withoutTrashed(),
+            expectCreatedAttribute: new Exists(rule: (new BaseExists('users', 'email'))->withoutTrashed())
+        );
+
+        yield $this->fixature(
+            attribute: new Exists('users', 'email', withoutTrashed: true, deletedAtColumn: 'deleted_when'),
+            expected: (new BaseExists('users', 'email'))->withoutTrashed('deleted_when'),
+            expectCreatedAttribute: new Exists(rule: (new BaseExists('users', 'email'))->withoutTrashed('deleted_when'))
+        );
+
         $closure = fn (Builder $builder) => $builder;
 
         yield $this->fixature(


### PR DESCRIPTION
This adds support for `withoutTrashed` to the `Exists` rule to bring it into line with the `Unique` rule.