### PR TITLE
Always allow authorize to run

### DIFF
--- a/src/DataPipes/AuthorizedDataPipe.php
+++ b/src/DataPipes/AuthorizedDataPipe.php
@@ -3,7 +3,6 @@
 namespace Spatie\LaravelData\DataPipes;
 
 use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Spatie\LaravelData\Support\DataClass;
 
@@ -11,10 +10,6 @@ class AuthorizedDataPipe implements DataPipe
 {
     public function handle(mixed $payload, DataClass $class, Collection $properties): Collection
     {
-        if (! $payload instanceof Request) {
-            return $properties;
-        }
-
         $this->ensureRequestIsAuthorized($class->name);
 
         return $properties;


### PR DESCRIPTION
We are using Livewire, which doesn't use Request. It would be nice if the `authorize()` handle could always run, even when not using a request. :)

Other workarounds:
- Add `->through(CustomAuthorizedDataPipe::class)` to `pipeline()`
- Convert to request first, however this isn't really friendly as we're losing the types(?)

Think this is the easiest option. Let me know!

Thanks.