### PR TITLE
Cast date times with a timezone

### DIFF
--- a/docs/advanced-usage/working-with-dates.md
+++ b/docs/advanced-usage/working-with-dates.md
@@ -56,6 +56,15 @@ Now when casting a date, a valid format will be searched. When none can be found
 
 When a transformers hasn't explicitly stated it's format, the first format within the array is used.
 
+## Casting dates in a different time zone
+
+Sometimes a date can be in a different timezone than the timezone you application uses. For example, if you application uses `Europe/Brussels` but your date is in `UTC`:
+
+```php
+#[WithCast(DateTimeInterfaceCast::class, timeZone: 'UTC')]
+public DateTime $date
+```
+
 ## Changing time zones
 
 When casting a date you may want to set an alternative timezone this can be achieved as such:

--- a/src/Casts/DateTimeInterfaceCast.php
+++ b/src/Casts/DateTimeInterfaceCast.php
@@ -12,7 +12,8 @@ class DateTimeInterfaceCast implements Cast
     public function __construct(
         protected null|string|array $format = null,
         protected ?string $type = null,
-        protected ?string $setTimeZone = null
+        protected ?string $setTimeZone = null,
+        protected ?string $timeZone = null
     ) {
     }
 
@@ -28,7 +29,11 @@ class DateTimeInterfaceCast implements Cast
 
         /** @var DateTimeInterface|null $datetime */
         $datetime = $formats
-            ->map(fn (string $format) => rescue(fn () => $type::createFromFormat($format, $value), report: false))
+            ->map(fn (string $format) => rescue(fn () => $type::createFromFormat(
+                $format,
+                $value,
+                isset($this->timeZone) ? new DateTimeZone($this->timeZone) : null
+            ), report: false))
             ->first(fn ($value) => (bool) $value);
 
         if (! $datetime) {

--- a/tests/Casts/DateTimeInterfaceCastTest.php
+++ b/tests/Casts/DateTimeInterfaceCastTest.php
@@ -98,35 +98,81 @@ it('can set an alternative timezone', function () {
         public DateTimeImmutable $dateTimeImmutable;
     };
 
-    expect(
-        $caster->cast(
-            DataProperty::create(new ReflectionProperty($class, 'carbon')),
-            '19-05-1994 00:00:00',
-            []
-        )->getTimezone()
-    )->toEqual(CarbonTimeZone::create('Europe/Brussels'));
+    expect($caster->cast(
+        DataProperty::create(new ReflectionProperty($class, 'carbon')),
+        '19-05-1994 00:00:00',
+        []
+    ))
+    ->format('Y-m-d H:i:s')->toEqual('1994-05-19 02:00:00')
+    ->getTimezone()->toEqual(CarbonTimeZone::create('Europe/Brussels'));
 
-    expect(
-        $caster->cast(
-            DataProperty::create(new ReflectionProperty($class, 'carbonImmutable')),
-            '19-05-1994 00:00:00',
-            []
-        )->getTimezone()
-    )->toEqual(CarbonTimeZone::create('Europe/Brussels'));
+    expect($caster->cast(
+        DataProperty::create(new ReflectionProperty($class, 'carbonImmutable')),
+        '19-05-1994 00:00:00',
+        []
+    ))
+    ->format('Y-m-d H:i:s')->toEqual('1994-05-19 02:00:00')
+    ->getTimezone()->toEqual(CarbonTimeZone::create('Europe/Brussels'));
 
-    expect(
-        $caster->cast(
-            DataProperty::create(new ReflectionProperty($class, 'dateTime')),
-            '19-05-1994 00:00:00',
-            []
-        )->getTimezone()
-    )->toEqual(new DateTimeZone('Europe/Brussels'));
+    expect($caster->cast(
+        DataProperty::create(new ReflectionProperty($class, 'dateTime')),
+        '19-05-1994 00:00:00',
+        []
+    ))
+    ->format('Y-m-d H:i:s')->toEqual('1994-05-19 02:00:00')
+    ->getTimezone()->toEqual(new DateTimeZone('Europe/Brussels'));
 
-    expect(
-        $caster->cast(
-            DataProperty::create(new ReflectionProperty($class, 'dateTimeImmutable')),
-            '19-05-1994 00:00:00',
-            []
-        )->getTimezone()
-    )->toEqual(new DateTimeZone('Europe/Brussels'));
+    expect($caster->cast(
+        DataProperty::create(new ReflectionProperty($class, 'dateTimeImmutable')),
+        '19-05-1994 00:00:00',
+        []
+    ))
+    ->format('Y-m-d H:i:s')->toEqual('1994-05-19 02:00:00')
+    ->getTimezone()->toEqual(new DateTimeZone('Europe/Brussels'));
+});
+
+it('can cast date times with a timezone', function () {
+    $caster = new DateTimeInterfaceCast('d-m-Y H:i:s', timeZone: 'Europe/Brussels');
+
+    $class = new class () {
+        public Carbon $carbon;
+
+        public CarbonImmutable $carbonImmutable;
+
+        public DateTime $dateTime;
+
+        public DateTimeImmutable $dateTimeImmutable;
+    };
+
+    expect($caster->cast(
+        DataProperty::create(new ReflectionProperty($class, 'carbon')),
+        '19-05-1994 00:00:00',
+        []
+    ))
+    ->format('Y-m-d H:i:s')->toEqual('1994-05-19 00:00:00')
+    ->getTimezone()->toEqual(CarbonTimeZone::create('Europe/Brussels'));
+
+    expect($caster->cast(
+        DataProperty::create(new ReflectionProperty($class, 'carbonImmutable')),
+        '19-05-1994 00:00:00',
+        []
+    ))
+    ->format('Y-m-d H:i:s')->toEqual('1994-05-19 00:00:00')
+    ->getTimezone()->toEqual(CarbonTimeZone::create('Europe/Brussels'));
+
+    expect($caster->cast(
+        DataProperty::create(new ReflectionProperty($class, 'dateTime')),
+        '19-05-1994 00:00:00',
+        []
+    ))
+    ->format('Y-m-d H:i:s')->toEqual('1994-05-19 00:00:00')
+    ->getTimezone()->toEqual(new DateTimeZone('Europe/Brussels'));
+
+    expect($caster->cast(
+        DataProperty::create(new ReflectionProperty($class, 'dateTimeImmutable')),
+        '19-05-1994 00:00:00',
+        []
+    ))
+    ->format('Y-m-d H:i:s')->toEqual('1994-05-19 00:00:00')
+    ->getTimezone()->toEqual(new DateTimeZone('Europe/Brussels'));
 });


### PR DESCRIPTION
I have a use case that's different than #200.
My laravel application is using the `Europe/Athens` timezone (in the `app.timezone` config), but i'm consuming data from an API that has dates in `UTC`.

By default, `1994-05-16 00:00:00` would be cast as `1994-05-16 00:00:00 Europe/Athens (+03:00)`, which is wrong:

```php
#[WithCast(DateTimeInterfaceCast::class)]
public Carbon $date
```

If I use the `setTimeZone` parameter, it would be cast as `1994-05-15 21:00:00 UTC (+00:00)` which is also wrong.

```php
#[WithCast(DateTimeInterfaceCast::class, setTimeZone: 'UTC')]
public Carbon $date
```

The correct way to handle this is to instantiate the date time object with the appropriate timezone in order to be cast as `1994-05-16 00:00:00 UTC (+00:00)`, which is what this PR addresses, by introducing the `timeZone` parameter:

```php
#[WithCast(DateTimeInterfaceCast::class, timeZone: 'UTC')]
public Carbon $date
```

This allows also to convert the `UTC` date time to `Europe/Athens`:

```php
#[WithCast(DateTimeInterfaceCast::class, timeZone: 'UTC', setTimeZone: 'Europe/Athens')]
public Carbon $date
```
