### PR TITLE
Introduce support to return 201 status code in Json Responses

### DIFF
--- a/config/data.php
+++ b/config/data.php
@@ -67,4 +67,10 @@ return [
      * which will only enable the caster locally.
      */
     'var_dumper_caster_mode' => 'development',
+
+    /**
+     * When enabled, Laravel Data will return a JsonResponse with status 201 in stead of the
+     * default status code 200 when the toResponse() method is called in a request with method 'post'
+     */
+    'json_response_201_on_post_requests' => false
 ];

--- a/config/data.php
+++ b/config/data.php
@@ -68,9 +68,4 @@ return [
      */
     'var_dumper_caster_mode' => 'development',
 
-    /**
-     * When enabled, Laravel Data will return a JsonResponse with status 201 in stead of the
-     * default status code 200 when the toResponse() method is called in a request with method 'post'
-     */
-    'json_response_201_on_post_requests' => false
 ];

--- a/docs/as-a-resource/from-data-to-resource.md
+++ b/docs/as-a-resource/from-data-to-resource.md
@@ -405,14 +405,7 @@ Now each transformed data object contains an `endpoints` key with all the endpoi
     }
 }
 ```
- ## Modifying the JSON Response status code
+ ## Response status code
 
-By default, Laravel Data will return a `200 OK` status code.
-When refactoring an existing implementation using Eloquent's API resources, you may however be used to your controllers returning a `201 CREATED` status code when you created a new model.
+When a resource is being returned from a controller, the status code of the response will automatically be set to `201 CREATED` when Laravel data detectes that the request's method is `POST`.  In all other cases, `200 OK` will be returned.
 
-Laravel determines whether it needs to return a `201 CREATED` in stead of the `200 OK` response code based on the Model's method `wasRecentlyCreated`.  Since Data objects do not have access to the model it was created for, we can not perform the same check in Laravel Data.
-However, you can instruct Laravel Data to always create a JSON Reponse with status code `201 CREATED` when it detects that the request's method is `POST` using the following setting in your `data.pho` config file:
-
-```php
-    'json_response_201_on_post_requests' => false
-```

--- a/docs/as-a-resource/from-data-to-resource.md
+++ b/docs/as-a-resource/from-data-to-resource.md
@@ -24,8 +24,6 @@ The JSON then will look like this:
 }
 ```
 
-
-
 You can manually transform a data object to JSON:
 
 ```php

--- a/docs/as-a-resource/from-data-to-resource.md
+++ b/docs/as-a-resource/from-data-to-resource.md
@@ -24,6 +24,8 @@ The JSON then will look like this:
 }
 ```
 
+
+
 You can manually transform a data object to JSON:
 
 ```php
@@ -404,4 +406,15 @@ Now each transformed data object contains an `endpoints` key with all the endpoi
         "delete":  "https://spatie.be/songs/1"
     }
 }
+```
+ ## Modifying the JSON Response status code
+
+By default, Laravel Data will return a `200 OK` status code.
+When refactoring an existing implementation using Eloquent's API resources, you may however be used to your controllers returning a `201 CREATED` status code when you created a new model.
+
+Laravel determines whether it needs to return a `201 CREATED` in stead of the `200 OK` response code based on the Model's method `wasRecentlyCreated`.  Since Data objects do not have access to the model it was created for, we can not perform the same check in Laravel Data.
+However, you can instruct Laravel Data to always create a JSON Reponse with status code `201 CREATED` when it detects that the request's method is `POST` using the following setting in your `data.pho` config file:
+
+```php
+    'json_response_201_on_post_requests' => false
 ```

--- a/src/Concerns/ResponsableData.php
+++ b/src/Concerns/ResponsableData.php
@@ -3,6 +3,8 @@
 namespace Spatie\LaravelData\Concerns;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Spatie\LaravelData\Contracts\IncludeableData as IncludeableDataContract;
 use Spatie\LaravelData\Resolvers\PartialsTreeFromRequestResolver;
 use Spatie\LaravelData\Support\Wrapping\WrapExecutionType;
@@ -22,9 +24,17 @@ trait ResponsableData
             $this->withPartialTrees($partialTrees);
         }
 
-        return new JsonResponse($this->transform(
-            wrapExecutionType: WrapExecutionType::Enabled,
-        ));
+        return new JsonResponse(
+            data: $this->transform(
+                wrapExecutionType: WrapExecutionType::Enabled,
+            ),
+            status: $this->calculateResponseStatus($request)
+        );
+    }
+
+    protected function calculateResponseStatus(Request $request): int {
+        return $request->isMethod('POST') &&
+               config('data.json_response_201_on_post_requests') ? Response::HTTP_CREATED : Response::HTTP_OK;
     }
 
     public static function allowedRequestIncludes(): ?array
@@ -46,4 +56,6 @@ trait ResponsableData
     {
         return [];
     }
+
+
 }

--- a/src/Concerns/ResponsableData.php
+++ b/src/Concerns/ResponsableData.php
@@ -33,8 +33,7 @@ trait ResponsableData
     }
 
     protected function calculateResponseStatus(Request $request): int {
-        return $request->isMethod('POST') &&
-               config('data.json_response_201_on_post_requests') ? Response::HTTP_CREATED : Response::HTTP_OK;
+        return $request->isMethod(Request::METHOD_POST) ? Response::HTTP_CREATED : Response::HTTP_OK;
     }
 
     public static function allowedRequestIncludes(): ?array

--- a/tests/RequestDataTest.php
+++ b/tests/RequestDataTest.php
@@ -50,22 +50,15 @@ it('can pass validation', function () {
         ->assertJson(['given' => 'Hello']);
 });
 
-it('can return 201 response on a post request when globally enabled', function() {
+it('can returns a 201 response code for POST requests', function() {
     Route::post('/example-route', function () {
         return new SimpleData(request()->input('string'));
     });
-
-    Config::set('data.json_response_201_on_post_requests', true);
 
     performRequest('Hello')
         ->assertCreated()
         ->assertJson(['string' => 'Hello']);
 
-    Config::set('data.json_response_201_on_post_requests', false);
-
-    performRequest('Hello')
-        ->assertOk()
-        ->assertJson(['string' => 'Hello']);
 });
 
 it('can fail validation', function () {

--- a/tests/RequestDataTest.php
+++ b/tests/RequestDataTest.php
@@ -8,6 +8,7 @@ use Illuminate\Testing\TestResponse;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
+use Illuminate\Support\Facades\Config;
 
 use function Pest\Laravel\handleExceptions;
 use function Pest\Laravel\postJson;
@@ -20,6 +21,7 @@ use Spatie\LaravelData\Tests\Factories\DataMagicMethodFactory;
 use Spatie\LaravelData\Tests\Factories\DataPropertyBlueprintFactory;
 use Spatie\LaravelData\Tests\Fakes\RequestData;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
+use function PHPUnit\Framework\assertEquals;
 
 function performRequest(string $string): TestResponse
 {
@@ -46,6 +48,24 @@ it('can pass validation', function () {
     performRequest('Hello')
         ->assertOk()
         ->assertJson(['given' => 'Hello']);
+});
+
+it('can return 201 response on a post request when globally enabled', function() {
+    Route::post('/example-route', function () {
+        return new SimpleData(request()->input('string'));
+    });
+
+    Config::set('data.json_response_201_on_post_requests', true);
+
+    performRequest('Hello')
+        ->assertCreated()
+        ->assertJson(['string' => 'Hello']);
+
+    Config::set('data.json_response_201_on_post_requests', false);
+
+    performRequest('Hello')
+        ->assertOk()
+        ->assertJson(['string' => 'Hello']);
 });
 
 it('can fail validation', function () {

--- a/tests/RequestDataTest.php
+++ b/tests/RequestDataTest.php
@@ -307,7 +307,7 @@ it('can wrap data', function () {
     });
 
     performRequest('Hello World')
-        ->assertOk()
+        ->assertCreated()
         ->assertJson(['data' => ['string' => 'Hello World']]);
 });
 
@@ -320,7 +320,7 @@ it('can wrap data collections', function () {
     });
 
     performRequest('Hello World')
-        ->assertOk()
+        ->assertCreated()
         ->assertJson([
             'data' => [
                 ['string' => 'Hello World'],

--- a/tests/Resolvers/DataFromSomethingResolverTest.php
+++ b/tests/Resolvers/DataFromSomethingResolverTest.php
@@ -261,7 +261,7 @@ it('will validate a request when given as a parameter to a custom creation metho
         'string' => 'Rick Astley',
     ])->assertJson([
         'string' => 'Rick Astley',
-    ])->assertOk();
+    ])->assertCreated();
 });
 
 it('can resolve payload dependency for rules', function () {


### PR DESCRIPTION
While refactoring our existing code from Laravel API resources to using Laravel Data, we noticed a lot of our tests were starting to fail, because we expect a `201 CREATED` response code when we are creating a new resource.

I checked the Laravel codebase, and they return a 201 when `$model->wasRecentlyCreated()` equals `true`.
Obviously, the same check can not be done in this package, but I believe it would make sense to test for the request method, and if it is a POST request, we can have return the Json response with a 201 status code, which is what I implemented in this PR.

Obviously, in order to ensure backwards compatibility, I disabled this by default by adding a new config parameter that is y default set to false, but can be enabled in the config file, so this can be release as a minor and not a major.