### PR TITLE
Allow sole method to be used on data collections without operator

### DIFF
--- a/src/Concerns/EnumerableMethods.php
+++ b/src/Concerns/EnumerableMethods.php
@@ -123,6 +123,6 @@ trait EnumerableMethods
      */
     public function sole(callable|string|null $key = null, mixed $operator = null, mixed $value = null)
     {
-        return $this->items->sole($key, $operator, $value);
+        return $this->items->sole(...func_get_args());
     }
 }

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -459,3 +459,21 @@ it(
             ->toEqual($expected);
     }
 )->with('collection-operations');
+
+it('can return a sole data object', function () {
+    $collection = SimpleData::collection(['A', 'B']);
+
+    $filtered = $collection->sole('string', '=', 'A');
+
+    expect('A')
+        ->toEqual($filtered->string);
+});
+
+it('can return a sole data object without specifying an operator', function () {
+    $collection = SimpleData::collection(['A', 'B']);
+
+    $filtered = $collection->sole('string', 'A');
+
+    expect('A')
+        ->toEqual($filtered->string);
+});


### PR DESCRIPTION
Laravel allows you to use `sole` without specifying an operator. It does this by checking the number of arguments.

This fixes an issue where the number of passed arguments was always 3.