### PR TITLE
Add a way to prepend DataPipes to the pipeline

### DIFF
--- a/src/DataPipeline.php
+++ b/src/DataPipeline.php
@@ -55,6 +55,13 @@ class DataPipeline
         return $this;
     }
 
+    public function firstThrough(string|DataPipe $pipe): static
+    {
+        array_unshift($this->pipes, $pipe);
+
+        return $this;
+    }
+
     public function execute(): Collection
     {
         /** @var \Spatie\LaravelData\Normalizers\Normalizer[] $normalizers */

--- a/tests/DataPipelineTest.php
+++ b/tests/DataPipelineTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Spatie\LaravelData\DataPipeline;
+use Spatie\LaravelData\DataPipes\AuthorizedDataPipe;
+use Spatie\LaravelData\DataPipes\CastPropertiesDataPipe;
+use Spatie\LaravelData\DataPipes\DefaultValuesDataPipe;
+
+it('can prepend a data pipe at the beginning of the pipeline', function () {
+    $pipeline = DataPipeline::create()
+        ->through(DefaultValuesDataPipe::class)
+        ->through(CastPropertiesDataPipe::class)
+        ->firstThrough(AuthorizedDataPipe::class);
+
+    $reflectionProperty = tap(
+        new ReflectionProperty(DataPipeline::class, 'pipes'),
+        static fn (ReflectionProperty $r) => $r->setAccessible(true),
+    );
+
+    $pipes = $reflectionProperty->getValue($pipeline);
+
+    expect($pipes)
+        ->toHaveCount(3)
+        ->toMatchArray([
+            AuthorizedDataPipe::class,
+            DefaultValuesDataPipe::class,
+            CastPropertiesDataPipe::class,
+        ]);
+});


### PR DESCRIPTION
This introduces the `firstThrough` method in the `DataPipeline` class.

It allows for adding a data pipe to the beginning of the pipeline. The use case of this would be if a user wants to run the properties through a datapipe before it runs through the default pipeline.

Without using this method the way to do this would be to copy the `pipeline` method from the parent `Data` class of a data object:

```php
 public static function pipeline(): DataPipeline
  {
      return DataPipeline::create()
          ->into(static::class)

          // New data pipe
          ->through(GuessCasingForKeyDataPipe::class) 

          // Default data pipes
          ->through(AuthorizedDataPipe::class)
          ->through(MapPropertiesDataPipe::class)
          ->through(ValidatePropertiesDataPipe::class)
          ->through(DefaultValuesDataPipe::class)
          ->through(CastPropertiesDataPipe::class);
  }
```

By using the added method we can simplify this procedure without affecting the default datapipes like so:

```php
 public static function pipeline(): DataPipeline
  {
      return parent::pipeline()->firstThrough(GuessCasingForKeyDataPipe::class);
  }
```