### PR TITLE
Fetch data and parent fields for ide completion

### DIFF
--- a/ide.json
+++ b/ide.json
@@ -5,7 +5,7 @@
             "complete": "classFields",
             "options": {
                 "fieldsFilter": {
-                    "fetch": "own",
+                    "fetch": "all",
                     "modifier": ["public"]
                 }
             },


### PR DESCRIPTION
IDE completion does not fetches parents fields for completion.

If we have 
```php
abstract class BaseSlot extends Data
{
    public function __construct(
        public CarbonImmutable $datetime,
        public ?int $project_activity_id,
    ) {
    }
}

class FinalSlot extends BaseSlot
{
    public function __construct(
        public ?bool $satisfied,
        CarbonImmutable $datetime,
        ?int $project_activity_id,
    ) {
        parent::__construct($datetime, $project_activity_id);
    }
}
```
completion provides only `satisfied` field : 
![image](https://user-images.githubusercontent.com/10199039/209219794-75927da3-5c3c-4dcf-a951-a2c9de496726.png)

After this update, inherited fields are also completed : 
![image](https://user-images.githubusercontent.com/10199039/209219975-2d34a3cd-c7fa-4b36-8092-b2a67e515110.png)

