### PR TITLE
Make eloquent collection cast respect collection

### DIFF
--- a/src/DataCollection.php
+++ b/src/DataCollection.php
@@ -143,6 +143,6 @@ class DataCollection implements DataCollectable, ArrayAccess
             throw CannotCastData::dataCollectionTypeRequired();
         }
 
-        return new DataCollectionEloquentCast(current($arguments));
+        return new DataCollectionEloquentCast(current($arguments), static::class);
     }
 }

--- a/src/Support/EloquentCasts/DataCollectionEloquentCast.php
+++ b/src/Support/EloquentCasts/DataCollectionEloquentCast.php
@@ -12,7 +12,8 @@ use Spatie\LaravelData\Exceptions\CannotCastData;
 class DataCollectionEloquentCast implements CastsAttributes
 {
     public function __construct(
-        protected string $dataClass
+        protected string $dataClass,
+        protected string $dataCollectionClass = DataCollection::class,
     ) {
     }
 
@@ -29,7 +30,7 @@ class DataCollectionEloquentCast implements CastsAttributes
             $data
         );
 
-        return new DataCollection($this->dataClass, $data);
+        return new ($this->dataCollectionClass)($this->dataClass, $data);
     }
 
     public function set($model, string $key, $value, array $attributes): ?string
@@ -53,7 +54,7 @@ class DataCollectionEloquentCast implements CastsAttributes
             $value
         );
 
-        $dataCollection = new DataCollection($this->dataClass, $data);
+        $dataCollection = new ($this->dataCollectionClass)($this->dataClass, $data);
 
         return $dataCollection->toJson();
     }

--- a/tests/Fakes/DummyModelWithCustomCollectionCasts.php
+++ b/tests/Fakes/DummyModelWithCustomCollectionCasts.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+class DummyModelWithCustomCollectionCasts extends DummyModelWithCasts
+{
+    protected $table = 'dummy_model_with_casts';
+
+    protected $casts = [
+        'data' => SimpleData::class,
+        'data_collection' => SimpleDataCollection::class.':'.SimpleData::class,
+    ];
+}

--- a/tests/Fakes/SimpleDataCollection.php
+++ b/tests/Fakes/SimpleDataCollection.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\DataCollection;
+
+class SimpleDataCollection extends DataCollection
+{
+    public function toJson($options = 0): string
+    {
+        return parent::toJson(JSON_PRETTY_PRINT);
+    }
+}

--- a/tests/Support/EloquentCasts/DataCollectionEloquentCastTest.php
+++ b/tests/Support/EloquentCasts/DataCollectionEloquentCastTest.php
@@ -5,7 +5,9 @@ use Illuminate\Support\Facades\DB;
 use function Pest\Laravel\assertDatabaseHas;
 
 use Spatie\LaravelData\Tests\Fakes\DummyModelWithCasts;
+use Spatie\LaravelData\Tests\Fakes\DummyModelWithCustomCollectionCasts;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
+use Spatie\LaravelData\Tests\Fakes\SimpleDataCollection;
 
 beforeEach(function () {
     DummyModelWithCasts::migrate();
@@ -79,4 +81,40 @@ it('can load null as a value', function () {
     $model = DummyModelWithCasts::first();
 
     expect($model->data_collection)->toBeNull();
+});
+
+it('can save a custom data collection', function () {
+    DummyModelWithCustomCollectionCasts::create([
+        'data_collection' => [
+            ['string' => 'Hello'],
+            ['string' => 'World'],
+        ],
+    ]);
+
+    assertDatabaseHas(DummyModelWithCustomCollectionCasts::class, [
+        'data_collection' => json_encode([
+            ['string' => 'Hello'],
+            ['string' => 'World'],
+        ], JSON_PRETTY_PRINT),
+    ]);
+});
+
+it('retrieves custom data collection', function () {
+    DB::table('dummy_model_with_casts')->insert([
+        'data_collection' => json_encode([
+            ['string' => 'Hello'],
+            ['string' => 'World'],
+        ]),
+    ]);
+
+    /** @var \Spatie\LaravelData\Tests\Fakes\DummyModelWithCustomCollectionCasts $model */
+    $model = DummyModelWithCustomCollectionCasts::first();
+
+    expect($model->data_collection)->toEqual(new SimpleDataCollection(
+        SimpleData::class,
+        [
+            new SimpleData('Hello'),
+            new SimpleData('World'),
+        ]
+    ));
 });


### PR DESCRIPTION
Having a `SlotLoadItem` beeing a `Data` and a `SlotLoadCollection` beeing a `DataCollection`, I would expect that defining

```php
protected $casts = [
        'slots' => SlotLoadCollection::class . ':' . SlotLoadItem::class,
];
```
gives me a `SlotLoadCollection` when fetching `$model->slots`. Currently, it gives me a `DataCollection`.

This PR fixes it.

I'm not sure if changing `DataCollectionEloquentCast` constructor signature is considered as a breaking change but IMHO it should not cause too much trouble.

