### PR TITLE
Handle custom regex validation rule

### DIFF
--- a/docs/as-a-data-transfer-object/request-to-data-object.md
+++ b/docs/as-a-data-transfer-object/request-to-data-object.md
@@ -109,6 +109,9 @@ class SongData extends Data
 }
 ```
 
+> When using the regex / not_regex patterns, it is necessary to specify rules in an array instead of using "|" delimiters,
+> especially if the regular expression contains a "|" character.
+
 It is even possible to use the validationAttribute objects within the `rules` method:
 
 ```php

--- a/src/Attributes/Validation/Rule.php
+++ b/src/Attributes/Validation/Rule.php
@@ -5,6 +5,7 @@ namespace Spatie\LaravelData\Attributes\Validation;
 use Attribute;
 use Illuminate\Contracts\Validation\InvokableRule as InvokableRuleContract;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
+use Illuminate\Support\Str;
 use Spatie\LaravelData\Support\Validation\ValidationRule;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
@@ -16,7 +17,7 @@ class Rule extends ValidationRule
     {
         foreach ($rules as $rule) {
             $newRules = match (true) {
-                is_string($rule) => explode('|', $rule),
+                is_string($rule) => Str::contains($rule, 'regex:') ? [$rule] : explode('|', $rule),
                 $rule instanceof RuleContract,
                 $rule instanceof InvokableRuleContract => [$rule],
                 is_array($rule) => $rule,

--- a/src/Resolvers/DataClassValidationRulesResolver.php
+++ b/src/Resolvers/DataClassValidationRulesResolver.php
@@ -91,7 +91,7 @@ class DataClassValidationRulesResolver
         return collect($overwrittenRules)
             ->map(
                 fn (mixed $rules) => collect(Arr::wrap($rules))
-                    ->map(fn (mixed $rule) => is_string($rule) ? explode('|', $rule) : $rule)
+                    ->map(fn (mixed $rule) => ! is_string($rule) || Str::contains($rule, 'regex:') ? $rule : explode('|', $rule))
                     ->map(fn (mixed $rule) => $rule instanceof ValidationRule ? $rule->getRules() : $rule)
                     ->flatten()
                     ->all()

--- a/src/Support/Validation/RulesMapper.php
+++ b/src/Support/Validation/RulesMapper.php
@@ -58,7 +58,7 @@ class RulesMapper
 
     protected function resolveStringRule(string $rule): mixed
     {
-        if (! str_contains($rule, '|')) {
+        if (str_contains($rule, 'regex:') || ! str_contains($rule, '|')) {
             try {
                 return $this->ruleFactory->create($rule);
             } catch (Throwable $t) {

--- a/tests/Attributes/Validation/RulesTest.php
+++ b/tests/Attributes/Validation/RulesTest.php
@@ -58,6 +58,7 @@ it('can use the Rule rule', function () {
         'test',
         ['a', 'b', 'c'],
         'x|y',
+        'regex:/test|ok/',
         $laravelRule,
         new Required()
     );
@@ -69,6 +70,7 @@ it('can use the Rule rule', function () {
         'c',
         'x',
         'y',
+        'regex:/test|ok/',
         $laravelRule,
         'required',
     ]);
@@ -91,6 +93,7 @@ it('can use the Rule rule with invokable rules', function () {
         'test',
         ['a', 'b', 'c'],
         'x|y',
+        'regex:/test|ok/',
         $invokableLaravelRule,
         new Required()
     );
@@ -102,6 +105,7 @@ it('can use the Rule rule with invokable rules', function () {
         'c',
         'x',
         'y',
+        'regex:/test|ok/',
         $invokableLaravelRule,
         'required',
     ]);

--- a/tests/Resolvers/DataClassValidationRulesResolverTest.php
+++ b/tests/Resolvers/DataClassValidationRulesResolverTest.php
@@ -185,3 +185,25 @@ it('will transform overwritten data rules into plain Laravel rules', function ()
         ],
     ]);
 });
+
+it('will keep custom regex rule unchanged', function () {
+    $data = new class () extends Data {
+        public string $name;
+        public string $out;
+
+        public static function rules(): array
+        {
+            return [
+                'name' => ['required', 'regex:/test|ok/'],
+                'out' => 'required|regex:/test|out/',
+            ];
+        }
+    };
+
+    expect(
+        $this->resolver->execute($data::class)->all()
+    )->toEqualCanonicalizing([
+        'name' => ['required', 'regex:/test|ok/'],
+        'out' => ['required|regex:/test|out/'],
+    ]);
+});

--- a/tests/Support/Validation/RulesMapperTest.php
+++ b/tests/Support/Validation/RulesMapperTest.php
@@ -5,6 +5,7 @@ use Illuminate\Validation\Rules\Exists as BaseExists;
 use Spatie\LaravelData\Attributes\Validation\Dimensions;
 use Spatie\LaravelData\Attributes\Validation\Exists;
 use Spatie\LaravelData\Attributes\Validation\Min;
+use Spatie\LaravelData\Attributes\Validation\Regex;
 use Spatie\LaravelData\Attributes\Validation\Required;
 use Spatie\LaravelData\Attributes\Validation\Rule;
 use Spatie\LaravelData\Support\Validation\RulesMapper;
@@ -24,6 +25,10 @@ it('can map string rules with arguments')
 it('can map string rules with key-value arguments')
     ->expect(fn () => $this->mapper->execute(['dimensions:min_width=100,min_height=200']))
     ->toEqual([new Dimensions(minWidth: 100, minHeight: 200)]);
+
+it('can map string rules with regex')
+    ->expect(fn () => $this->mapper->execute(['regex:/test|ok/']))
+    ->toEqual([new Regex('/test|ok/')]);
 
 it('can map multiple rules')
     ->expect(fn () => $this->mapper->execute(['required', 'min:0']))


### PR DESCRIPTION
When using custom validation rules with regex and "|" character, we end up with this error message : 
preg_match(): No ending delimiter '/' found

in this example, each rule will fail :
```
use App\Support\DataTransfertObjects\Data;

class TestData extends Data
{
    public function __constructor(
        public readonly string $name
        public readonly string $other
    ) {}

    public static function rules()
    {
        return [
            'name' => 'required|regex:/test|ok/',
            'other' => ['required', 'regex:/test|ok/']
        ];
    }
}
```
This PR add support for regex rule with "|" character.
But there is a constraint : users must provide custom rules as array.
This is ok :
```
[
     'name' => ['required', 'regex:/test|ok/']
]
```
but not this :
```
[
     'name' => 'required|regex:/test|ok/'
]
```
That's why i added a note in the documentation.
