### PR TITLE
Making methods available in extending class

### DIFF
--- a/src/Resolvers/DataPropertyValidationRulesResolver.php
+++ b/src/Resolvers/DataPropertyValidationRulesResolver.php
@@ -89,7 +89,7 @@ class DataPropertyValidationRulesResolver
         return $nestedRules->prepend($toplevelRules, $rulePath);
     }
 
-    private function resolveDataClassOrCollectionTopLevelRules(
+    protected function resolveDataClassOrCollectionTopLevelRules(
         bool $isNullable,
         bool $isOptional,
         DataProperty $property
@@ -149,7 +149,7 @@ class DataPropertyValidationRulesResolver
         return false;
     }
 
-    private function resolveRulePath(?string $payloadPath, string $propertyName): string
+    protected function resolveRulePath(?string $payloadPath, string $propertyName): string
     {
         return $payloadPath ? "{$payloadPath}.{$propertyName}" : $propertyName;
     }


### PR DESCRIPTION
While I wanted to extend the class and implement the fix for #311 in my own implementation of the class (and DI'ing it), overriding the method, I noticed these functions were defined private, so I was unable access them in my class.