### PR TITLE
Prevent fatal error when passing a string containing only an integer to JSON Normalizer.

### DIFF
--- a/src/Normalizers/JsonNormalizer.php
+++ b/src/Normalizers/JsonNormalizer.php
@@ -13,7 +13,8 @@ class JsonNormalizer implements Normalizer
         }
 
         try {
-            return json_decode($value, associative: true, flags: JSON_THROW_ON_ERROR);
+            $maybe_array = json_decode($value, associative: true, flags: JSON_THROW_ON_ERROR);
+            return is_array($maybe_array) ? $maybe_array : null;
         } catch (JsonException) {
             return null;
         }

--- a/tests/Normalizers/JsonNormalizerTest.php
+++ b/tests/Normalizers/JsonNormalizerTest.php
@@ -14,3 +14,11 @@ it('can create a data object from JSON', function () {
 it("won't create a data object from a regular string", function () {
     MultiData::from('Hello World');
 })->throws(CannotCreateData::class);
+
+it("won't create a data object from an integer", function() {
+    MultiData::from(1234);
+})->throws(CannotCreateData::class);
+
+it("won't create a data object from a string containing only an integer", function() {
+    MultiData::from('1234');
+})->throws(CannotCreateData::class);


### PR DESCRIPTION
This PR adds a check to the JSON normalizer make sure that `json_decode()` returned an array before returning the results of `json_decode()` from the normalizer, which must return an array or null.

Without this PR passing a string that contains an integer, such as `'12345'`, to the JSON normalizer causes the error `TypeError: Spatie\LaravelData\Normalizers\JsonNormalizer::normalize(): Return value must be of type ?array, int returned`. This is because a string containing an integer appears to be valid JSON, (or is at least parsable by PHP's parser), but the result of parsing it as JSON is the integer contained within the string, not an array.

For example, (in a Laravel app with spatie/laravel-data installed):
```
$normalizer = new \Spatie\LaravelData\Normalizers\JsonNormalizer;

$normalized = $normaliser->normalize('12345'); // Causes "TypeError: Spatie\LaravelData\Normalizers\JsonNormalizer::normalize(): Return value must be of type ?array, int returned."
```

I also added tests that hopefully work and are correct. I am not super familiar with testing and even less familiar with non-PHPUnit tests!
 
An alternate approach would be to ensure that a string passed to the `::from` method of a Data object actually contains JSON before sending it to the JSON normalizer, and throwing a CannotCreateData exception if it does not.