### PR TITLE
Ignore leading ! in DateTimeInterfaceTransformer

### DIFF
--- a/src/Transformers/DateTimeInterfaceTransformer.php
+++ b/src/Transformers/DateTimeInterfaceTransformer.php
@@ -18,6 +18,8 @@ class DateTimeInterfaceTransformer implements Transformer
     {
         [$format] = Arr::wrap($this->format ?? config('data.date_format'));
 
+        $format = ltrim($format, '!');
+
         /** @var \DateTimeInterface $value */
         if ($this->setTimeZone) {
             $value = (clone $value)->setTimezone(new DateTimeZone($this->setTimeZone));

--- a/tests/Transformers/DateTimeInterfaceTransformerTest.php
+++ b/tests/Transformers/DateTimeInterfaceTransformerTest.php
@@ -134,3 +134,20 @@ it('can change the timezone', function () {
         )
     )->toEqual('1994-05-19T02:00:00+02:00');
 });
+
+it('can transform dates with leading !', function () {
+    $transformer = new DateTimeInterfaceTransformer();
+
+    $class = new class () {
+        public Carbon $carbon;
+    };
+
+    config(['data.date_format' => '!Y-m-d']);
+
+    expect(
+        $transformer->transform(
+            DataProperty::create(new ReflectionProperty($class, 'carbon')),
+            Carbon::createFromFormat('!Y-m-d', '1994-05-19')
+        )
+    )->toEqual('1994-05-19');
+});


### PR DESCRIPTION
Using `!` in `DateTime ` creation format allows the developer to reset undefined fields.

For exemple, `Carbon::createFromFormat('!Y-m-d', '1994-05-19')` gives an instance of Carbon with `hour` set to 0 instead of current hour.

When defining `data.date_format` config with `!Y-m-d H:i:s`, `Data` creation works properly 
```php
$myData = MyData::from(['started_at' => '2022-01-13 08:26:00']);
```
but the serialization will add the extra `!`
```php
$myData->toArray(); // ['started_at' => '!2022-01-13 08:26:00']);
```

This PR removes leading `!` in `DateTimeInterfaceTransformer` in order to make `!` modifier usable in `data.date_format` config