### PR TITLE
[Docs] Fixes Arrayable typos in docs

### DIFF
--- a/docs/advanced-usage/normalizers.md
+++ b/docs/advanced-usage/normalizers.md
@@ -15,7 +15,7 @@ A `Normalizer` will take a payload like a model and will transform it into an ar
 By default, there are five normalizers for each data object:
 
 - **ModelNormalizer** will cast eloquent models
-- **ArraybleNormalizer** will cast `Arrayable`'s
+- **ArrayableNormalizer** will cast `Arrayable`'s
 - **ObjectNormalizer** will cast `stdObject`'s
 - **ArrayNormalizer** will cast arrays
 - **JsonNormalizer** will cast json strings
@@ -34,7 +34,7 @@ class SongData extends Data
     {
         return [
             ModelNormalizer::class,
-            ArraybleNormalizer::class,
+            ArrayableNormalizer::class,
             ObjectNormalizer::class,
             ArrayNormalizer::class,
             JsonNormalizer::class,
@@ -46,7 +46,7 @@ class SongData extends Data
 A normalizer implements the `Normalizer` interface and should return an array representation of the payload, or null if it cannot normalize the payload:
 
 ```php
-class ArraybleNormalizer implements Normalizer
+class ArrayableNormalizer implements Normalizer
 {
     public function normalize(mixed $value): ?array
     {

--- a/docs/as-a-resource/transformers.md
+++ b/docs/as-a-resource/transformers.md
@@ -41,7 +41,7 @@ class ArtistData extends Data{
 }
 ```
 
-Next to a `DateTimeInterfaceTransformer` the package also ships with an `ArraybleTransformer` that transforms an `Arrayable` object to an array.
+Next to a `DateTimeInterfaceTransformer` the package also ships with an `ArrayableTransformer` that transforms an `Arrayable` object to an array.
 
 It is possible to create transformers for your specific types. You can find more info [here](/docs/laravel-data/v2/advanced-usage/creating-a-transformer).
 


### PR DESCRIPTION
This fixes typos in the docs, changing Arrayble to Array**a**ble in ArrayableNormalizer and ArrayableTransformer.