### PR TITLE
Add Laravel 10.x Compactibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,9 +10,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.1, 8.2]
-        laravel: [8.*, 9.*]
+        laravel: [8.*, 9.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 10.*
+            testbench: 8.*
           - laravel: 8.*
             testbench: ^6.25
           - laravel: 9.*

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require" : {
         "php" : "^8.1",
-        "illuminate/contracts" : "^8.83|^9.30",
+        "illuminate/contracts" : "^8.83|^9.30|^10.0",
         "phpdocumentor/type-resolver" : "^1.5",
         "spatie/laravel-package-tools" : "^1.9.0"
     },
@@ -27,7 +27,7 @@
         "inertiajs/inertia-laravel" : "^0.6.3",
         "nette/php-generator" : "^3.5",
         "nunomaduro/larastan" : "^2.0|^1.0.3",
-        "orchestra/testbench" : "^6.24|^7.6",
+        "orchestra/testbench" : "^6.24|^7.6|^8.0",
         "pestphp/pest" : "^1.22",
         "pestphp/pest-plugin-laravel" : "^1.3",
         "phpstan/extension-installer" : "^1.1",


### PR DESCRIPTION
Now that [spatie/laravel-typescript-transformer](https://github.com/spatie/laravel-typescript-transformer/releases/tag/2.1.7) has been updated, this package can be upgraded to support Laravel 10.x.

[See the test runner](https://github.com/njoguamos/laravel-data/actions/runs/3993630454)