### PR TITLE
Add FieldReference to Before and After Validation Attribute

### DIFF
--- a/src/Attributes/Validation/After.php
+++ b/src/Attributes/Validation/After.php
@@ -4,11 +4,12 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use DateTimeInterface;
+use Spatie\LaravelData\Support\Validation\References\FieldReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class After extends StringValidationAttribute
 {
-    public function __construct(protected string|DateTimeInterface $date)
+    public function __construct(protected string|DateTimeInterface|FieldReference $date)
     {
     }
 

--- a/src/Attributes/Validation/Before.php
+++ b/src/Attributes/Validation/Before.php
@@ -4,12 +4,13 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use DateTimeInterface;
+use Spatie\LaravelData\Support\Validation\References\FieldReference;
 use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class Before extends StringValidationAttribute
 {
-    public function __construct(protected string | DateTimeInterface|RouteParameterReference $date)
+    public function __construct(protected string|DateTimeInterface|RouteParameterReference|FieldReference $date)
     {
     }
 


### PR DESCRIPTION
```
    #[WithCast(DateTimeInterfaceCast::class)]
    #[Before(new FieldReference('end_at'))]
    public Carbon $start_at;

    #[WithCast(DateTimeInterfaceCast::class)]
    #[After(new FieldReference('start_at'))]
    public Carbon $end_at;
```

To prevent validation issues when the data is nested (inside a DataCollection for example)