### PR TITLE
Fix rules() typing

### DIFF
--- a/src/Concerns/ValidateableData.php
+++ b/src/Concerns/ValidateableData.php
@@ -8,10 +8,11 @@ use Illuminate\Validation\Validator;
 use Spatie\LaravelData\Resolvers\DataValidationRulesResolver;
 use Spatie\LaravelData\Resolvers\DataValidatorResolver;
 use Spatie\LaravelData\Support\Validation\DataRules;
+use Spatie\LaravelData\Support\Validation\ValidationContext;
 use Spatie\LaravelData\Support\Validation\ValidationPath;
 
 /**
- * @method static array rules(...$args)
+ * @method static array rules(ValidationContext $context)
  * @method static array messages(...$args)
  * @method static array attributes(...$args)
  * @method static bool stopOnFirstFailure()


### PR DESCRIPTION
Since laravel-data v3, rules method expect a `ValidationContext` argument. Currently, laravel-data document the rules method as following on `ValidateableData` trait :

```php
/** 
 * @method static array rules(...$args)
 */
```

This lead to following static analyzer warning in our project :

> Parameter's name changed from 'args' to 'context'

This PR fixes the `@method` doc