### PR TITLE
Add toHtml for Livewire

### DIFF
--- a/src/Lazy.php
+++ b/src/Lazy.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Spatie\LaravelData\Support\Lazy\ConditionalLazy;
 use Spatie\LaravelData\Support\Lazy\DefaultLazy;
 use Spatie\LaravelData\Support\Lazy\InertiaLazy;
+use Spatie\LaravelData\Support\Lazy\LivewireLazy;
 use Spatie\LaravelData\Support\Lazy\RelationalLazy;
 
 abstract class Lazy
@@ -31,6 +32,11 @@ abstract class Lazy
     public static function inertia(Closure $value): InertiaLazy
     {
         return new InertiaLazy($value);
+    }
+    
+    public static function livewire(Closure $value): LivewireLazy
+    {
+        return new LivewireLazy($value);
     }
 
     abstract public function resolve(): mixed;

--- a/src/Support/Lazy/LivewireLazy.php
+++ b/src/Support/Lazy/LivewireLazy.php
@@ -4,7 +4,6 @@ namespace Spatie\LaravelData\Support\Lazy;
 
 use Closure;
 use Illuminate\Contracts\Support\Htmlable;
-use Inertia\LazyProp;
 
 class LivewireLazy extends ConditionalLazy implements Htmlable
 {
@@ -22,10 +21,5 @@ class LivewireLazy extends ConditionalLazy implements Htmlable
     public function toHtml(): mixed
     {
         return $this->resolve();
-    }
-
-    public function __toString(): string
-    {
-        return $this->toHtml();
     }
 }

--- a/src/Support/Lazy/LivewireLazy.php
+++ b/src/Support/Lazy/LivewireLazy.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\LaravelData\Support\Lazy;
+
+use Closure;
+use Illuminate\Contracts\Support\Htmlable;
+use Inertia\LazyProp;
+
+class LivewireLazy extends ConditionalLazy implements Htmlable
+{
+    public function __construct(
+        Closure $value,
+    ) {
+        parent::__construct(fn () => true, $value);
+    }
+
+    public function resolve(): mixed
+    {
+        return ($this->value)();
+    }
+
+    public function toHtml(): mixed
+    {
+        return $this->resolve();
+    }
+
+    public function __toString(): string
+    {
+        return $this->toHtml();
+    }
+}


### PR DESCRIPTION
This is my UserData class, using the introduced `LivewireLazy`:
```php
class UserData extends Data implements Wireable
{
    use WireableData;

    public function __construct(
        public Optional|string $id,
        public Optional|Lazy|string $email,
        #[DataCollectionOf(AddressData::class)]
        public Optional|Lazy|DataCollection $addresses,
    ) {
    }

    public static function fromModel(User $model): self
    {
        return new self(
            id: $model->getRouteKey(),
            email: Lazy::livewire(fn () => $model->email),
            addresses: Lazy::livewire(fn () => AddressData::collection($model->addresses)),
        );
    }
}
```

The `UserEditController.php` (basic example):
```php
<?php

class UserEditController
{
    public $user;
    
    public function mount()
    {
        $this->user = UserData::from(User::first())
            ->include('*');
    }
}
```

Without `LivewireLazy`:
```php
{{ $this->user->email }} // htmlspecialchars(): Argument #1 ($string) must be of type string, Spatie\LaravelData\Support\Lazy\DefaultLazy given
```

With `LivewireLazy` it works as expected:
```php
{{ $this->user->email }} // email@example.com
```

However the `AddressData` collection still results in a `LivewireLazy` collection instead of actually returning the data objects. I need to explicit call `{{ $this->user->addresses->resolve()->first() }}`.

Is this intended? Any workaround?

I think this PR would be a good fit, as Livewire is used to output the data object directly in most cases.

Thanks!