### PR TITLE
Add support for Validation Rule Contract in Rule rule

### DIFF
--- a/src/Attributes/Validation/Rule.php
+++ b/src/Attributes/Validation/Rule.php
@@ -5,15 +5,16 @@ namespace Spatie\LaravelData\Attributes\Validation;
 use Attribute;
 use Illuminate\Contracts\Validation\InvokableRule as InvokableRuleContract;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
+use Illuminate\Contracts\Validation\ValidationRule as ValidationRuleContract;
 use Spatie\LaravelData\Support\Validation\ValidationRule;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class Rule extends ValidationRule
 {
-    /** @var array<string|array|ValidationRule|RuleContract|InvokableRuleContract> */
+    /** @var array<string|array|ValidationRule|RuleContract|InvokableRuleContract|ValidationRuleContract> */
     protected array $rules = [];
 
-    public function __construct(string|array|ValidationRule|RuleContract|InvokableRuleContract ...$rules)
+    public function __construct(string|array|ValidationRule|RuleContract|InvokableRuleContract|ValidationRuleContract ...$rules)
     {
         $this->rules = $rules;
     }

--- a/tests/Attributes/Validation/RulesTest.php
+++ b/tests/Attributes/Validation/RulesTest.php
@@ -9,6 +9,7 @@ use Spatie\LaravelData\Support\Validation\ValidationPath;
 use Spatie\LaravelData\Support\Validation\ValidationRule;
 use Spatie\LaravelData\Tests\Fakes\Rules\CustomInvokableLaravelRule;
 use Spatie\LaravelData\Tests\Fakes\Rules\CustomLaravelRule;
+use Spatie\LaravelData\Tests\Fakes\Rules\CustomLaravelValidationRule;
 use Spatie\TestTime\TestTime;
 
 beforeEach(function () {
@@ -85,6 +86,27 @@ it('can use the Rule rule with invokable rules', function () {
         'x',
         'y',
         new CustomInvokableLaravelRule(),
+        'required',
+    ]);
+});
+
+it('can use the Rule rule with validation rule contract', function () {
+    $rule = new Rule(
+        'test',
+        ['a', 'b', 'c'],
+        'x|y',
+        new CustomLaravelValidationRule(),
+        new Required()
+    );
+
+    expect(app(RuleDenormalizer::class)->execute($rule, ValidationPath::create()))->toMatchArray([
+        'test',
+        'a',
+        'b',
+        'c',
+        'x',
+        'y',
+        new CustomLaravelValidationRule(),
         'required',
     ]);
 });

--- a/tests/Fakes/Rules/CustomLaravelValidationRule.php
+++ b/tests/Fakes/Rules/CustomLaravelValidationRule.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class CustomLaravelValidationRule implements ValidationRule
+{
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+    }
+}


### PR DESCRIPTION
Added support for `Illuminate\Contracts\Validation\ValidationRule` in `Spatie\LaravelData\Attributes\Validation\Rule`. Didn't remove depreciated contracts for compability reasons.