### PR TITLE
Quote non-standard object keys when transforming to Typescript

### DIFF
--- a/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
+++ b/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
@@ -81,6 +81,10 @@ class DataTypeScriptTransformer extends DtoTransformer
 
                 $propertyName = $dataProperty->outputMappedName ?? $dataProperty->name;
 
+                if (! preg_match('/^[$_a-zA-Z][$_a-zA-Z0-9]*$/', $propertyName)) {
+                    $propertyName = "'{$propertyName}'";
+                }
+
                 return $isOptional
                     ? "{$carry}{$propertyName}?: {$transformed};" . PHP_EOL
                     : "{$carry}{$propertyName}: {$transformed};" . PHP_EOL;

--- a/tests/Support/TypeScriptTransformer/DataTypeScriptTransformerTest.php
+++ b/tests/Support/TypeScriptTransformer/DataTypeScriptTransformerTest.php
@@ -160,10 +160,12 @@ it('uses the correct types for cursor paginated data collection of attributes', 
 it('outputs types with properties using their mapped name', function () {
     $config = TypeScriptTransformerConfig::create();
 
-    $data = new class ('Good job Ruben') extends Data {
+    $data = new class ('Good job Ruben', 'Hi Ruben') extends Data {
         public function __construct(
             #[MapOutputName(SnakeCaseMapper::class)]
             public string $someCamelCaseProperty,
+            #[MapOutputName('some:non:standard:property')]
+            public string $someNonStandardProperty,
         ) {
         }
     };

--- a/tests/__snapshots__/DataTypeScriptTransformerTest__it_outputs_types_with_properties_using_their_mapped_name__1.txt
+++ b/tests/__snapshots__/DataTypeScriptTransformerTest__it_outputs_types_with_properties_using_their_mapped_name__1.txt
@@ -1,3 +1,4 @@
 {
 some_camel_case_property: string;
+'some:non:standard:property': string;
 }


### PR DESCRIPTION
Adds quotes to property names that contain special characters.

Rationale and further discussion may be found here: https://github.com/spatie/typescript-transformer/discussions/48