### PR TITLE
Allow using closures within the with method

### DIFF
--- a/src/Concerns/AppendableData.php
+++ b/src/Concerns/AppendableData.php
@@ -24,12 +24,20 @@ trait AppendableData
     {
         $additional = $this->with();
 
-        foreach ($this->_additional as $name => $value) {
-            $additional[$name] = $value instanceof Closure
+        $computedAdditional = [];
+
+        foreach ($additional as $name => $value) {
+            $computedAdditional[$name] = $value instanceof Closure
                 ? ($value)($this)
                 : $value;
         }
 
-        return $additional;
+        foreach ($this->_additional as $name => $value) {
+            $computedAdditional[$name] = $value instanceof Closure
+                ? ($value)($this)
+                : $value;
+        }
+
+        return $computedAdditional;
     }
 }

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -595,6 +595,46 @@ it('can append data via method overwriting', function () {
     ]);
 });
 
+it('can append data via method overwriting with closures', function () {
+    $data = new class ('Freek') extends Data {
+        public function __construct(public string $name)
+        {
+        }
+
+        public function with(): array
+        {
+            return ['alt_name' => static function (self $data) {
+                return $data->name . ' from Spatie via closure';
+            }];
+        }
+    };
+
+    expect($data->toArray())->toMatchArray([
+        'name' => 'Freek',
+        'alt_name' => 'Freek from Spatie via closure',
+    ]);
+});
+
+test('when using additional method and with method additional method gets priority', function () {
+    $data = new class ('Freek') extends Data {
+        public function __construct(public string $name)
+        {
+        }
+
+        public function with(): array
+        {
+            return ['alt_name' => static function (self $data) {
+                return $data->name . ' from Spatie via closure';
+            }];
+        }
+    };
+
+    expect($data->additional(['alt_name' => 'I m Freek from additional'])->toArray())->toMatchArray([
+        'name' => 'Freek',
+        'alt_name' => 'I m Freek from additional',
+    ]);
+});
+
 it('can get the data object without mapping properties names', function () {
     $data = new class ('Freek') extends Data {
         public function __construct(


### PR DESCRIPTION
I am using closures within as array value within the `with()` method, and i find it strange that you do not automatically unwrap the value when calling `getAdditionalData`. So this is what this pr does. 

I have also made it so that if a developer uses additional and the with and the keys collide then the keys from additional take priority 