### PR TITLE
Allow laravel-data validation rules to be used in Laravel validator

### DIFF
--- a/src/Attributes/Validation/StringValidationAttribute.php
+++ b/src/Attributes/Validation/StringValidationAttribute.php
@@ -2,18 +2,9 @@
 
 namespace Spatie\LaravelData\Attributes\Validation;
 
-use Spatie\LaravelData\Support\Validation\RuleDenormalizer;
-use Spatie\LaravelData\Support\Validation\ValidationPath;
-use Stringable;
-
-abstract class StringValidationAttribute extends ValidationAttribute implements Stringable
+abstract class StringValidationAttribute extends ValidationAttribute
 {
     abstract public function parameters(): array;
-
-    public function __toString(): string
-    {
-        return implode('|', app(RuleDenormalizer::class)->execute($this, ValidationPath::create()));
-    }
 
     public static function create(string ...$parameters): static
     {

--- a/src/Attributes/Validation/ValidationAttribute.php
+++ b/src/Attributes/Validation/ValidationAttribute.php
@@ -4,13 +4,21 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Carbon\Carbon;
 use Spatie\LaravelData\Support\Validation\References\FieldReference;
+use Spatie\LaravelData\Support\Validation\RuleDenormalizer;
+use Spatie\LaravelData\Support\Validation\ValidationPath;
 use Spatie\LaravelData\Support\Validation\ValidationRule;
+use Stringable;
 
-abstract class ValidationAttribute extends ValidationRule
+abstract class ValidationAttribute extends ValidationRule implements Stringable
 {
     abstract public static function keyword(): string;
 
     abstract public static function create(string ...$parameters): static;
+
+    public function __toString(): string
+    {
+        return implode('|', app(RuleDenormalizer::class)->execute($this, ValidationPath::create()));
+    }
 
     protected static function parseDateValue(mixed $value): mixed
     {

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator as ValidatorFacade;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\Exists as LaravelExists;
 
@@ -2103,4 +2104,17 @@ it('can handle a string as (wrong) payload', function () {
         ->assertErrors([
             'simple' => 'hello-world',
         ]);
+});
+
+it('can use laravel-data validation rules in laravel validator', function () {
+    $validator = ValidatorFacade::make(
+        [
+            'property' => 'test',
+        ],
+        [
+            'property' => [new Required(), new StringType(), new Max(10)],
+        ],
+    );
+
+    expect($validator->passes())->toBeTrue();
 });

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -2107,14 +2107,26 @@ it('can handle a string as (wrong) payload', function () {
 });
 
 it('can use laravel-data validation rules in laravel validator', function () {
-    $validator = ValidatorFacade::make(
+    $rules = [new Required(), new StringType(), new Max(10)];
+
+    $validatorToPass = ValidatorFacade::make(
         [
             'property' => 'test',
         ],
         [
-            'property' => [new Required(), new StringType(), new Max(10)],
+            'property' => $rules,
         ],
     );
 
-    expect($validator->passes())->toBeTrue();
+    $validatorToFail = ValidatorFacade::make(
+        [
+            'property' => 'testLongerText',
+        ],
+        [
+            'property' => $rules,
+        ],
+    );
+
+    expect($validatorToPass->passes())->toBeTrue()
+        ->and($validatorToFail->passes())->toBeFalse();
 });

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -6,7 +6,6 @@ use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\Exists as LaravelExists;
 


### PR DESCRIPTION
With the v2 version of laravel-data, it was possible to use all of the class-based validation rules in the `src/Attributes/Validation` folder with the Laravel validator, as an alternative to passing the rules by their string representation.
This provided a clean, typed representation of the rules in places, where using the rules as attributes would not work, like with Laravel Nova validation rules.

This use case has been, as of v3, broken, since [commit reference](https://github.com/spatie/laravel-data/commit/350d6fe61317910f7088042f787a1b72bd68c136#diff-e7432095734fd5269dcb9a94fd9d878cb6279dbcf736081dddd796554f0c7cd2).

This PR reintroduces support for using the validation rule classes provided by the package with the Laravel validator and adds a test to protect this use case from future breaks.