### PR TITLE
Introduce FormRequestNormalizer

### DIFF
--- a/config/data.php
+++ b/config/data.php
@@ -47,6 +47,7 @@ return [
      */
     'normalizers' => [
         Spatie\LaravelData\Normalizers\ModelNormalizer::class,
+        // Spatie\LaravelData\Normalizers\FormRequestNormalizer::class,
         Spatie\LaravelData\Normalizers\ArrayableNormalizer::class,
         Spatie\LaravelData\Normalizers\ObjectNormalizer::class,
         Spatie\LaravelData\Normalizers\ArrayNormalizer::class,

--- a/src/Normalizers/FormRequestNormalizer.php
+++ b/src/Normalizers/FormRequestNormalizer.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\LaravelData\Normalizers;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class FormRequestNormalizer implements Normalizer
+{
+    public function normalize(mixed $value): ?array
+    {
+        if (! $value instanceof FormRequest) {
+            return null;
+        }
+
+        return $value->validated();
+    }
+}

--- a/tests/Fakes/DataWithNullable.php
+++ b/tests/Fakes/DataWithNullable.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Data;
+
+class DataWithNullable extends Data
+{
+    public function __construct(
+        public string $string,
+        public ?string $nullableString,
+    ) {
+    }
+}

--- a/tests/Normalizers/FormRequestNormalizerTest.php
+++ b/tests/Normalizers/FormRequestNormalizerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Foundation\Http\FormRequest;
+use Spatie\LaravelData\Normalizers\FormRequestNormalizer;
+use Spatie\LaravelData\Tests\Fakes\DataWithNullable;
+
+beforeEach(function () {
+    config()->set('data.normalizers', [FormRequestNormalizer::class]);
+});
+
+it('can create a data object from FormRequest', function () {
+    $request = new class () extends FormRequest {
+        public function rules(): array
+        {
+            return [
+                'string' => 'required|string',
+                'nullableString' => 'nullable|string',
+            ];
+        }
+    };
+    $request
+        ->replace([
+            'string' => 'Hello',
+            'nullableString' => 'World',
+        ])
+        ->setContainer(app())
+        ->validateResolved();
+
+    $originalData = new DataWithNullable('Hello', 'World');
+    $createdData = DataWithNullable::from($request);
+
+    expect($createdData)->toEqual($originalData);
+});
+
+it("excludes unsafe data", function () {
+    $request = new class () extends FormRequest {
+        public function rules(): array
+        {
+            return [
+                'string' => 'required|string',
+            ];
+        }
+    };
+    $request
+        ->replace([
+            'string' => 'Hello',
+            'nullableString' => 'World',
+        ])
+        ->setContainer(app())
+        ->validateResolved();
+
+    $originalData = new DataWithNullable('Hello', null);
+    $createdData = DataWithNullable::from($request);
+
+    expect($createdData)->toEqual($originalData);
+});


### PR DESCRIPTION
This PR introduces a `FormRequestNormalizer` which allows to create a Data from validated content of a `FormRequest`. 

IMHO, it is more safe than to rely on the fact that a `Request` is `Arrayable` because unvalidated data won't be included in the `Data` with this new `FormRequestNormalizer`.

I did not include this new normalizer by default in the configuration because I think it could break existing applications if unvalidated data are used to create `Data` objects. I would be glad to enable it by default  if you think it's better.