### PR TITLE
Add Request validation data pipe

### DIFF
--- a/docs/as-a-data-transfer-object/request-to-data-object.md
+++ b/docs/as-a-data-transfer-object/request-to-data-object.md
@@ -168,6 +168,34 @@ The rules will now look like this:
 ]
 ```
 
+### Overwrite Request Validation Data
+
+Overwrite the data that needs to be verified in the request. You can add a `validationData` method like FromRequest to
+provide the data used to participate in the form validation, but which must be a static method.
+
+A Request object will be provided as the first parameter.
+
+```php
+class SongData extends Data
+{
+    public function __construct(
+        public string $title,
+        public string $artist,
+    ) {
+    }
+    
+    public static function validationData(\Illuminate\Http\Request $request): array
+    {
+        return [
+            'title'  => $request->header('title'),
+            'artist' => $request->input('artist');
+        ];
+    }
+}
+
+
+```
+
 ### Rule attribute
 
 One special attribute is the `Rule` attribute. With it, you can write rules just like you would when creating a custom

--- a/src/Concerns/BaseData.php
+++ b/src/Concerns/BaseData.php
@@ -15,6 +15,7 @@ use Spatie\LaravelData\DataPipes\CastPropertiesDataPipe;
 use Spatie\LaravelData\DataPipes\DefaultValuesDataPipe;
 use Spatie\LaravelData\DataPipes\FillRouteParameterPropertiesDataPipe;
 use Spatie\LaravelData\DataPipes\MapPropertiesDataPipe;
+use Spatie\LaravelData\DataPipes\RequestValidationDataPipe;
 use Spatie\LaravelData\DataPipes\ValidatePropertiesDataPipe;
 use Spatie\LaravelData\PaginatedDataCollection;
 use Spatie\LaravelData\Resolvers\DataFromSomethingResolver;
@@ -72,6 +73,7 @@ trait BaseData
     {
         return DataPipeline::create()
             ->into(static::class)
+            ->through(RequestValidationDataPipe::class)
             ->through(AuthorizedDataPipe::class)
             ->through(MapPropertiesDataPipe::class)
             ->through(FillRouteParameterPropertiesDataPipe::class)

--- a/src/DataPipes/RequestValidationDataPipe.php
+++ b/src/DataPipes/RequestValidationDataPipe.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\LaravelData\DataPipes;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Spatie\LaravelData\Support\DataClass;
+
+class RequestValidationDataPipe implements DataPipe
+{
+    public function handle(mixed $payload, DataClass $class, Collection $properties): Collection
+    {
+        if (! $payload instanceof Request) {
+            return $properties;
+        }
+
+        $className = $class->name;
+        if (method_exists($className, 'validationData')) {
+            return Collection::make($className::validationData($payload));
+        }
+
+        return $properties;
+    }
+}

--- a/src/Resolvers/DataFromSomethingResolver.php
+++ b/src/Resolvers/DataFromSomethingResolver.php
@@ -5,7 +5,6 @@ namespace Spatie\LaravelData\Resolvers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Spatie\LaravelData\Contracts\BaseData;
-use Spatie\LaravelData\DataPipes\RequestValidationDataPipe;
 use Spatie\LaravelData\Normalizers\ArrayableNormalizer;
 use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelData\Support\DataMethod;
@@ -45,9 +44,6 @@ class DataFromSomethingResolver
             function (Collection $carry, mixed $payload) use ($class) {
                 /** @var BaseData $class */
                 $pipeline = $class::pipeline();
-                if ($payload instanceof Request) {
-                    $pipeline->firstThrough(RequestValidationDataPipe::class);
-                }
 
                 foreach ($class::normalizers() as $normalizer) {
                     $pipeline->normalizer($normalizer);
@@ -93,7 +89,6 @@ class DataFromSomethingResolver
         foreach ($payloads as $payload) {
             if ($payload instanceof Request) {
                 $class::pipeline()
-                    ->firstThrough(RequestValidationDataPipe::class)
                     ->normalizer(ArrayableNormalizer::class)
                     ->into($class)
                     ->using($payload)

--- a/src/Resolvers/DataFromSomethingResolver.php
+++ b/src/Resolvers/DataFromSomethingResolver.php
@@ -5,6 +5,7 @@ namespace Spatie\LaravelData\Resolvers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Spatie\LaravelData\Contracts\BaseData;
+use Spatie\LaravelData\DataPipes\RequestValidationDataPipe;
 use Spatie\LaravelData\Normalizers\ArrayableNormalizer;
 use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelData\Support\DataMethod;
@@ -44,6 +45,9 @@ class DataFromSomethingResolver
             function (Collection $carry, mixed $payload) use ($class) {
                 /** @var BaseData $class */
                 $pipeline = $class::pipeline();
+                if ($payload instanceof Request) {
+                    $pipeline->firstThrough(RequestValidationDataPipe::class);
+                }
 
                 foreach ($class::normalizers() as $normalizer) {
                     $pipeline->normalizer($normalizer);
@@ -89,6 +93,7 @@ class DataFromSomethingResolver
         foreach ($payloads as $payload) {
             if ($payload instanceof Request) {
                 $class::pipeline()
+                    ->firstThrough(RequestValidationDataPipe::class)
                     ->normalizer(ArrayableNormalizer::class)
                     ->into($class)
                     ->using($payload)

--- a/tests/DataPipes/RequestValidationDataPipeTest.php
+++ b/tests/DataPipes/RequestValidationDataPipeTest.php
@@ -1,0 +1,22 @@
+<?php
+
+it('use request validationData', function () {
+    $dataClass = new class () extends \Spatie\LaravelData\Data {
+        public int $id;
+        public string $token;
+
+        public static function validationData(\Illuminate\Http\Request $request): array
+        {
+            return ['id' => 1, 'token' => $request->header('token')];
+        }
+    };
+
+    $request = Mockery::mock(\Illuminate\Http\Request::class);
+    $request->expects('header')->with('token')->andReturn('hello');
+    $request->expects('toArray')->andReturn([]);
+
+    $data = $dataClass::from($request);
+
+    expect($data->id)->toEqual(1);
+    expect($data->token)->toEqual('hello');
+});


### PR DESCRIPTION
Overwrite the data that needs to be verified in the request. You can add a `validationData` method like FromRequest to
provide the data used to participate in the form validation

- [framework/FormRequest.php at 10.x · laravel/framework](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Foundation/Http/FormRequest.php#L133)