### PR TITLE
Add support for models without all columns

### DIFF
--- a/src/Normalizers/ModelNormalizer.php
+++ b/src/Normalizers/ModelNormalizer.php
@@ -16,19 +16,25 @@ class ModelNormalizer implements Normalizer
         $properties = $value->toArray();
 
         foreach ($value->getDates() as $key) {
-            $properties[$key] = $value->getAttribute($key);
+            if (isset($properties[$key])) {
+                $properties[$key] = $value->getAttribute($key);
+            }
         }
 
         foreach ($value->getCasts() as $key => $cast) {
             if ($this->isDateCast($cast)) {
-                $properties[$key] = $value->getAttribute($key);
+                if (isset($properties[$key])) {
+                    $properties[$key] = $value->getAttribute($key);
+                }
             }
         }
 
         foreach ($value->getRelations() as $key => $relation) {
             $key = $value::$snakeAttributes ? Str::snake($key) : $key;
 
-            $properties[$key] = $relation;
+            if (isset($properties[$key])) {
+                $properties[$key] = $relation;
+            }
         }
 
         return $properties;


### PR DESCRIPTION
Support for models without all columns.

Example:

```
$model = Team::query()
    ->with(relations: [
        'user:id,name',
        'club:id,name,country',
        'ranking:id,team_id,rank,rating',
     ])
     ->find(id: $id);
```

Currently throwing an error: `Illuminate\Database\Eloquent\MissingAttributeException: The attribute [created_at] either does not exist or was not retrieved for model [App\Models\Ranking]. in /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:469` in `Laravel 10`.