### PR TITLE
Fix usage of properties' mapped output names in 'only', 'except', 'includes', and 'excludes' operations

### DIFF
--- a/docs/as-a-resource/lazy-properties.md
+++ b/docs/as-a-resource/lazy-properties.md
@@ -378,3 +378,49 @@ It is also possible to run exclude, except and only operations on a data object:
 - You can define **except** in `allowedRequestExcept` and use the `except` key in your query string
 - You can define **only** in `allowedRequestOnly` and use the `only` key in your query string
 
+### Mapping attributes support
+
+When a data object uses attributes like MapName, MapOutputName, the operations **includes**, **excludes**, **except**, and **only**
+expects these output names to be specified in a query string.
+
+Example:
+
+```php
+class UserData extends Data
+{
+    public function __construct(
+        public string $title,
+        #[MapOutputName('favorite_song')] // Mapped output name
+        public Lazy|SongData $song,
+    ) {
+    }
+
+    public static function allowedRequestExcept(): ?array
+    {
+        return [
+            'song' // Original property name
+        ];
+    }
+
+    public static function fromModel(User $user): self
+    {
+        return new self(
+            $user->title,
+            Lazy::create(fn() => SongData::from($user->song))
+        );
+    }
+}
+```
+
+To except the `song` property in your code:
+```php
+UserData::from(User::first())->except('song');
+```
+
+To except the `song` property in a query string you must use mapped output name — `favorite_song`:
+```
+https://spatie.be/my-account?except[]=favorite_song
+```
+
+The same is when a data object uses `MapName` attribute with any case mapper.
+

--- a/src/Resolvers/PartialsTreeFromRequestResolver.php
+++ b/src/Resolvers/PartialsTreeFromRequestResolver.php
@@ -7,24 +7,68 @@ use Spatie\LaravelData\Contracts\BaseData;
 use Spatie\LaravelData\Contracts\BaseDataCollectable;
 use Spatie\LaravelData\Contracts\IncludeableData;
 use Spatie\LaravelData\Support\AllowedPartialsParser;
+use Spatie\LaravelData\Support\DataClass;
 use Spatie\LaravelData\Support\DataConfig;
-use Spatie\LaravelData\Support\PartialsParser;
+use Spatie\LaravelData\Support\DataProperty;
 use Spatie\LaravelData\Support\PartialTrees;
+use Spatie\LaravelData\Support\RequestPartialsParser;
 use TypeError;
 
 class PartialsTreeFromRequestResolver
 {
     public function __construct(
         protected DataConfig $dataConfig,
-        protected PartialsParser $partialsParser,
+        protected RequestPartialsParser $partialsParser,
         protected AllowedPartialsParser $allowedPartialsParser,
     ) {
+    }
+
+    protected function createOutputNameMapping(DataClass $dataClass): array
+    {
+        return $dataClass
+            ->properties
+            ->mapWithKeys(function (DataProperty $dataProperty) use ($dataClass) {
+
+                $field = $dataProperty->name;
+                $outputMappedName = $dataProperty->outputMappedName ?? $dataProperty->name;
+
+                if ($dataProperty->type->isDataObject || $dataProperty->type->isDataCollectable) {
+                    return [
+                        $outputMappedName => [
+                            'name' => $field,
+                            'children' => $this->createOutputNameMapping(
+                                $this->dataConfig->getDataClass($dataProperty->type->dataClass)
+                            )
+                        ],
+                    ];
+                }
+
+                return [
+                    $outputMappedName => [
+                        'name' => $field,
+                        'children' => []
+                    ]
+                ];
+            })->all();
     }
 
     public function execute(
         IncludeableData $data,
         Request $request,
     ): PartialTrees {
+
+        $dataClass = match (true) {
+            $data instanceof BaseData => $data::class,
+            $data instanceof BaseDataCollectable => $data->getDataClass(),
+            default => throw new TypeError('Invalid type of data')
+        };
+
+        $dataClass = $this->dataConfig->getDataClass($dataClass);
+
+        $outputNameMapping = $this->createOutputNameMapping($dataClass);
+
+        $this->partialsParser->setOutputNameMapping($outputNameMapping);
+
         $requestedIncludesTree = $this->partialsParser->execute(
             $request->has('include') ? $this->arrayFromRequest($request, 'include') : []
         );
@@ -38,16 +82,10 @@ class PartialsTreeFromRequestResolver
             $request->has('except') ? $this->arrayFromRequest($request, 'except') : []
         );
 
-        $dataClass = match (true) {
-            $data instanceof BaseData => $data::class,
-            $data instanceof BaseDataCollectable => $data->getDataClass(),
-            default => throw new TypeError('Invalid type of data')
-        };
-
-        $allowedRequestIncludesTree = $this->allowedPartialsParser->execute('allowedRequestIncludes', $this->dataConfig->getDataClass($dataClass));
-        $allowedRequestExcludesTree = $this->allowedPartialsParser->execute('allowedRequestExcludes', $this->dataConfig->getDataClass($dataClass));
-        $allowedRequestOnlyTree = $this->allowedPartialsParser->execute('allowedRequestOnly', $this->dataConfig->getDataClass($dataClass));
-        $allowedRequestExceptTree = $this->allowedPartialsParser->execute('allowedRequestExcept', $this->dataConfig->getDataClass($dataClass));
+        $allowedRequestIncludesTree = $this->allowedPartialsParser->execute('allowedRequestIncludes', $dataClass);
+        $allowedRequestExcludesTree = $this->allowedPartialsParser->execute('allowedRequestExcludes', $dataClass);
+        $allowedRequestOnlyTree = $this->allowedPartialsParser->execute('allowedRequestOnly', $dataClass);
+        $allowedRequestExceptTree = $this->allowedPartialsParser->execute('allowedRequestExcept', $dataClass);
 
         $partialTrees = $data->getPartialTrees();
 

--- a/src/Resolvers/PartialsTreeFromRequestResolver.php
+++ b/src/Resolvers/PartialsTreeFromRequestResolver.php
@@ -27,8 +27,7 @@ class PartialsTreeFromRequestResolver
     {
         return $dataClass
             ->properties
-            ->mapWithKeys(function (DataProperty $dataProperty) use ($dataClass) {
-
+            ->mapWithKeys(function (DataProperty $dataProperty) {
                 $field = $dataProperty->name;
                 $outputMappedName = $dataProperty->outputMappedName ?? $dataProperty->name;
 
@@ -38,7 +37,7 @@ class PartialsTreeFromRequestResolver
                             'name' => $field,
                             'children' => $this->createOutputNameMapping(
                                 $this->dataConfig->getDataClass($dataProperty->type->dataClass)
-                            )
+                            ),
                         ],
                     ];
                 }
@@ -46,8 +45,8 @@ class PartialsTreeFromRequestResolver
                 return [
                     $outputMappedName => [
                         'name' => $field,
-                        'children' => []
-                    ]
+                        'children' => [],
+                    ],
                 ];
             })->all();
     }
@@ -56,7 +55,6 @@ class PartialsTreeFromRequestResolver
         IncludeableData $data,
         Request $request,
     ): PartialTrees {
-
         $dataClass = match (true) {
             $data instanceof BaseData => $data::class,
             $data instanceof BaseDataCollectable => $data->getDataClass(),

--- a/src/Support/RequestPartialsParser.php
+++ b/src/Support/RequestPartialsParser.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Spatie\LaravelData\Support;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Spatie\LaravelData\Support\TreeNodes\AllTreeNode;
+use Spatie\LaravelData\Support\TreeNodes\DisabledTreeNode;
+use Spatie\LaravelData\Support\TreeNodes\ExcludedTreeNode;
+use Spatie\LaravelData\Support\TreeNodes\PartialTreeNode;
+use Spatie\LaravelData\Support\TreeNodes\TreeNode;
+
+class RequestPartialsParser
+{
+    protected array $outputNameMapping = [];
+
+    public function setOutputNameMapping(array $outputNameMapping = []): self
+    {
+        $this->outputNameMapping = $outputNameMapping;
+        return $this;
+    }
+
+    public function execute(array $partials, ?array $outputNameMapping = null): TreeNode
+    {
+        $nodes = new DisabledTreeNode();
+
+        $outputNameMapping = $outputNameMapping ?? $this->outputNameMapping;
+
+        foreach ($partials as $directive) {
+            $directive = str_replace(' ', '', $directive);
+
+            $nested = str_contains($directive, '.') ? Str::after($directive, '.') : null;
+            $field = Str::before($directive, '.');
+
+            $mappedProperty = $outputNameMapping[$field] ?? [];
+            $mappedField = $mappedProperty['name'] ?? $field;
+
+            $mappedPropertyChildren = $mappedProperty['children'] ?? [];
+
+            if ($field === '*') {
+                return new AllTreeNode();
+            }
+
+            if (Str::startsWith($field, '{') && Str::endsWith($field, '}')) {
+                $children = collect(explode(',', substr($field, 1, -1)))
+                    ->values()
+                    ->map(function ($child) use ($outputNameMapping) {
+                        return $outputNameMapping[$child]['name'] ?? $child;
+                    })
+                    ->flip()
+                    ->map(fn () => new ExcludedTreeNode())
+                    ->all();
+
+                $nodes = $nodes->merge(new PartialTreeNode($children));
+
+                continue;
+            }
+
+            $nestedNode = $nested === null || count($mappedPropertyChildren) === 0
+                ? new ExcludedTreeNode()
+                : $this->execute([$nested], $mappedPropertyChildren);
+
+            $nodes = $nodes->merge(new PartialTreeNode([
+                $mappedField => $nestedNode,
+            ]));
+        }
+
+        return $nodes;
+    }
+}

--- a/tests/Fakes/SimpleChildDataWithMappedOutputName.php
+++ b/tests/Fakes/SimpleChildDataWithMappedOutputName.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Attributes\MapOutputName;
+use Spatie\LaravelData\Data;
+
+class SimpleChildDataWithMappedOutputName extends Data
+{
+    public function __construct(
+        public int $id,
+        #[MapOutputName('child_amount')]
+        public float $amount
+    ) {
+    }
+
+    public static function allowedRequestExcept(): ?array
+    {
+        return ['amount'];
+    }
+}

--- a/tests/Fakes/SimpleDataWithMappedOutputName.php
+++ b/tests/Fakes/SimpleDataWithMappedOutputName.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Attributes\MapOutputName;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Mappers\SnakeCaseMapper;
+
+#[MapName(SnakeCaseMapper::class)]
+class SimpleDataWithMappedOutputName extends Data
+{
+    public function __construct(
+        public int $id,
+        #[MapOutputName('paid_amount')]
+        public float $amount,
+        public string $anyString,
+        public SimpleChildDataWithMappedOutputName $child
+    ) {
+    }
+
+    public static function allowedRequestExcept(): ?array
+    {
+        return [
+            'amount',
+            'anyString',
+            'child'
+        ];
+    }
+}

--- a/tests/Resolvers/PartialsTreeFromRequestResolverTest.php
+++ b/tests/Resolvers/PartialsTreeFromRequestResolverTest.php
@@ -12,6 +12,8 @@ use Spatie\LaravelData\Support\TreeNodes\PartialTreeNode;
 use Spatie\LaravelData\Support\TreeNodes\TreeNode;
 use Spatie\LaravelData\Tests\Fakes\LazyData;
 use Spatie\LaravelData\Tests\Fakes\MultiLazyData;
+use Spatie\LaravelData\Tests\Fakes\SimpleChildDataWithMappedOutputName;
+use Spatie\LaravelData\Tests\Fakes\SimpleDataWithMappedOutputName;
 
 beforeEach(function () {
     $this->resolver = resolve(PartialsTreeFromRequestResolver::class);
@@ -211,5 +213,33 @@ it('handles parsing includes from request', function (array $input, array $expec
     yield 'input as comma separated' => [
         'input' => ['include' => 'artist,name'],
         'expected' => ['artist', 'name'],
+    ];
+});
+
+it('handles parsing except from request with mapped output name', function (array $input, array $expectedArray) {
+    $dataclass = SimpleDataWithMappedOutputName::from([
+        'id'         => 1,
+        'amount'     => 1000,
+        'any_string' => 'test',
+        'child'      => SimpleChildDataWithMappedOutputName::from([
+            'id'     => 2,
+            'amount' => 2000,
+        ])
+    ]);
+
+    $request = request()->merge($input);
+
+    $data = $dataclass->toResponse($request)->getData(assoc: true);
+
+    expect($data)->toMatchArray($expectedArray);
+})->with(function () {
+    yield 'input as array' => [
+        'input'       => ['except' => ['paid_amount', 'any_string', 'child.child_amount']],
+        'expectedArray' => [
+            'id' => 1,
+            'child' => [
+                'id' => 2
+            ]
+        ],
     ];
 });


### PR DESCRIPTION
Fixes #387 