### PR TITLE
Remove superfluous php version check

### DIFF
--- a/tests/Casts/EnumCastTest.php
+++ b/tests/Casts/EnumCastTest.php
@@ -7,8 +7,6 @@ use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
 use Spatie\LaravelData\Tests\Fakes\Enums\DummyUnitEnum;
 
 beforeEach(function () {
-    onlyPHP81();
-
     $this->caster = new EnumCast();
 });
 

--- a/tests/DataPipes/CastPropertiesDataPipeTest.php
+++ b/tests/DataPipes/CastPropertiesDataPipeTest.php
@@ -176,8 +176,6 @@ it('allows casting', function () {
 });
 
 it('allows casting of enums', function () {
-    onlyPHP81();
-
     $data = EnumData::from([
         'enum' => 'foo',
     ]);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -13,10 +13,3 @@ uses(Spatie\LaravelData\Tests\TestCase::class)->in('.');
 | Functions
 |--------------------------------------------------------------------------
 */
-
-function onlyPHP81()
-{
-    if (version_compare(phpversion(), '8.1', '<')) {
-        test()->markTestIncomplete('This test is only supported in PHP versions > PHP 8.1');
-    }
-}

--- a/tests/Transformers/EnumTransformerTest.php
+++ b/tests/Transformers/EnumTransformerTest.php
@@ -5,8 +5,6 @@ use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
 use Spatie\LaravelData\Transformers\EnumTransformer;
 
 it('can transform enums', function () {
-    onlyPHP81();
-
     $transformer = new EnumTransformer();
 
     $class = new class () {


### PR DESCRIPTION
As the package requires `php:^8.1` we do not need to check for the version in the tests.