### PR TITLE
Improve performance when creating large amounts of Data objects

### DIFF
--- a/src/Concerns/BaseData.php
+++ b/src/Concerns/BaseData.php
@@ -49,7 +49,7 @@ trait BaseData
 
     public static function from(mixed ...$payloads): static
     {
-        return app(DataFromSomethingResolver::class)->execute(
+        return app(DataFromSomethingResolver::class)->reset()->execute(
             static::class,
             ...$payloads
         );
@@ -57,7 +57,7 @@ trait BaseData
 
     public static function withoutMagicalCreationFrom(mixed ...$payloads): static
     {
-        return app(DataFromSomethingResolver::class)->withoutMagicalCreation()->execute(
+        return app(DataFromSomethingResolver::class)->reset()->withoutMagicalCreation()->execute(
             static::class,
             ...$payloads
         );

--- a/src/LaravelDataServiceProvider.php
+++ b/src/LaravelDataServiceProvider.php
@@ -4,6 +4,8 @@ namespace Spatie\LaravelData;
 
 use Spatie\LaravelData\Commands\DataMakeCommand;
 use Spatie\LaravelData\Contracts\BaseData;
+use Spatie\LaravelData\Resolvers\DataFromArrayResolver;
+use Spatie\LaravelData\Resolvers\DataFromSomethingResolver;
 use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelData\Support\VarDumper\VarDumperManager;
 use Spatie\LaravelPackageTools\Package;
@@ -24,6 +26,14 @@ class LaravelDataServiceProvider extends PackageServiceProvider
         $this->app->singleton(
             DataConfig::class,
             fn () => new DataConfig(config('data'))
+        );
+
+        $this->app->singleton(
+            DataFromSomethingResolver::class,
+            fn () => new DataFromSomethingResolver(
+                app(DataConfig::class),
+                app(DataFromArrayResolver::class),
+            ),
         );
 
         /** @psalm-suppress UndefinedInterfaceMethod */

--- a/src/Resolvers/DataFromSomethingResolver.php
+++ b/src/Resolvers/DataFromSomethingResolver.php
@@ -18,6 +18,14 @@ class DataFromSomethingResolver
     ) {
     }
 
+    public function reset(): self
+    {
+        $this->withoutMagicalCreation = false;
+        $this->ignoredMagicalMethods = [];
+
+        return $this;
+    }
+
     public function withoutMagicalCreation(bool $withoutMagicalCreation = true): self
     {
         $this->withoutMagicalCreation = $withoutMagicalCreation;

--- a/tests/Resolvers/DataFromSomethingResolverTest.php
+++ b/tests/Resolvers/DataFromSomethingResolverTest.php
@@ -128,10 +128,10 @@ it('can create data ignoring certain magical methods', function () {
     }
 
     expect(
-        app(DataFromSomethingResolver::class)->ignoreMagicalMethods('fromArray')->execute(DummyA::class, ['hash_id' => 1, 'name' => 'Taylor'])
+        app(DataFromSomethingResolver::class)->reset()->ignoreMagicalMethods('fromArray')->execute(DummyA::class, ['hash_id' => 1, 'name' => 'Taylor'])
     )->toEqual(new DummyA(null, 'Taylor'));
 
     expect(
-        app(DataFromSomethingResolver::class)->execute(DummyA::class, ['hash_id' => 1, 'name' => 'Taylor'])
+        app(DataFromSomethingResolver::class)->reset()->execute(DummyA::class, ['hash_id' => 1, 'name' => 'Taylor'])
     )->toEqual(new DummyA(1, 'Taylor'));
 });


### PR DESCRIPTION
# Description
When creating a large amount of Data objects in a single request cycle the repeated calls to `app()` that are used to resolve the dependencies for the `DataFromSomethingResolver` causes a performance bottleneck.

# Implementation

This PR registers the `DataFromSomthingResolver` as a singleton in the service provider and adds a `reset()` method on the class so that the internal state can be reset. This allows it to continue working when being called by either `from()` or  `withoutMagicalCreationFrom()`. This decreases the overall calls to the `app()` helper function (and subsequently reduces the downstream calls to other "magic methods" that resolve the dependancies) when instantiating a new `Data` object and increases the performance.
# Tests

Run the automated test suite and ensure that it completes successfully.
## Performance Tests

Using xdebug profiling and webgrind to to analyze the results I have seen an improvement in speed of approximately 12-18% when creating 30K instances of a Data object.  I have provided the Data object class `ZipCode` and customer caster class `ZipCaster`, as well as the sample dataset that was used for the testing. I have also provided a test script that was used to run the test 10 times and show the average.

[zips.txt.zip](https://github.com/spatie/laravel-data/files/11137440/zips.txt.zip)
[ziptest.php.zip](https://github.com/spatie/laravel-data/files/11137527/ziptest.php.zip)
[ZipCode.php.zip](https://github.com/spatie/laravel-data/files/11137531/ZipCode.php.zip)
[ZipCaster.php.zip](https://github.com/spatie/laravel-data/files/11137534/ZipCaster.php.zip)

Unzip and move the `zips.txt`.
Make sure the `ziptest.php` script has the right path to find the `zips.txt` file and run the script.
```php
php ziptest.php
```

