### PR TITLE
Allow to fetch union data properties in unified way

### DIFF
--- a/src/Lazy.php
+++ b/src/Lazy.php
@@ -46,4 +46,14 @@ abstract class Lazy
     {
         return $this->defaultIncluded ?? false;
     }
+
+    public function __get(string $name): mixed
+    {
+        return $this->resolve()->$name;
+    }
+
+    public function __call(string $name, array $arguments): mixed
+    {
+        return call_user_func_array([$this->resolve(), $name], $arguments);
+    }
 }

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -58,6 +58,7 @@ use Spatie\LaravelData\Tests\Fakes\Transformers\ConfidentialDataCollectionTransf
 use Spatie\LaravelData\Tests\Fakes\Transformers\ConfidentialDataTransformer;
 use Spatie\LaravelData\Tests\Fakes\Transformers\StringToUpperTransformer;
 use Spatie\LaravelData\Tests\Fakes\UlarData;
+use Spatie\LaravelData\Tests\Fakes\UnionData;
 use Spatie\LaravelData\Transformers\DateTimeInterfaceTransformer;
 use Spatie\LaravelData\WithData;
 
@@ -2277,4 +2278,32 @@ it('during the serialization process some properties are thrown away', function 
     expect($invaded->_only)->toBeEmpty();
     expect($invaded->_except)->toBeEmpty();
     expect($invaded->_wrap)->toBeNull();
+});
+
+it('can fetch lazy union data', function () {
+    $data = UnionData::from(1);
+
+    expect($data->id)
+        ->toBe(1)
+        ->and($data->simple->string)
+        ->toBe('A')
+        ->and($data->dataCollection->toCollection()->pluck('string')->toArray())
+        ->toBe(['B', 'C'])
+        ->and($data->fakeModel->string)
+        ->toBe('lazy')
+    ;
+});
+
+it('can fetch non-lazy union data', function () {
+    $data = UnionData::from('A');
+
+    expect($data->id)
+        ->toBe(1)
+        ->and($data->simple->string)
+        ->toBe('A')
+        ->and($data->dataCollection->toCollection()->pluck('string')->toArray())
+        ->toBe(['B', 'C'])
+        ->and($data->fakeModel->string)
+        ->toBe('non-lazy')
+    ;
 });

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -2283,27 +2283,17 @@ it('during the serialization process some properties are thrown away', function 
 it('can fetch lazy union data', function () {
     $data = UnionData::from(1);
 
-    expect($data->id)
-        ->toBe(1)
-        ->and($data->simple->string)
-        ->toBe('A')
-        ->and($data->dataCollection->toCollection()->pluck('string')->toArray())
-        ->toBe(['B', 'C'])
-        ->and($data->fakeModel->string)
-        ->toBe('lazy')
-    ;
+    expect($data->id)->toBe(1);
+    expect($data->simple->string)->toBe('A');
+    expect($data->dataCollection->toCollection()->pluck('string')->toArray())->toBe(['B', 'C']);
+    expect($data->fakeModel->string)->toBe('lazy');
 });
 
 it('can fetch non-lazy union data', function () {
     $data = UnionData::from('A');
 
-    expect($data->id)
-        ->toBe(1)
-        ->and($data->simple->string)
-        ->toBe('A')
-        ->and($data->dataCollection->toCollection()->pluck('string')->toArray())
-        ->toBe(['B', 'C'])
-        ->and($data->fakeModel->string)
-        ->toBe('non-lazy')
-    ;
+    expect($data->id)->toBe(1);
+    expect($data->simple->string)->toBe('A');
+    expect($data->dataCollection->toCollection()->pluck('string')->toArray())->toBe(['B', 'C']);
+    expect($data->fakeModel->string)->toBe('non-lazy');
 });

--- a/tests/Fakes/UnionData.php
+++ b/tests/Fakes/UnionData.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\DataCollection;
+use Spatie\LaravelData\Lazy;
+use Spatie\LaravelData\Tests\Fakes\Models\FakeModel;
+
+class UnionData extends Data
+{
+    public function __construct(
+        public int $id,
+        public SimpleData|Lazy $simple,
+        #[DataCollectionOf(SimpleData::class)]
+        public DataCollection|Lazy $dataCollection,
+        public FakeModel|Lazy $fakeModel,
+    ) {
+    }
+
+    public static function fromInt(int $id): self
+    {
+        return new self(
+            id: $id,
+            simple: Lazy::create(fn () => SimpleData::from('A')),
+            dataCollection: Lazy::create(fn () => SimpleData::collection(['B', 'C'])),
+            fakeModel: Lazy::create(fn () => FakeModel::factory()->create([
+                'string' => 'lazy',
+            ])),
+        );
+    }
+
+    public static function fromString(string $name): self
+    {
+        return new self(
+            id: 1,
+            simple: SimpleData::from($name),
+            dataCollection: SimpleData::collection(['B', 'C']),
+            fakeModel: FakeModel::factory()->create([
+                'string' => 'non-lazy',
+            ]),
+        );
+    }
+}


### PR DESCRIPTION
This PR came from the discussion #379 . It allows to fetch lazy and non-lazy properties in the same way (regardless the fact how DTO was created - lazy or not).