### PR TITLE
Fix the behavior of the resolvePropertyValue method for nested value as an array that a part of AllTreeNode

### DIFF
--- a/src/Transformers/DataTransformer.php
+++ b/src/Transformers/DataTransformer.php
@@ -199,12 +199,16 @@ class DataTransformer
             return null;
         }
 
-        if (is_array($value) && ($trees->only instanceof AllTreeNode || $trees->only instanceof PartialTreeNode)) {
-            $value = Arr::only($value, $trees->only->getFields());
-        }
+        if (is_array($value)) {
+            if ($trees->only instanceof PartialTreeNode) {
+                $value = Arr::only($value, $trees->only->getFields());
+            }
 
-        if (is_array($value) && ($trees->except instanceof AllTreeNode || $trees->except instanceof PartialTreeNode)) {
-            $value = Arr::except($value, $trees->except->getFields());
+            if ($trees->except instanceof AllTreeNode) {
+                $value = [];
+            } elseif ($trees->except instanceof PartialTreeNode) {
+                $value = Arr::except($value, $trees->except->getFields());
+            }
         }
 
         if ($transformer = $this->resolveTransformerForValue($property, $value)) {


### PR DESCRIPTION
It fixes the situation when it needs to apply the `only` or `except` operation for a nested array of the nested property. 
For example:

```php
AlbumData::from(Album::first())->only('songs.artist.photo.*'); 
```

Here `photo` is an array property of `artist`.

Look at these lines:
https://github.com/spatie/laravel-data/blob/7f424af3dfb912845b8f0db48dd69e02fd636c57/src/Transformers/DataTransformer.php#L202-L204

As you can notice the result of `$value` will be `[]` always because `$trees->only->getFields()` will return `['*']` for AllTreeNode.

```php
$value = Arr::only($value, $trees->only->getFields()); 
```

https://github.com/spatie/laravel-data/blob/7f424af3dfb912845b8f0db48dd69e02fd636c57/src/Support/TreeNodes/AllTreeNode.php#L27-L30

Unfortunately, this fix does not solve the problem in a case like this: 
```php
AlbumData::from(Album::first())->only('songs.artist.photo'); // Without .* at the end 
```
because here on line 25 directive will be as `photo` without `.*` ending. 
https://github.com/spatie/laravel-data/blob/7f424af3dfb912845b8f0db48dd69e02fd636c57/src/Support/PartialsParser.php#L25-L32

So it requires improving some logic maybe by rewriting `execute()` method of `PartialsParser`.