### PR TITLE
Add merge method to Data Collections

### DIFF
--- a/src/Concerns/EnumerableMethods.php
+++ b/src/Concerns/EnumerableMethods.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelData\Concerns;
 
 use Spatie\LaravelData\Contracts\DataCollectable;
+use Spatie\LaravelData\DataCollection;
 
 /**
  * @template TKey of array-key
@@ -124,5 +125,19 @@ trait EnumerableMethods
     public function sole(callable|string|null $key = null, mixed $operator = null, mixed $value = null)
     {
         return $this->items->sole(...func_get_args());
+    }
+
+    /**
+     * @param DataCollection $collection
+     *
+     * @return static
+     */
+    public function merge(DataCollection $collection): static
+    {
+        $cloned = clone $this;
+
+        $cloned->items = $cloned->items->merge($collection->items);
+
+        return $cloned;
     }
 }

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -480,6 +480,20 @@ it('can return a sole data object without specifying an operator', function () {
         ->toEqual($filtered->string);
 });
 
+test('a collection can be merged', function () {
+    $collectionA = SimpleData::collection(['A', 'B']);
+    $collectionB = SimpleData::collection(['C', 'D']);
+
+    $filtered = $collectionA->merge($collectionB)->toArray();
+
+    expect([
+        ['string' => 'A'],
+        ['string' => 'B'],
+        ['string' => 'C'],
+        ['string' => 'D'],
+    ])
+        ->toMatchArray($filtered);
+});
 
 it('can serialize and unserialize a data collection', function () {
     $collection = SimpleData::collection(['A', 'B']);


### PR DESCRIPTION
There is no merge method to Data Collections, and I think is quite useful. I'm adding it following the patters of the other methods.