### PR TITLE
add ability to instantiate an eloquent cast when null value using null database values

### DIFF
--- a/docs/advanced-usage/eloquent-casting.md
+++ b/docs/advanced-usage/eloquent-casting.md
@@ -74,3 +74,57 @@ Artist::create([
     ],
 ]);
 ```
+
+## Using defaults for null database values
+
+By default, if a database value is `null`, then the model attribute will also be `null`. However, sometimes you might want to instantiate the attribute with some default values.
+
+To achieve this, you may provide an additional `nullable` [Cast Parameter](https://laravel.com/docs/eloquent-mutators#cast-parameters) to ensure the caster gets instantiated.
+
+```php
+class Song extends Model
+{
+    protected $casts = [
+        'artist' => ArtistData::class . ':nullable',
+    ];
+}
+```
+
+This will ensure that the `ArtistData` caster is instantiated even when the `artist` attribute in the database is `null`.
+
+You may then specify some default values in the cast which will be used instead.
+
+```php
+class ArtistData extends Data 
+{
+    public string $name = 'Default name';
+}
+```
+
+```php
+Song::findOrFail($id)->artist->name; // 'Default name'
+```
+
+### Nullable collections
+
+You can also use the `nullable` argument in the case where you _always_ want a `DataCollection` to be returned.
+
+The first argument (after `:`) should always be the data class to be used with the `DataCollection`, but you can add `nullable` as a comma separated second argument.
+
+```php
+class Artist extends Model
+{
+    protected $casts = [
+        'songs' => DataCollection::class.':'.SongData::class.',nullable',
+    ];
+}
+```
+
+```php
+$artist = Artist::create([
+    'songs' => null
+]);
+
+$artist->songs;             // DataCollection
+$artist->songs->count();    // 0
+```

--- a/src/Concerns/TransformableData.php
+++ b/src/Concerns/TransformableData.php
@@ -28,6 +28,6 @@ trait TransformableData
 
     public static function castUsing(array $arguments)
     {
-        return new DataEloquentCast(static::class);
+        return new DataEloquentCast(static::class, $arguments);
     }
 }

--- a/src/DataCollection.php
+++ b/src/DataCollection.php
@@ -139,10 +139,10 @@ class DataCollection implements DataCollectable, ArrayAccess
 
     public static function castUsing(array $arguments)
     {
-        if (count($arguments) !== 1) {
+        if (count($arguments) < 1) {
             throw CannotCastData::dataCollectionTypeRequired();
         }
 
-        return new DataCollectionEloquentCast(current($arguments), static::class);
+        return new DataCollectionEloquentCast($arguments[0], static::class, array_slice($arguments, 1));
     }
 }

--- a/src/Support/EloquentCasts/DataCollectionEloquentCast.php
+++ b/src/Support/EloquentCasts/DataCollectionEloquentCast.php
@@ -14,11 +14,16 @@ class DataCollectionEloquentCast implements CastsAttributes
     public function __construct(
         protected string $dataClass,
         protected string $dataCollectionClass = DataCollection::class,
+        protected array $arguments = []
     ) {
     }
 
     public function get($model, string $key, $value, array $attributes): ?DataCollection
     {
+        if ($value === null && in_array('nullable', $this->arguments)) {
+            $value = '[]';
+        }
+
         if ($value === null) {
             return null;
         }

--- a/src/Support/EloquentCasts/DataEloquentCast.php
+++ b/src/Support/EloquentCasts/DataEloquentCast.php
@@ -11,12 +11,18 @@ class DataEloquentCast implements CastsAttributes
 {
     public function __construct(
         /** @var class-string<\Spatie\LaravelData\Contracts\BaseData> $dataClass */
-        protected string $dataClass
+        protected string $dataClass,
+        /** @var string[] $arguments */
+        protected array $arguments = []
     ) {
     }
 
     public function get($model, string $key, $value, array $attributes): ?BaseData
     {
+        if (is_null($value) && in_array('nullable', $this->arguments)) {
+            $value = '{}';
+        }
+
         if ($value === null) {
             return null;
         }

--- a/tests/Fakes/Models/DummyModelWithNullableCasts.php
+++ b/tests/Fakes/Models/DummyModelWithNullableCasts.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\LaravelData\Tests\Fakes\SimpleData;
+use Spatie\LaravelData\Tests\Fakes\SimpleDataCollection;
+use Spatie\LaravelData\Tests\Fakes\SimpleDataWithDefaultValue;
+
+class DummyModelWithNullableCasts extends Model
+{
+    protected $casts = [
+        'data' => SimpleDataWithDefaultValue::class.':nullable',
+        'data_collection' => SimpleDataCollection::class.':'.SimpleData::class.',nullable',
+    ];
+
+    protected $table = 'dummy_model_with_casts';
+
+    public $timestamps = false;
+}

--- a/tests/Fakes/SimpleDataWithDefaultValue.php
+++ b/tests/Fakes/SimpleDataWithDefaultValue.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Data;
+
+class SimpleDataWithDefaultValue extends Data
+{
+    public function __construct(
+        public string $string = 'default'
+    ) {
+    }
+
+    public static function fromString(string $string): self
+    {
+        return new self($string);
+    }
+}

--- a/tests/Support/EloquentCasts/DataCollectionEloquentCastTest.php
+++ b/tests/Support/EloquentCasts/DataCollectionEloquentCastTest.php
@@ -5,7 +5,9 @@ use Illuminate\Support\Facades\DB;
 use function Pest\Laravel\assertDatabaseHas;
 
 use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithCasts;
+
 use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithCustomCollectionCasts;
+use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithNullableCasts;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
 use Spatie\LaravelData\Tests\Fakes\SimpleDataCollection;
 
@@ -117,4 +119,17 @@ it('retrieves custom data collection', function () {
             new SimpleData('World'),
         ]
     ));
+});
+
+it('loads a custom data collection when nullable argument used and value is null in database', function () {
+    DB::table('dummy_model_with_casts')->insert([
+        'data' => null,
+    ]);
+
+    /** @var \Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithNullableCasts $model */
+    $model = DummyModelWithNullableCasts::first();
+
+    expect($model->data_collection)
+        ->toBeInstanceOf(SimpleDataCollection::class)
+        ->toBeEmpty();
 });

--- a/tests/Support/EloquentCasts/DataEloquentCastTest.php
+++ b/tests/Support/EloquentCasts/DataEloquentCastTest.php
@@ -5,7 +5,11 @@ use Illuminate\Support\Facades\DB;
 use function Pest\Laravel\assertDatabaseHas;
 
 use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithCasts;
+
+use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithNullableCasts;
+
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
+use Spatie\LaravelData\Tests\Fakes\SimpleDataWithDefaultValue;
 
 beforeEach(function () {
     DummyModelWithCasts::migrate();
@@ -61,4 +65,17 @@ it('can load null as a value', function () {
     $model = DummyModelWithCasts::first();
 
     expect($model->data)->toBeNull();
+});
+
+it('loads a cast object when nullable argument used and value is null in database', function () {
+    DB::table('dummy_model_with_casts')->insert([
+        'data' => null,
+    ]);
+
+    /** @var \Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithNullableCasts $model */
+    $model = DummyModelWithNullableCasts::first();
+
+    expect($model->data)
+        ->toBeInstanceOf(SimpleDataWithDefaultValue::class)
+        ->string->toEqual('default');
 });


### PR DESCRIPTION
Addresses situation when you may want the cast object to instantiated even when the database value is null.

The current `DataEloquentCast` get() method returns `null` if the database value is `null`.

This PR introduces a "nullable" [Cast Parameter](https://laravel.com/docs/eloquent-mutators#cast-parameters) that will ensure the Caster gets instantiated rather than return null. The nullable parameter was inspired by the [Spatie Laravel Enum package](https://github.com/spatie/laravel-enum#model-attribute-casting) that uses the same parameter, albeit for slightly different purposes.

The nullable parameter name can obviously be changed if preferred, but it was also applied to good effect in the [jessarcher/laravel-castable-data-transfer-object](https://github.com/jessarcher/laravel-castable-data-transfer-object/pull/13) package which extends the `spatie/data-transfer-object` package.

I am currently migrating from `spatie/data-transfer-object` to `spatie/laravel-data` on a number of projects. I have a few use cases where this would be incredibly useful, particularly when working with Livewire, and running into issues using @entangle not having any (default) values. 