### PR TITLE
Add missing constructor parameters to error message

### DIFF
--- a/src/Exceptions/CannotCreateData.php
+++ b/src/Exceptions/CannotCreateData.php
@@ -5,6 +5,7 @@ namespace Spatie\LaravelData\Exceptions;
 use Exception;
 use Illuminate\Support\Collection;
 use Spatie\LaravelData\Support\DataClass;
+use Spatie\LaravelData\Support\DataProperty;
 use Throwable;
 
 class CannotCreateData extends Exception
@@ -28,7 +29,12 @@ class CannotCreateData extends Exception
         $message = "Could not create `{$dataClass->name}`: the constructor requires {$dataClass->constructorMethod->parameters->count()} parameters, {$parameters->count()} given.";
 
         if ($parameters->isNotEmpty()) {
-            $message .= " Parameters given: {$parameters->keys()->join(', ')}.";
+            $message .= " Parameters given: {$parameters->keys()->join(', ')}. Parameters missing: {$dataClass
+                ->constructorMethod
+                ->parameters
+                ->reject(fn (DataProperty $parameter) => $parameters->has($parameter->name))
+                ->map(fn (DataProperty $parameter) => $parameter->name)
+                ->join(', ')}";
         }
 
         return new self($message, previous: $previous);


### PR DESCRIPTION
Currently only the given parameters are displayed when failing to create a data object. But if a Data Object has a lot of parameters it is hard to find the missing property. 

This PR suggests displaying the missing constructor property names as well in the error message.