### PR TITLE
Changing Request to FormRequest

### DIFF
--- a/docs/as-a-data-transfer-object/creating-a-data-object.md
+++ b/docs/as-a-data-transfer-object/creating-a-data-object.md
@@ -263,7 +263,7 @@ Song::firstOrFail($id)->getData(); // A SongData object
 We can do the same with a FormRequest, we don't use a property here to define the data class but use a method instead:
 
 ```php
-class SongRequest extends Request
+class SongRequest extends FormRequest
 {
     use WithData;
     


### PR DESCRIPTION
This small detail threw me off into a rabbit hole for hours, trying to extend `Illuminate\Http\Request` 😵

By letting the code example extend from `FormRequest` instead, it is made very explicit how important this small detail is.