### PR TITLE
[fix] move make:data command options to config

### DIFF
--- a/config/data.php
+++ b/config/data.php
@@ -68,4 +68,16 @@ return [
      * which will only enable the caster locally.
      */
     'var_dumper_caster_mode' => 'development',
+
+    /*
+     * This configuration property is used to override default namespace to store data objects.
+     * The --namespace option has the higher priority.
+     */
+    'namespace' => 'Data',
+
+    /*
+     * This configuration property is used for override default suffix in data objects class names.
+     * The --suffix option has higher priority.
+     */
+    'suffix' => 'Data',
 ];

--- a/src/Commands/DataMakeCommand.php
+++ b/src/Commands/DataMakeCommand.php
@@ -53,14 +53,14 @@ class DataMakeCommand extends GeneratorCommand
                 'N',
                 InputOption::VALUE_REQUIRED,
                 'The namespace (under \App) to place this Data class.',
-                'Data',
+                config('data.namespace', 'Data'),
             ],
             [
                 'suffix',
                 's',
                 InputOption::VALUE_REQUIRED,
                 'Suffix the class with this value.',
-                'Data',
+                config('data.suffix', 'Data'),
             ],
             [
                 'force',


### PR DESCRIPTION
This feature should make the creation of data objects classes more comfortable.
It helps to avoid long spamming `--namespace="..."` option.