### PR TITLE
Fixed target namespace when creating files with Laravel Idea

### DIFF
--- a/ide.json
+++ b/ide.json
@@ -41,7 +41,7 @@
             "classSuffix": "Data",
             "files": [
                 {
-                    "directory": "/app/Data",
+                    "appNamespace": "Data",
                     "name": "${INPUT_CLASS|className|upperCamelCase}.php",
                     "template": {
                         "type": "stub",
@@ -61,7 +61,7 @@
             "classSuffix": "Cast",
             "files": [
                 {
-                    "directory": "/app/Data/Casts",
+                    "appNamespace": "Data\\Casts",
                     "name": "${INPUT_CLASS|className|upperCamelCase}.php",
                     "template": {
                         "type": "stub",
@@ -81,7 +81,7 @@
             "classSuffix": "Transformer",
             "files": [
                 {
-                    "directory": "/app/Data/Transformers",
+                    "appNamespace": "Data\\Transformers",
                     "name": "${INPUT_CLASS|className|upperCamelCase}.php",
                     "template": {
                         "type": "stub",
@@ -101,7 +101,7 @@
             "classSuffix": "Rule",
             "files": [
                 {
-                    "directory": "/app/Data/Rules",
+                    "appNamespace": "Data\\Rules",
                     "name": "${INPUT_CLASS|className|upperCamelCase}.php",
                     "template": {
                         "type": "stub",


### PR DESCRIPTION
If you specify a target directory, such as "app/Data", the files will always be created in this directory, even if the main namespace of the application or package is in another folder, such as "src":

```
app
  Data
    SomeData
src
  Console
  Enums
```

Replacing the target directory with a namespace parameter will allow the Laravel Idea plugin to create files inside the application's Namespace:

```
src
  Console
  Data
    SomeData
  Enums
```

![Untitled Project](https://github.com/spatie/laravel-data/assets/10347617/3dd835c4-0e7b-4d25-af8a-dd835a8541f4)
