### PR TITLE
Allowing collection to be created passing null

### DIFF
--- a/src/Concerns/BaseData.php
+++ b/src/Concerns/BaseData.php
@@ -80,7 +80,7 @@ trait BaseData
             ->through(CastPropertiesDataPipe::class);
     }
 
-    public static function collection(Enumerable|array|AbstractPaginator|Paginator|AbstractCursorPaginator|CursorPaginator|DataCollection $items): DataCollection|CursorPaginatedDataCollection|PaginatedDataCollection
+    public static function collection(Enumerable|array|AbstractPaginator|Paginator|AbstractCursorPaginator|CursorPaginator|DataCollection|null $items): DataCollection|CursorPaginatedDataCollection|PaginatedDataCollection
     {
         if ($items instanceof Paginator || $items instanceof AbstractPaginator) {
             return new (static::$_paginatedCollectionClass)(static::class, $items);

--- a/src/Contracts/BaseData.php
+++ b/src/Contracts/BaseData.php
@@ -28,7 +28,7 @@ interface BaseData
      *
      * @return ($items is \Illuminate\Pagination\AbstractCursorPaginator|\Illuminate\Pagination\CursorPaginator ? \Spatie\LaravelData\CursorPaginatedDataCollection<array-key, static> : ($items is \Illuminate\Pagination\Paginator|\Illuminate\Pagination\AbstractPaginator ? \Spatie\LaravelData\PaginatedDataCollection<array-key, static> : \Spatie\LaravelData\DataCollection<array-key, static>))
      */
-    public static function collection(Enumerable|array|AbstractPaginator|Paginator|AbstractCursorPaginator|CursorPaginator|DataCollection $items): DataCollection|CursorPaginatedDataCollection|PaginatedDataCollection;
+    public static function collection(Enumerable|array|AbstractPaginator|Paginator|AbstractCursorPaginator|CursorPaginator|DataCollection|null $items): DataCollection|CursorPaginatedDataCollection|PaginatedDataCollection;
 
     public static function normalizers(): array;
 

--- a/src/DataCollection.php
+++ b/src/DataCollection.php
@@ -45,9 +45,9 @@ class DataCollection implements DataCollectable, ArrayAccess
      */
     public function __construct(
         public readonly string $dataClass,
-        Enumerable|array|DataCollection $items
+        Enumerable|array|DataCollection|null $items
     ) {
-        if (is_array($items)) {
+        if (is_array($items) || is_null($items)) {
             $items = new Collection($items);
         }
 

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -529,3 +529,10 @@ it('during the serialization process some properties are thrown away', function 
     expect($invaded->_except)->toBeEmpty();
     expect($invaded->_wrap)->toBeNull();
 });
+
+it('can create an empty collection passing null', function () {
+    $collection = SimpleData::collection(null);
+
+    expect($collection)->toBeInstanceOf(DataCollection::class);
+    expect($collection->toJson())->toBe('[]');
+});


### PR DESCRIPTION
Currently if you call `Data::collection(null)`, it breaks... it's useful for when you are doing something like `Data::collection($var?->collection)` and avoiding doing and if or `Data::collection($var?->collection ?? [])`...

Also keeps consistent with Laravel's Collection, which you can create passing null and will just create an empty collection.