### PR TITLE
Fix validation docs link to unique rule in Laravel docs

### DIFF
--- a/docs/advanced-usage/validation-attributes.md
+++ b/docs/advanced-usage/validation-attributes.md
@@ -857,7 +857,7 @@ public string $closure;
 
 ### Unique
 
-[Docs](https://laravel.com/docs/9.x/validation#rule-unqiue)
+[Docs](https://laravel.com/docs/9.x/validation#rule-unique)
 
 ```php
 #[Unique('users')]


### PR DESCRIPTION
Fixes a small typo in the docs for the link to the **unique** rule in the Laravel docs.