### PR TITLE
Update type

### DIFF
--- a/src/Concerns/EnumerableMethods.php
+++ b/src/Concerns/EnumerableMethods.php
@@ -29,9 +29,11 @@ trait EnumerableMethods
     }
 
     /**
-     * @param callable(TValue, TKey): TValue $map
+     * @template TMapValue
      *
-     * @return static
+     * @param  callable(TValue, TKey): TMapValue  $callback
+     *
+     * @return static<TKey, TMapValue>
      */
     public function map(callable $map): static
     {


### PR DESCRIPTION
It should be possible to re-map a collection of models to a collection of arrays with something like

```php
$collection->map(fn (Model $item) => ['id' => $item->id])
```

But the current type hit expects `->map()` to return the same typed collection as the input. The updated type infers the returned type from the closure return.

This is the same type definition that Laravel's collection `->map()` uses, https://github.com/laravel/framework/blob/85ad68cb0bcb5143e0e915098097c6d23ea22e7e/src/Illuminate/Collections/Collection.php#L767-L774