### PR TITLE
Add Declined and DeclinedIf validation attributes

### DIFF
--- a/docs/advanced-usage/validation-attributes.md
+++ b/docs/advanced-usage/validation-attributes.md
@@ -251,6 +251,24 @@ public Carbon $closure;
 public Carbon $closure; 
 ```
 
+### Declined
+
+[Docs](https://laravel.com/docs/9.x/validation#rule-declined)
+
+```php
+#[Declined]
+public bool $closure; 
+```
+
+### DeclinedIf
+
+[Docs](https://laravel.com/docs/9.x/validation#rule-declined-if)
+
+```php
+#[DeclinedIf('other_field', 'equals_this')]
+public bool $closure; 
+```
+
 ### Different
 
 [Docs](https://laravel.com/docs/9.x/validation#rule-different)

--- a/src/Attributes/Validation/Declined.php
+++ b/src/Attributes/Validation/Declined.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\LaravelData\Attributes\Validation;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+class Declined extends StringValidationAttribute
+{
+    public static function keyword(): string
+    {
+        return 'declined';
+    }
+
+    public function parameters(): array
+    {
+        return [];
+    }
+}

--- a/src/Attributes/Validation/DeclinedIf.php
+++ b/src/Attributes/Validation/DeclinedIf.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Spatie\LaravelData\Attributes\Validation;
+
+use Attribute;
+use BackedEnum;
+use Spatie\LaravelData\Support\Validation\References\FieldReference;
+use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+class DeclinedIf extends StringValidationAttribute
+{
+    protected FieldReference $field;
+
+    public function __construct(
+        string|FieldReference $field,
+        protected string|bool|int|float|BackedEnum|RouteParameterReference $value,
+    ) {
+        $this->field = $this->parseFieldReference($field);
+    }
+
+    public static function keyword(): string
+    {
+        return 'declined_if';
+    }
+
+    public function parameters(): array
+    {
+        return [$this->field, $this->value];
+    }
+
+    public static function create(string ...$parameters): static
+    {
+        return parent::create(
+            $parameters[0],
+            self::parseBooleanValue($parameters[1]),
+        );
+    }
+}

--- a/src/Support/Validation/ValidationRuleFactory.php
+++ b/src/Support/Validation/ValidationRuleFactory.php
@@ -23,6 +23,8 @@ use Spatie\LaravelData\Attributes\Validation\CurrentPassword;
 use Spatie\LaravelData\Attributes\Validation\Date;
 use Spatie\LaravelData\Attributes\Validation\DateEquals;
 use Spatie\LaravelData\Attributes\Validation\DateFormat;
+use Spatie\LaravelData\Attributes\Validation\Declined;
+use Spatie\LaravelData\Attributes\Validation\DeclinedIf;
 use Spatie\LaravelData\Attributes\Validation\Different;
 use Spatie\LaravelData\Attributes\Validation\Digits;
 use Spatie\LaravelData\Attributes\Validation\DigitsBetween;
@@ -122,6 +124,8 @@ class ValidationRuleFactory
             Date::keyword() => Date::class,
             DateEquals::keyword() => DateEquals::class,
             DateFormat::keyword() => DateFormat::class,
+            Declined::keyword() => Declined::class,
+            DeclinedIf::keyword() => DeclinedIf::class,
             Different::keyword() => Different::class,
             Digits::keyword() => Digits::class,
             DigitsBetween::keyword() => DigitsBetween::class,

--- a/tests/Datasets/Attributes/RulesDataset.php
+++ b/tests/Datasets/Attributes/RulesDataset.php
@@ -26,6 +26,8 @@ use Spatie\LaravelData\Attributes\Validation\CurrentPassword;
 use Spatie\LaravelData\Attributes\Validation\Date;
 use Spatie\LaravelData\Attributes\Validation\DateEquals;
 use Spatie\LaravelData\Attributes\Validation\DateFormat;
+use Spatie\LaravelData\Attributes\Validation\Declined;
+use Spatie\LaravelData\Attributes\Validation\DeclinedIf;
 use Spatie\LaravelData\Attributes\Validation\Different;
 use Spatie\LaravelData\Attributes\Validation\Digits;
 use Spatie\LaravelData\Attributes\Validation\DigitsBetween;
@@ -115,6 +117,7 @@ dataset('attributes', function () {
     yield from dateEqualsAttributes();
     yield from dimensionsAttributes();
     yield from distinctAttributes();
+    yield from declinedIfAttributes();
     yield from emailAttributes();
     yield from endsWithAttributes();
     yield from existsAttributes();
@@ -184,6 +187,12 @@ dataset('attributes', function () {
         attribute: new DateFormat('Y-m-d'),
         expected: 'date_format:Y-m-d',
     );
+
+    yield fixature(
+        attribute: new Declined(),
+        expected: 'declined',
+    );
+
 
     yield fixature(
         attribute: new Different('field'),
@@ -583,6 +592,35 @@ function distinctAttributes(): Generator
         attribute: new Distinct('fake'),
         expected: '',
         exception: CannotBuildValidationRule::class
+    );
+}
+
+function declinedIfAttributes(): Generator
+{
+    yield fixature(
+        attribute: new DeclinedIf('value', 'string'),
+        expected: 'declined_if:value,string',
+    );
+
+    yield fixature(
+        attribute: new DeclinedIf('value', true),
+        expected: 'declined_if:value,true',
+    );
+
+    yield fixature(
+        attribute: new DeclinedIf('value', 42),
+        expected: 'declined_if:value,42',
+    );
+
+    yield fixature(
+        attribute: new DeclinedIf('value', 3.14),
+        expected: 'declined_if:value,3.14',
+    );
+
+    yield fixature(
+        attribute: new DeclinedIf('value', DummyBackedEnum::FOO),
+        expected: 'declined_if:value,foo',
+        expectCreatedAttribute: new DeclinedIf('value', 'foo')
     );
 }
 


### PR DESCRIPTION
Adds the **Declined** and the **DeclinedIf** if validation rules.

The implementation strategy is equal to the [Accepted](https://github.com/spatie/laravel-data/blob/main/src/Attributes/Validation/Accepted.php) and [AcceptedIf](https://github.com/spatie/laravel-data/blob/main/src/Attributes/Validation/AcceptedIf.php).

As part of #571 