### PR TITLE
feat: support `Arrayable` when casting to `DataCollection`

### DIFF
--- a/src/Support/EloquentCasts/DataCollectionEloquentCast.php
+++ b/src/Support/EloquentCasts/DataCollectionEloquentCast.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelData\Support\EloquentCasts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Support\Arrayable;
 use Spatie\LaravelData\Contracts\BaseData;
 use Spatie\LaravelData\Contracts\BaseDataCollectable;
 use Spatie\LaravelData\Contracts\TransformableData;
@@ -46,6 +47,10 @@ class DataCollectionEloquentCast implements CastsAttributes
 
         if ($value instanceof BaseDataCollectable && $value instanceof TransformableData) {
             $value = $value->all();
+        }
+
+        if ($value instanceof Arrayable) {
+            $value = $value->toArray();
         }
 
         if (! is_array($value)) {

--- a/tests/Support/EloquentCasts/DataCollectionEloquentCastTest.php
+++ b/tests/Support/EloquentCasts/DataCollectionEloquentCastTest.php
@@ -47,6 +47,22 @@ it('can save a data object as an array', function () {
     ]);
 });
 
+it('can save a data object as an array from a collection', function () {
+    DummyModelWithCasts::create([
+        'data_collection' => collect([
+            ['string' => 'Hello'],
+            ['string' => 'World'],
+        ]),
+    ]);
+
+    assertDatabaseHas(DummyModelWithCasts::class, [
+        'data_collection' => json_encode([
+            ['string' => 'Hello'],
+            ['string' => 'World'],
+        ]),
+    ]);
+});
+
 it('can load a data object', function () {
     DB::table('dummy_model_with_casts')->insert([
         'data_collection' => json_encode([


### PR DESCRIPTION
This pull request adds support for casting `Collection` instances to `DataCollection`. 

I had to use `->toArray` in multiple scenarios when using `DataCollection` casts, but I think that should be handled by `laravel-data` directly.