### PR TITLE
Add TitleCaseMapper

### DIFF
--- a/src/Mappers/TitleCaseMapper.php
+++ b/src/Mappers/TitleCaseMapper.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\LaravelData\Mappers;
+
+use Illuminate\Support\Str;
+
+class TitleCaseMapper implements NameMapper
+{
+    public function map(int|string $name): string|int
+    {
+        if (!is_string($name)) {
+            return $name;
+        }
+
+        return Str::title($name);
+    }
+}


### PR DESCRIPTION
I've implemented this mapper to handle incoming data from an API that returns its fields in titlecase e.g "FirstName" that I want to receive as a property called `$firstName`.

See example from the external API docs:

![image](https://github.com/spatie/laravel-data/assets/797280/5b1857c9-5e5c-44b9-a6fa-402c1ac63db6)

Just providing this as it would have saved me some time had it existed by default.