### PR TITLE
Add Lowercase and Uppercase validation rules

### DIFF
--- a/docs/advanced-usage/validation-attributes.md
+++ b/docs/advanced-usage/validation-attributes.md
@@ -530,6 +530,15 @@ public int $closure;
 public int $closure; 
 ```
 
+### Lowercase
+
+[Docs](https://laravel.com/docs/9.x/validation#rule-lowercase)
+
+```php
+#[Lowercase]
+public string $closure; 
+```
+
 ### Max
 
 [Docs](https://laravel.com/docs/9.x/validation#rule-max)
@@ -886,6 +895,15 @@ public string $closure;
 
 #[Unique('users', ignore: 5)]
 public string $closure;
+```
+
+### Uppercase
+
+[Docs](https://laravel.com/docs/9.x/validation#rule-uppercase)
+
+```php
+#[Uppercase]
+public string $closure; 
 ```
 
 ### Url

--- a/src/Attributes/Validation/Lowercase.php
+++ b/src/Attributes/Validation/Lowercase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\LaravelData\Attributes\Validation;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+class Lowercase extends StringValidationAttribute
+{
+    public static function keyword(): string
+    {
+        return 'lowercase';
+    }
+
+    public function parameters(): array
+    {
+        return [];
+    }
+}

--- a/src/Attributes/Validation/Uppercase.php
+++ b/src/Attributes/Validation/Uppercase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\LaravelData\Attributes\Validation;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+class Uppercase extends StringValidationAttribute
+{
+    public static function keyword(): string
+    {
+        return 'uppercase';
+    }
+
+    public function parameters(): array
+    {
+        return [];
+    }
+}

--- a/src/Support/Validation/ValidationRuleFactory.php
+++ b/src/Support/Validation/ValidationRuleFactory.php
@@ -49,6 +49,7 @@ use Spatie\LaravelData\Attributes\Validation\IPv6;
 use Spatie\LaravelData\Attributes\Validation\Json;
 use Spatie\LaravelData\Attributes\Validation\LessThan;
 use Spatie\LaravelData\Attributes\Validation\LessThanOrEqualTo;
+use Spatie\LaravelData\Attributes\Validation\Lowercase;
 use Spatie\LaravelData\Attributes\Validation\Max;
 use Spatie\LaravelData\Attributes\Validation\Mimes;
 use Spatie\LaravelData\Attributes\Validation\MimeTypes;
@@ -80,6 +81,7 @@ use Spatie\LaravelData\Attributes\Validation\StringType;
 use Spatie\LaravelData\Attributes\Validation\Timezone;
 use Spatie\LaravelData\Attributes\Validation\Ulid;
 use Spatie\LaravelData\Attributes\Validation\Unique;
+use Spatie\LaravelData\Attributes\Validation\Uppercase;
 use Spatie\LaravelData\Attributes\Validation\Url;
 use Spatie\LaravelData\Attributes\Validation\Uuid;
 use Spatie\LaravelData\Exceptions\CouldNotCreateValidationRule;
@@ -148,6 +150,7 @@ class ValidationRuleFactory
             Json::keyword() => Json::class,
             LessThan::keyword() => LessThan::class,
             LessThanOrEqualTo::keyword() => LessThanOrEqualTo::class,
+            Lowercase::keyword() => Lowercase::class,
             Max::keyword() => Max::class,
             Mimes::keyword() => Mimes::class,
             MimeTypes::keyword() => MimeTypes::class,
@@ -178,6 +181,7 @@ class ValidationRuleFactory
             StringType::keyword() => StringType::class,
             Timezone::keyword() => Timezone::class,
             Unique::keyword() => Unique::class,
+            Uppercase::keyword() => Uppercase::class,
             Url::keyword() => Url::class,
             Ulid::keyword() => Ulid::class,
             Uuid::keyword() => Uuid::class,

--- a/tests/Datasets/Attributes/RulesDataset.php
+++ b/tests/Datasets/Attributes/RulesDataset.php
@@ -52,6 +52,7 @@ use Spatie\LaravelData\Attributes\Validation\IPv6;
 use Spatie\LaravelData\Attributes\Validation\Json;
 use Spatie\LaravelData\Attributes\Validation\LessThan;
 use Spatie\LaravelData\Attributes\Validation\LessThanOrEqualTo;
+use Spatie\LaravelData\Attributes\Validation\Lowercase;
 use Spatie\LaravelData\Attributes\Validation\Max;
 use Spatie\LaravelData\Attributes\Validation\Mimes;
 use Spatie\LaravelData\Attributes\Validation\MimeTypes;
@@ -83,6 +84,7 @@ use Spatie\LaravelData\Attributes\Validation\StringType;
 use Spatie\LaravelData\Attributes\Validation\Timezone;
 use Spatie\LaravelData\Attributes\Validation\Ulid;
 use Spatie\LaravelData\Attributes\Validation\Unique;
+use Spatie\LaravelData\Attributes\Validation\Uppercase;
 use Spatie\LaravelData\Attributes\Validation\Url;
 use Spatie\LaravelData\Attributes\Validation\Uuid;
 use Spatie\LaravelData\Exceptions\CannotBuildValidationRule;
@@ -289,6 +291,11 @@ dataset('attributes', function () {
     );
 
     yield fixature(
+        attribute: new Lowercase(),
+        expected: 'lowercase',
+    );
+
+    yield fixature(
         attribute: new Max(10),
         expected: 'max:10',
     );
@@ -356,6 +363,11 @@ dataset('attributes', function () {
     yield fixature(
         attribute: new Timezone(),
         expected: 'timezone',
+    );
+
+    yield fixature(
+        attribute: new Uppercase(),
+        expected: 'uppercase',
     );
 
     yield fixature(


### PR DESCRIPTION
Adds the Lowercase and Uppercase rules as validation attributes.

As part of https://github.com/spatie/laravel-data/discussions/570