### PR TITLE
feat: support multiple transformers and excluding transformers from Eloquent casting

### DIFF
--- a/src/Attributes/WithTransformer.php
+++ b/src/Attributes/WithTransformer.php
@@ -6,7 +6,7 @@ use Attribute;
 use Spatie\LaravelData\Exceptions\CannotCreateTransformerAttribute;
 use Spatie\LaravelData\Transformers\Transformer;
 
-#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
 class WithTransformer
 {
     public array $arguments;

--- a/src/Concerns/BaseData.php
+++ b/src/Concerns/BaseData.php
@@ -102,8 +102,9 @@ trait BaseData
         bool $transformValues = true,
         WrapExecutionType $wrapExecutionType = WrapExecutionType::Disabled,
         bool $mapPropertyNames = true,
+        bool $castingForEloquent = false,
     ): array {
-        return DataTransformer::create($transformValues, $wrapExecutionType, $mapPropertyNames)->transform($this);
+        return DataTransformer::create($transformValues, $wrapExecutionType, $mapPropertyNames, $castingForEloquent)->transform($this);
     }
 
     public function getMorphClass(): string

--- a/src/Concerns/BaseDataCollectable.php
+++ b/src/Concerns/BaseDataCollectable.php
@@ -39,12 +39,14 @@ trait BaseDataCollectable
         bool $transformValues = true,
         WrapExecutionType $wrapExecutionType = WrapExecutionType::Disabled,
         bool $mapPropertyNames = true,
+        bool $castingForEloquent = false,
     ): array {
         $transformer = new DataCollectableTransformer(
             $this->dataClass,
             $transformValues,
             $wrapExecutionType,
             $mapPropertyNames,
+            $castingForEloquent,
             $this->getPartialTrees(),
             $this->items,
             $this->getWrap(),

--- a/src/Contracts/ExcludeFromEloquentCasts.php
+++ b/src/Contracts/ExcludeFromEloquentCasts.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\LaravelData\Contracts;
+
+/** Marker interface for transformers that should not be applied to Eloquent casts. */
+interface ExcludeFromEloquentCasts
+{
+    //
+}

--- a/src/Contracts/TransformableData.php
+++ b/src/Contracts/TransformableData.php
@@ -22,6 +22,7 @@ interface TransformableData extends JsonSerializable, Jsonable, Arrayable, Eloqu
         bool $transformValues = true,
         WrapExecutionType $wrapExecutionType = WrapExecutionType::Disabled,
         bool $mapPropertyNames = true,
+        bool $castingForEloquent = false,
     ): array;
 
     public static function castUsing(array $arguments);

--- a/src/Support/DataConfig.php
+++ b/src/Support/DataConfig.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\LaravelData\Support;
 
+use Illuminate\Support\Arr;
 use ReflectionClass;
 use Spatie\LaravelData\Casts\Cast;
 use Spatie\LaravelData\Contracts\BaseData;
-use Spatie\LaravelData\Transformers\Transformer;
 
 class DataConfig
 {
@@ -33,15 +33,22 @@ class DataConfig
             $config['rule_inferrers'] ?? []
         );
 
-        foreach ($config['transformers'] ?? [] as $transformable => $transformer) {
-            $this->transformers[ltrim($transformable, ' \\')] = app($transformer);
-        }
+        $this->setTransformers($config['transformers'] ?? []);
 
         foreach ($config['casts'] ?? [] as $castable => $cast) {
             $this->casts[ltrim($castable, ' \\')] = app($cast);
         }
 
         $this->morphMap = new DataClassMorphMap();
+    }
+
+    public function setTransformers(array $transformers): self
+    {
+        foreach ($transformers as $transformable => $transformers) {
+            $this->transformers[ltrim($transformable, ' \\')] = array_map(resolve(...), Arr::wrap($transformers));
+        }
+
+        return $this;
     }
 
     public function getDataClass(string $class): DataClass
@@ -75,23 +82,23 @@ class DataConfig
         return null;
     }
 
-    public function findGlobalTransformerForValue(mixed $value): ?Transformer
+    public function findGlobalTransformersForValue(mixed $value): array
     {
         if (gettype($value) !== 'object') {
-            return null;
+            return [];
         }
 
-        foreach ($this->transformers as $transformable => $transformer) {
+        foreach ($this->transformers as $transformable => $transformers) {
             if ($value::class === $transformable) {
-                return $transformer;
+                return $transformers;
             }
 
             if (is_a($value::class, $transformable, true)) {
-                return $transformer;
+                return $transformers;
             }
         }
 
-        return null;
+        return [];
     }
 
     public function getRuleInferrers(): array

--- a/src/Support/DataProperty.php
+++ b/src/Support/DataProperty.php
@@ -13,7 +13,6 @@ use Spatie\LaravelData\Attributes\WithTransformer;
 use Spatie\LaravelData\Casts\Cast;
 use Spatie\LaravelData\Mappers\NameMapper;
 use Spatie\LaravelData\Resolvers\NameMappersResolver;
-use Spatie\LaravelData\Transformers\Transformer;
 
 /**
  * @property Collection<string, object> $attributes
@@ -32,7 +31,7 @@ class DataProperty
         public readonly bool $hasDefaultValue,
         public readonly mixed $defaultValue,
         public readonly ?Cast $cast,
-        public readonly ?Transformer $transformer,
+        public readonly Collection $transformers,
         public readonly ?string $inputMappedName,
         public readonly ?string $outputMappedName,
         public readonly Collection $attributes,
@@ -86,7 +85,7 @@ class DataProperty
             hasDefaultValue: $property->isPromoted() ? $hasDefaultValue : $property->hasDefaultValue(),
             defaultValue: $property->isPromoted() ? $defaultValue : $property->getDefaultValue(),
             cast: $attributes->first(fn (object $attribute) => $attribute instanceof GetsCast)?->get(),
-            transformer: $attributes->first(fn (object $attribute) => $attribute instanceof WithTransformer)?->get(),
+            transformers: $attributes->filter(fn (object $attribute) => $attribute instanceof WithTransformer)->map->get(),
             inputMappedName: $inputMappedName,
             outputMappedName: $outputMappedName,
             attributes: $attributes,

--- a/src/Support/EloquentCasts/DataEloquentCast.php
+++ b/src/Support/EloquentCasts/DataEloquentCast.php
@@ -66,11 +66,11 @@ class DataEloquentCast implements CastsAttributes
         if ($isAbstractClassCast) {
             return json_encode([
                 'type' => $this->dataConfig->morphMap->getDataClassAlias($value::class) ?? $value::class,
-                'data' => json_decode($value->toJson(), associative: true, flags: JSON_THROW_ON_ERROR),
+                'data' => json_decode(json_encode($value->transform(castingForEloquent: true)), associative: true, flags: JSON_THROW_ON_ERROR),
             ]);
         }
 
-        return $value->toJson();
+        return json_encode($value->transform(castingForEloquent: true));
     }
 
     protected function isAbstractClassCast(): bool

--- a/src/Transformers/DataCollectableTransformer.php
+++ b/src/Transformers/DataCollectableTransformer.php
@@ -20,6 +20,7 @@ class DataCollectableTransformer
         protected bool $transformValues,
         protected WrapExecutionType $wrapExecutionType,
         protected bool $mapPropertyNames,
+        protected bool $castingForEloquent,
         protected PartialTrees $trees,
         protected Enumerable|CursorPaginator|Paginator $items,
         protected Wrap $wrap,
@@ -60,6 +61,7 @@ class DataCollectableTransformer
                     ? WrapExecutionType::TemporarilyDisabled
                     : $this->wrapExecutionType,
                 $this->mapPropertyNames,
+                $this->castingForEloquent,
             );
         }
 

--- a/tests/Fakes/Enums/DummyBackedEnumWithOptions.php
+++ b/tests/Fakes/Enums/DummyBackedEnumWithOptions.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes\Enums;
+
+use Spatie\LaravelData\Tests\Fakes\Interfaces\HasOptions;
+
+enum DummyBackedEnumWithOptions: string implements HasOptions
+{
+    case CAPTAIN = 'captain';
+    case FIRST_OFFICER = 'first_officer';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::CAPTAIN => 'Captain',
+            self::FIRST_OFFICER => 'First Officer',
+        };
+    }
+
+    public function toOptions(): array
+    {
+        return array_map(
+            callback: fn (self $enum) => [
+                'value' => $enum->value,
+                'label' => $enum->label(),
+            ],
+            array: self::cases()
+        );
+
+    }
+}

--- a/tests/Fakes/Interfaces/HasOptions.php
+++ b/tests/Fakes/Interfaces/HasOptions.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes\Interfaces;
+
+interface HasOptions
+{
+    public function toOptions(): array;
+}

--- a/tests/Fakes/Models/DummyModelWithEloquentExcludedCasts.php
+++ b/tests/Fakes/Models/DummyModelWithEloquentExcludedCasts.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnumWithOptions;
+use Spatie\LaravelData\Tests\Fakes\SimpleDataWithEloquentExcludedTransformerData;
+
+class DummyModelWithEloquentExcludedCasts extends Model
+{
+    protected $casts = [
+        'data' => SimpleDataWithEloquentExcludedTransformerData::class,
+        'eloquent_excluded_enum' => DummyBackedEnumWithOptions::class,
+    ];
+
+    public $timestamps = false;
+
+    public static function migrate()
+    {
+        Schema::create('dummy_model_with_eloquent_excluded_casts', function (Blueprint $blueprint) {
+            $blueprint->increments('id');
+
+            $blueprint->text('data')->nullable();
+            $blueprint->string('eloquent_excluded_enum');
+        });
+    }
+}

--- a/tests/Fakes/SimpleDataWithEloquentExcludedTransformerData.php
+++ b/tests/Fakes/SimpleDataWithEloquentExcludedTransformerData.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
+use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnumWithOptions;
+
+class SimpleDataWithEloquentExcludedTransformerData extends Data
+{
+    public function __construct(
+        public readonly string $string,
+        public readonly DummyBackedEnumWithOptions $enum,
+        public readonly DummyBackedEnum $normal_enum,
+    ) {
+    }
+}

--- a/tests/Fakes/Transformers/OptionsTransformer.php
+++ b/tests/Fakes/Transformers/OptionsTransformer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes\Transformers;
+
+use BackedEnum;
+use Spatie\LaravelData\Contracts\ExcludeFromEloquentCasts;
+use Spatie\LaravelData\Support\DataProperty;
+use Spatie\LaravelData\Tests\Fakes\Interfaces\HasOptions;
+use Spatie\LaravelData\Transformers\Transformer;
+
+class OptionsTransformer implements Transformer, ExcludeFromEloquentCasts
+{
+    public function transform(DataProperty $property, mixed $value): ?array
+    {
+        if (! $value instanceof BackedEnum || ! $value instanceof HasOptions) {
+            return null;
+        }
+
+        return $value->toOptions();
+    }
+};

--- a/tests/Support/DataPropertyTest.php
+++ b/tests/Support/DataPropertyTest.php
@@ -41,7 +41,7 @@ it('can get the transformer attribute', function () {
         public SimpleData $property;
     });
 
-    expect($helper->transformer)->toEqual(new DateTimeInterfaceTransformer());
+    expect($helper->transformers)->first()->toEqual(new DateTimeInterfaceTransformer());
 });
 
 it('can get the transformer attribute with arguments', function () {
@@ -50,7 +50,7 @@ it('can get the transformer attribute with arguments', function () {
         public SimpleData $property;
     });
 
-    expect($helper->transformer)->toEqual(new DateTimeInterfaceTransformer('d-m-y'));
+    expect($helper->transformers)->first()->toEqual(new DateTimeInterfaceTransformer('d-m-y'));
 });
 
 it('can get the mapped input name', function () {


### PR DESCRIPTION
This pull request is an attempt at solving the use case described in #579. 

It implements two major changes:
- Base classes and properties now support multiple transformers
- Transformers implementing `ExcludeFromEloquentCasts` are ignored during Eloquent casting

Additionally:
- `WithTransformer` can now be applied multiple times.
- `setTransformers` has been added to `DataConfig` for convenience

Note: technically, this pull request contains a breaking change (`DataProperty::$transformer` is now `DataProperty::$transformers`).

Marking as draft because I'm not convinced about this approach.