### PR TITLE
feat!: add context to transformers

### DIFF
--- a/src/Attributes/WithTransformer.php
+++ b/src/Attributes/WithTransformer.php
@@ -6,7 +6,7 @@ use Attribute;
 use Spatie\LaravelData\Exceptions\CannotCreateTransformerAttribute;
 use Spatie\LaravelData\Transformers\Transformer;
 
-#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
 class WithTransformer
 {
     public array $arguments;

--- a/src/Concerns/BaseData.php
+++ b/src/Concerns/BaseData.php
@@ -102,8 +102,9 @@ trait BaseData
         bool $transformValues = true,
         WrapExecutionType $wrapExecutionType = WrapExecutionType::Disabled,
         bool $mapPropertyNames = true,
+        ?string $context = null,
     ): array {
-        return DataTransformer::create($transformValues, $wrapExecutionType, $mapPropertyNames)->transform($this);
+        return DataTransformer::create($transformValues, $wrapExecutionType, $mapPropertyNames, $context)->transform($this);
     }
 
     public function getMorphClass(): string

--- a/src/Concerns/BaseDataCollectable.php
+++ b/src/Concerns/BaseDataCollectable.php
@@ -39,12 +39,14 @@ trait BaseDataCollectable
         bool $transformValues = true,
         WrapExecutionType $wrapExecutionType = WrapExecutionType::Disabled,
         bool $mapPropertyNames = true,
+        ?string $context = null,
     ): array {
         $transformer = new DataCollectableTransformer(
             $this->dataClass,
             $transformValues,
             $wrapExecutionType,
             $mapPropertyNames,
+            $context,
             $this->getPartialTrees(),
             $this->items,
             $this->getWrap(),

--- a/src/Concerns/ResponsableData.php
+++ b/src/Concerns/ResponsableData.php
@@ -27,6 +27,7 @@ trait ResponsableData
         return new JsonResponse(
             data: $this->transform(
                 wrapExecutionType: WrapExecutionType::Enabled,
+                context: 'response'
             ),
             status: $this->calculateResponseStatus($request)
         );

--- a/src/Concerns/TransformableData.php
+++ b/src/Concerns/TransformableData.php
@@ -13,17 +13,22 @@ trait TransformableData
 
     public function toArray(): array
     {
-        return $this->transform();
+        return $this->transform(context: 'array');
     }
 
     public function toJson($options = 0): string
     {
-        return json_encode($this->transform(), $options);
+        return json_encode($this->transform(context: 'json'), $options);
+    }
+
+    public function toEloquent(): string
+    {
+        return json_encode($this->transform(context: 'eloquent'));
     }
 
     public function jsonSerialize(): array
     {
-        return $this->transform();
+        return $this->transform(context: 'json');
     }
 
     public static function castUsing(array $arguments)

--- a/src/Contracts/TransformableData.php
+++ b/src/Contracts/TransformableData.php
@@ -14,6 +14,8 @@ interface TransformableData extends JsonSerializable, Jsonable, Arrayable, Eloqu
 
     public function toArray(): array;
 
+    public function toEloquent(): string;
+
     public function toJson($options = 0): string;
 
     public function jsonSerialize(): array;
@@ -22,6 +24,7 @@ interface TransformableData extends JsonSerializable, Jsonable, Arrayable, Eloqu
         bool $transformValues = true,
         WrapExecutionType $wrapExecutionType = WrapExecutionType::Disabled,
         bool $mapPropertyNames = true,
+        ?string $context = null,
     ): array;
 
     public static function castUsing(array $arguments);

--- a/src/Support/DataProperty.php
+++ b/src/Support/DataProperty.php
@@ -13,7 +13,6 @@ use Spatie\LaravelData\Attributes\WithTransformer;
 use Spatie\LaravelData\Casts\Cast;
 use Spatie\LaravelData\Mappers\NameMapper;
 use Spatie\LaravelData\Resolvers\NameMappersResolver;
-use Spatie\LaravelData\Transformers\Transformer;
 
 /**
  * @property Collection<string, object> $attributes
@@ -32,7 +31,7 @@ class DataProperty
         public readonly bool $hasDefaultValue,
         public readonly mixed $defaultValue,
         public readonly ?Cast $cast,
-        public readonly ?Transformer $transformer,
+        public readonly Collection $transformers,
         public readonly ?string $inputMappedName,
         public readonly ?string $outputMappedName,
         public readonly Collection $attributes,
@@ -86,7 +85,7 @@ class DataProperty
             hasDefaultValue: $property->isPromoted() ? $hasDefaultValue : $property->hasDefaultValue(),
             defaultValue: $property->isPromoted() ? $defaultValue : $property->getDefaultValue(),
             cast: $attributes->first(fn (object $attribute) => $attribute instanceof GetsCast)?->get(),
-            transformer: $attributes->first(fn (object $attribute) => $attribute instanceof WithTransformer)?->get(),
+            transformers: $attributes->filter(fn (object $attribute) => $attribute instanceof WithTransformer)->map->get(),
             inputMappedName: $inputMappedName,
             outputMappedName: $outputMappedName,
             attributes: $attributes,

--- a/src/Support/EloquentCasts/DataEloquentCast.php
+++ b/src/Support/EloquentCasts/DataEloquentCast.php
@@ -66,11 +66,11 @@ class DataEloquentCast implements CastsAttributes
         if ($isAbstractClassCast) {
             return json_encode([
                 'type' => $this->dataConfig->morphMap->getDataClassAlias($value::class) ?? $value::class,
-                'data' => json_decode($value->toJson(), associative: true, flags: JSON_THROW_ON_ERROR),
+                'data' => json_decode($value->toEloquent(), associative: true, flags: JSON_THROW_ON_ERROR),
             ]);
         }
 
-        return $value->toJson();
+        return $value->toEloquent();
     }
 
     protected function isAbstractClassCast(): bool

--- a/src/Transformers/ArrayableTransformer.php
+++ b/src/Transformers/ArrayableTransformer.php
@@ -6,7 +6,7 @@ use Spatie\LaravelData\Support\DataProperty;
 
 class ArrayableTransformer implements Transformer
 {
-    public function transform(DataProperty $property, mixed $value): array
+    public function transform(DataProperty $property, mixed $value, ?string $context = null): array
     {
         /** @var \Illuminate\Contracts\Support\Arrayable $value */
         return $value->toArray();

--- a/src/Transformers/DataCollectableTransformer.php
+++ b/src/Transformers/DataCollectableTransformer.php
@@ -20,6 +20,7 @@ class DataCollectableTransformer
         protected bool $transformValues,
         protected WrapExecutionType $wrapExecutionType,
         protected bool $mapPropertyNames,
+        protected ?string $context,
         protected PartialTrees $trees,
         protected Enumerable|CursorPaginator|Paginator $items,
         protected Wrap $wrap,
@@ -33,7 +34,9 @@ class DataCollectableTransformer
         }
 
         $this->items->through(
-            $this->transformItemClosure()
+            fn (mixed $item) => $item instanceof BaseData
+                ? $this->transformItemClosure()($item)->transform(context: $this->context)
+                : $item
         );
 
         return $this->transformValues
@@ -60,6 +63,7 @@ class DataCollectableTransformer
                     ? WrapExecutionType::TemporarilyDisabled
                     : $this->wrapExecutionType,
                 $this->mapPropertyNames,
+                $this->context,
             );
         }
 

--- a/src/Transformers/DateTimeInterfaceTransformer.php
+++ b/src/Transformers/DateTimeInterfaceTransformer.php
@@ -14,7 +14,7 @@ class DateTimeInterfaceTransformer implements Transformer
     ) {
     }
 
-    public function transform(DataProperty $property, mixed $value): string
+    public function transform(DataProperty $property, mixed $value, ?string $context = null): string
     {
         [$format] = Arr::wrap($this->format ?? config('data.date_format'));
 

--- a/src/Transformers/EnumTransformer.php
+++ b/src/Transformers/EnumTransformer.php
@@ -6,7 +6,7 @@ use Spatie\LaravelData\Support\DataProperty;
 
 class EnumTransformer implements Transformer
 {
-    public function transform(DataProperty $property, mixed $value): string|int
+    public function transform(DataProperty $property, mixed $value, ?string $context = null): string|int
     {
         return $value->value;
     }

--- a/src/Transformers/Transformer.php
+++ b/src/Transformers/Transformer.php
@@ -6,5 +6,5 @@ use Spatie\LaravelData\Support\DataProperty;
 
 interface Transformer
 {
-    public function transform(DataProperty $property, mixed $value): mixed;
+    public function transform(DataProperty $property, mixed $value, ?string $context = null): mixed;
 }

--- a/tests/Fakes/Transformers/ConfidentialDataCollectionTransformer.php
+++ b/tests/Fakes/Transformers/ConfidentialDataCollectionTransformer.php
@@ -8,9 +8,9 @@ use Spatie\LaravelData\Transformers\Transformer;
 
 class ConfidentialDataCollectionTransformer implements Transformer
 {
-    public function transform(DataProperty $property, mixed $value): mixed
+    public function transform(DataProperty $property, mixed $value, ?string $context = null): mixed
     {
         /** @var \Spatie\LaravelData\DataCollection $value */
-        return $value->toCollection()->map(fn (Data $data) => (new ConfidentialDataTransformer())->transform($property, $data))->toArray();
+        return $value->toCollection()->map(fn (Data $data) => (new ConfidentialDataTransformer())->transform($property, $data, $context))->toArray();
     }
 }

--- a/tests/Fakes/Transformers/ConfidentialDataTransformer.php
+++ b/tests/Fakes/Transformers/ConfidentialDataTransformer.php
@@ -9,7 +9,7 @@ use Spatie\LaravelData\Transformers\Transformer;
 
 class ConfidentialDataTransformer implements Transformer
 {
-    public function transform(DataProperty $property, mixed $value): mixed
+    public function transform(DataProperty $property, mixed $value, ?string $context = null): mixed
     {
         /** @var \Spatie\LaravelData\Data $value */
         return collect($value->toArray())->map(fn (mixed $value) => 'CONFIDENTIAL')->toArray();

--- a/tests/Fakes/Transformers/StringToUpperTransformer.php
+++ b/tests/Fakes/Transformers/StringToUpperTransformer.php
@@ -7,7 +7,7 @@ use Spatie\LaravelData\Transformers\Transformer;
 
 class StringToUpperTransformer implements Transformer
 {
-    public function transform(DataProperty $property, mixed $value): string
+    public function transform(DataProperty $property, mixed $value, ?string $context = null): string
     {
         return strtoupper($value);
     }

--- a/tests/Support/DataPropertyTest.php
+++ b/tests/Support/DataPropertyTest.php
@@ -41,7 +41,7 @@ it('can get the transformer attribute', function () {
         public SimpleData $property;
     });
 
-    expect($helper->transformer)->toEqual(new DateTimeInterfaceTransformer());
+    expect($helper->transformers->first())->toEqual(new DateTimeInterfaceTransformer());
 });
 
 it('can get the transformer attribute with arguments', function () {
@@ -50,7 +50,7 @@ it('can get the transformer attribute with arguments', function () {
         public SimpleData $property;
     });
 
-    expect($helper->transformer)->toEqual(new DateTimeInterfaceTransformer('d-m-y'));
+    expect($helper->transformers->first())->toEqual(new DateTimeInterfaceTransformer('d-m-y'));
 });
 
 it('can get the mapped input name', function () {

--- a/tests/Transformers/DateTimeInterfaceTransformerTest.php
+++ b/tests/Transformers/DateTimeInterfaceTransformerTest.php
@@ -64,7 +64,6 @@ it('can transform dates with an alternative format', function () {
         $transformer->transform(
             DataProperty::create(new ReflectionProperty($class, 'carbon')),
             new Carbon('19-05-1994 00:00:00'),
-            []
         )
     )->toEqual('19-05-1994');
 
@@ -72,7 +71,6 @@ it('can transform dates with an alternative format', function () {
         $transformer->transform(
             DataProperty::create(new ReflectionProperty($class, 'carbonImmutable')),
             new CarbonImmutable('19-05-1994 00:00:00'),
-            []
         )
     )->toEqual('19-05-1994');
 
@@ -80,7 +78,6 @@ it('can transform dates with an alternative format', function () {
         $transformer->transform(
             DataProperty::create(new ReflectionProperty($class, 'dateTime')),
             new DateTime('19-05-1994 00:00:00'),
-            []
         )
     )->toEqual('19-05-1994');
 
@@ -88,7 +85,6 @@ it('can transform dates with an alternative format', function () {
         $transformer->transform(
             DataProperty::create(new ReflectionProperty($class, 'dateTimeImmutable')),
             new DateTimeImmutable('19-05-1994 00:00:00'),
-            []
         )
     )->toEqual('19-05-1994');
 });


### PR DESCRIPTION
This pull request is an alternative to https://github.com/spatie/laravel-data/pull/588, which I personally prefer.

Along with also allowing multiple transformers for a class, it adds a context property to the `Transformer` contract, which can be an arbitrary string.

This allows to transform data differently depending on the context (`response`, `eloquent`, a custom context...).

Unfortunately, this is a breaking change if using a custom `Transformer` implementation. I couldn't find a way to implement the feature in a backwards-compatible way.

<details>
<summary>Example</summary>
&nbsp;

Usage:

```php
// In a controller
return SomeData::collection($query->paginate())->transform(context: 'hybridly');
// or
return SomeData::from($data)->transform(context: 'hybridly');
```

App-specific stuff:

```php
// Custom TypeScript Transformer that generates a proper type using `HasOptions`
final class OptionsTransformer extends EnumTransformer
{
    protected function toEnumValue(ReflectionEnumBackedCase $case): string
    {
        if ($case->getEnum()->implementsInterface(HasOptions::class)) {
            return json_encode($case->getValue()->toOption());
        }

        $value = $case->getBackingValue();

        return \is_string($value) ? "'{$value}'" : "{$value}";
    }
}

// Custom Laravel Data transformer for transforming the enum in options
final class OptionsTransformer implements Transformer
{
    public function transform(DataProperty $property, mixed $value, ?string $context = null): null|string|array
    {
        if (!$value instanceof BackedEnum) {
            return null;
        }

        if ($context === 'hybridly' && $value instanceof HasOptions) {
            return $value->toOption();
        }

        return $value->value;
    }
}

// Interface for my enums
interface HasOptions
{
    public function toOption(): array;
}

// Example implementation
enum PilotGrade: string implements HasOptions
{
    case CAPTAIN = 'captain';
    case FIRST_OFFICER = 'first_officer';
    case PILOT = 'pilot';

    public function toHumanReadableString(): string
    {
        return match ($this) {
            static::FIRST_OFFICER => 'First officer',
            static::CAPTAIN => 'Captain',
            static::PILOT => 'Pilot',
        };
    }

    public function toOption(): array
    {
        return [
            'value' => $this->value,
            'label' => $this->toHumanReadableString(),
        ];
    }
}
```

</details>

Concerns:
- `$context` as a `string` might be restrictive, this could be an array or even a dedicated class
- Calling `transform` with the same context everywhere would be repetitive, but this could be attenuated by making the `BaseData` class `Macroable`
- This is a breaking change so we have to wait until v4... :(