### PR TITLE
Add DataCollectionSynth

### DIFF
--- a/src/Synths/DataCollectionSynth.php
+++ b/src/Synths/DataCollectionSynth.php
@@ -28,9 +28,19 @@ class DataCollectionSynth extends Synth
         ];
     }
 
-    public function hydrate($value, $meta)
+    /**
+     * @param  array<mixed>  $value
+     * @param  array<string, class-string>  $meta
+     * @param  mixed  $hydrateChild
+     * @return \Spatie\LaravelData\DataCollection
+     */
+    public function hydrate($value, $meta, $hydrateChild)
     {
-        return new DataCollection($meta['class'], $value);
+        foreach ($value as $key => $child) {
+            $value[$key] = $hydrateChild($key, $child);
+        }
+
+        return $meta['class']::make($value);
     }
 
     public function get(&$target, $key)

--- a/src/Synths/DataCollectionSynth.php
+++ b/src/Synths/DataCollectionSynth.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Spatie\LaravelData\Synths;
+
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+use Spatie\LaravelData\DataCollection;
+
+class DataCollectionSynth extends Synth
+{
+    public static $key = 'dtcl';
+
+    public static function match($target)
+    {
+        return get_class($target) == DataCollection::class;
+    }
+
+    public function dehydrate(DataCollection $target)
+    {
+        return [$target->toArray(), ['class' => $target->dataClass]];
+    }
+
+    public function hydrate($value, $meta)
+    {
+        return new DataCollection($meta['class'], $value);
+    }
+
+    public function get(&$target, $key)
+    {
+        return $target[$key] ?? null;
+    }
+
+    public function set(&$target, $key, $value)
+    {
+        $target[$key] = $value;
+    }
+}

--- a/src/Synths/DataCollectionSynth.php
+++ b/src/Synths/DataCollectionSynth.php
@@ -14,9 +14,18 @@ class DataCollectionSynth extends Synth
         return get_class($target) == DataCollection::class;
     }
 
-    public function dehydrate(DataCollection $target)
+    public function dehydrate(DataCollection $target, $dehydrateChild)
     {
-        return [$target->toArray(), ['class' => $target->dataClass]];
+        $data = $target->all();
+
+        foreach ($data as $key => $child) {
+            $data[$key] = $dehydrateChild($key, $child);
+        }
+
+        return [
+            $data,
+            ['class' => get_class($target)],
+        ];
     }
 
     public function hydrate($value, $meta)


### PR DESCRIPTION
Going to leave this as draft because I'd like to explain my use case and see if you folks are willing to accept this. If so, I will add tests.

In my project I have a custom DataCollection called `StationCollection` and because I'm using Livewire (v3), I had it `implement Wireable`. However, the `WireableSynth` in Livewire expects properties:

```php
    function set(&$target, $key, $value) {
        $target->{$key} = $value;
    }
```

Which throws an error when used.

To work around this I created a `DataCollectionSynth` that handles things properly, and then made a custom synth that inherits from `DataCollectionSynth` to deal with my custom stuff (mostly type hinting).

Note that to use this, one would have to add this to your service provider, `Livewire::propertySynthesizer(DataCollectionSynth::class);`

Does that sound reasonable?