### PR TITLE
Add generic type for WithData trait

### DIFF
--- a/src/WithData.php
+++ b/src/WithData.php
@@ -3,12 +3,17 @@
 namespace Spatie\LaravelData;
 
 use Spatie\LaravelData\Contracts\BaseData;
-use Spatie\LaravelData\Contracts\DataObject;
 use Spatie\LaravelData\Exceptions\InvalidDataClass;
 
+/**
+ * @template T
+ */
 trait WithData
 {
-    public function getData(): DataObject
+    /**
+     * @return T
+     */
+    public function getData()
     {
         $dataClass = match (true) {
             /** @psalm-suppress UndefinedThisPropertyFetch */


### PR DESCRIPTION
It becomes possible to add PHPDoc when using the "WithData" trait:
```
class CommentRequest extends FormRequest {

    /** @use WithData<\App\Data\CommentData> */
    use WithData;

    protected string $dataClass = CommentData::class;

    //Some code
}
```
Then type hinting works correctly after calling the "getData" method:
```
public function store(CommentRequest $request): JsonResponse {
    
    $commentData = $request->getData();
    //$commentData is now of type CommentData
    
    //Some code
}
```
