### PR TITLE
[Fix] Static analysis of `DataCollection::map(...)` and `DataCollection::through(...)` methods

### DIFF
--- a/src/Concerns/EnumerableMethods.php
+++ b/src/Concerns/EnumerableMethods.php
@@ -8,6 +8,7 @@ use Spatie\LaravelData\DataCollection;
 /**
  * @template TKey of array-key
  * @template TValue
+ * @template TMapValue
  *
  * @implements \ArrayAccess<TKey, TValue>
  * @implements  DataCollectable<TValue>
@@ -15,7 +16,7 @@ use Spatie\LaravelData\DataCollection;
 trait EnumerableMethods
 {
     /**
-     * @param callable(TValue, TKey): TValue $through
+     * @param callable(TValue, TKey): TMapValue $through
      *
      * @return static
      */
@@ -29,7 +30,7 @@ trait EnumerableMethods
     }
 
     /**
-     * @param callable(TValue, TKey): TValue $map
+     * @param callable(TValue, TKey): TMapValue $map
      *
      * @return static
      */


### PR DESCRIPTION
## The problem

The static analysis type hinting for  `DataCollection::map(...)` and `DataCollection::through(...)` expect the return type of the passed closures to match the same type of each item within the collection. Typically the `map` method of arrays, or Laravel collections, is used to transform a collection of items into something different (i.e. a different collection of items, who's types may not match the initial collections types).

Currently, this expectation can lead to static analysis errors such as:

```
Parameter #1 $map of method Spatie\LaravelData\DataCollection<int, App\Data\Foo>::map() expects callable(App\Data\Foo, int): App\Data\Foo, Closure(App\Data\Foo, int): App\Data\Bar given
```

## The fix
The fix here is is to add another template to both these methods `TMapValue` to use as the return type, which may or may not be the same type as items in the collection