### PR TITLE
fix: adds environment variable to disable structure caching

### DIFF
--- a/config/data.php
+++ b/config/data.php
@@ -76,6 +76,7 @@ return [
      * store should be used.
      */
     'structure_caching' => [
+        'enabled' => env('DATA_STRUCTURE_CACHE_ENABLED', true),
         'directories' => [app_path('Data')],
         'cache' => [
             'store' => env('CACHE_DRIVER', 'file'),

--- a/docs/advanced-usage/performance.md
+++ b/docs/advanced-usage/performance.md
@@ -63,3 +63,5 @@ When using reflection discovery, the base directory and root namespace can be co
 ```
 
 You can read more about reflection discovery [here](https://github.com/spatie/php-structure-discoverer#parsers).
+
+Caching can be disabled e.g. for development or test environments by setting `DATA_STRUCTURE_CACHE_ENABLED=false` in .env

--- a/src/LaravelDataServiceProvider.php
+++ b/src/LaravelDataServiceProvider.php
@@ -24,15 +24,22 @@ class LaravelDataServiceProvider extends PackageServiceProvider
 
     public function packageRegistered(): void
     {
-        $this->app->singleton(
-            DataStructureCache::class,
-            fn () => new DataStructureCache(config('data.structure_caching.cache'))
-        );
+        if (config('data.structure_caching.enabled')) {
+            $this->app->singleton(
+                DataStructureCache::class,
+                fn () => new DataStructureCache(config('data.structure_caching.cache'))
+            );
 
-        $this->app->singleton(
-            DataConfig::class,
-            fn () => $this->app->make(DataStructureCache::class)->getConfig() ?? new DataConfig(config('data'))
-        );
+            $this->app->singleton(
+                DataConfig::class,
+                fn () => $this->app->make(DataStructureCache::class)->getConfig() ?? new DataConfig(config('data'))
+            );
+        } else {
+            $this->app->singleton(
+                DataConfig::class,
+                fn () => new DataConfig(config('data'))
+            );
+        }
 
         /** @psalm-suppress UndefinedInterfaceMethod */
         $this->app->beforeResolving(BaseData::class, function ($class, $parameters, $app) {


### PR DESCRIPTION
Suggestion to resolve [#641](https://github.com/spatie/laravel-data/issues/641) - adds config and environment variable to disable structure caching that was introduced in v3.11.0

Disabling caching could be useful in development environments, and also in tests where you might want to [mock the Cache facade](https://laravel.com/docs/master/mocking#mocking-facades) without also having to mock the various calls to Cache made by this package.