### PR TITLE
Added `push()` method

### DIFF
--- a/src/DataCollection.php
+++ b/src/DataCollection.php
@@ -78,6 +78,20 @@ class DataCollection implements DataCollectable, ArrayAccess
     }
 
     /**
+     * @param TValue ...$values
+     *
+     * @return static
+     */
+    public function push(...$values): static
+    {
+        foreach ($values as $value) {
+            $this[] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
      * @param TKey $offset
      *
      * @return bool

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -128,6 +128,17 @@ it('is iteratable', function () {
     expect($letters)->toMatchArray(['A', 'B', 'C', 'D']);
 });
 
+it('can add items', function () {
+    $collection = SimpleData::collection([
+        'A', 'B', 'C',
+    ]);
+
+    $collection->push('D', 'E');
+
+    expect($collection)->toHaveCount(5);
+    expect($collection[3])->toEqual(SimpleData::from('D')->withPartialTrees(new PartialTrees()));
+});
+
 it('has array access', function () {
     $collection = SimpleData::collection([
         'A', 'B', SimpleData::from('C'), SimpleData::from('D'),


### PR DESCRIPTION
I was looking for a fluent way to add items to collection but wasn't able to find one.
Current alternatives:
```php
SimpleData::collection()->toCollection()->push('foo'); //Technically works if underlying collection is `\Illuminate\Support\Collection`, but cannot be properly type hinted because `$items` is `\Illuminate\Support\Enumerable`.
```
```php
$collection = SimpleData::collection();
$collection[] = 'foo'; //This works because `DataCollection` implements `ArrayAccess`
```

This proposed method is the same as `\Illuminate\Support\Collection::push()`.