### PR TITLE
Prevent out of memory with multiple requests in a test

### DIFF
--- a/src/LaravelDataServiceProvider.php
+++ b/src/LaravelDataServiceProvider.php
@@ -41,6 +41,10 @@ class LaravelDataServiceProvider extends PackageServiceProvider
         );
 
         $this->app->beforeResolving(BaseData::class, function ($class, $parameters, $app) {
+            if ($app->has($class)) {
+                return;
+            }
+            
             $app->bind(
                 $class,
                 fn ($container) => $class::from($container['request'])

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -21,7 +21,7 @@ beforeEach(function () {
         ValidationException::class,
     ]);
 
-    Route::post('/example-route', function (Sim $data) {
+    Route::post('/example-route', function (SimpleData $data) {
         return ['given' => $data->string];
     });
 });
@@ -36,6 +36,18 @@ it('can pass validation', function () {
     ])
         ->assertOk()
         ->assertJson(['given' => 'Hello']);
+});
+
+it('can make multiple requests', function () {
+    postJson('/example-route', [
+        'string' => 'Hello',
+    ])
+        ->assertOk();
+
+    postJson('/example-route', [
+        'string' => 'Hello',
+    ])
+        ->assertOk();
 });
 
 it('can returns a 201 response code for POST requests', function () {


### PR DESCRIPTION
This fixes #656. I added a test and got it to pass by restoring some code from the v3 branch.

Here is the [previous commit](https://github.com/spatie/laravel-data/commit/46e2d19c8bfebe1bca4fc5c7149ab21bac9461fb#diff-66963ca1bf7d4336f8d577f1113c285b8be2aae97a64d22f983c75acf12c1285) when the check was removed.

I do not use Laravel Octane or know enough about it to know if this fix would be compatible with Octane. 