### PR TITLE
Backport cache fix to v3

### DIFF
--- a/src/Support/Caching/CachedDataConfig.php
+++ b/src/Support/Caching/CachedDataConfig.php
@@ -20,7 +20,21 @@ class CachedDataConfig extends DataConfig
 
     public function getDataClass(string $class): DataClass
     {
-        return $this->cache?->getDataClass($class) ?? parent::getDataClass($class);
+        if (array_key_exists($class, $this->dataClasses)) {
+            return $this->dataClasses[$class];
+        }
+
+        if ($this->cache === null) {
+            return parent::getDataClass($class);
+        }
+
+        $dataClass = $this->cache->getDataClass($class);
+
+        if ($dataClass === null) {
+            return parent::getDataClass($class);
+        }
+
+        return $this->dataClasses[$class] = $dataClass;
     }
 
     public function setCache(DataStructureCache $cache): self


### PR DESCRIPTION
I noticed that the latest V4 version has a fix to caching - is it possible to back port this to V3 while we are still on this version? We can't easily upgrade to V4 yet, but I have noticed that the laravel-data caching isn't particularly performant in production and maybe this will help.

I also noticed there was a separate caching fix commit, but I'm not sure if it is applicable to V3 as it had a lot more change.