### PR TITLE
Fix edge case when transforming union collectible type

### DIFF
--- a/src/Resolvers/TransformedDataCollectableResolver.php
+++ b/src/Resolvers/TransformedDataCollectableResolver.php
@@ -105,7 +105,7 @@ class TransformedDataCollectableResolver
     protected function transformationClosure(
         TransformationContext $nestedContext,
     ): Closure {
-        return function (BaseData $data) use ($nestedContext) {
+        return function ($data) use ($nestedContext) {
             if (! $data instanceof TransformableData || ! $nestedContext->transformValues) {
                 return $data;
             }


### PR DESCRIPTION
This fixes an edge case where a property may both be `Collection<int, Product>|Collection<int, array>`. 

**Steps for reproduction**

```php
use Spatie\LaravelData\Data;

class Person extends Data
{
    public function __construct(
        /** @var array<int, Pet>|array<int, array> */
        public array $pets,
    ) {
    }
}

class Pet extends Data
{
    public function __construct(
        public string $name,
    ) {
    }
}

$person = new Person(
    pets: [
        ['name' => 'Fido']
    ]
);

dd(json_encode($person));
```

This will produce the following error

TypeError: Spatie\LaravelData\Resolvers\TransformedDataCollectableResolver::Spatie\LaravelData\Resolvers\{closure}(): Argument #1 ($data) must be of type Spatie\LaravelData\Contracts\BaseData, array given, called in vendor/spatie/laravel-data/src/Resolvers/TransformedDataCollectableResolver.php on line 72

vendor/spatie/laravel-data/src/Resolvers/TransformedDataCollectableResolver.php:108
vendor/spatie/laravel-data/src/Resolvers/TransformedDataCollectableResolver.php:72
vendor/spatie/laravel-data/src/Resolvers/TransformedDataCollectableResolver.php:49
vendor/spatie/laravel-data/src/Resolvers/TransformedDataResolver.php:164
vendor/spatie/laravel-data/src/Resolvers/TransformedDataResolver.php:66
vendor/spatie/laravel-data/src/Resolvers/TransformedDataResolver.php:37
vendor/spatie/laravel-data/src/Concerns/TransformableData.php:35
vendor/spatie/laravel-data/src/Concerns/TransformableData.php:55

**Fix**
Simply removing the typehint will return the original $data and fix the issue.