### PR TITLE
docs: fix typo in example

### DIFF
--- a/docs/as-a-data-transfer-object/collections.md
+++ b/docs/as-a-data-transfer-object/collections.md
@@ -111,7 +111,7 @@ use Illuminate\Support\Collection;
 
 class AlbumData extends Data
 {    
-    public string $title
+    public string $title;
     /** @var Collection<int, SongData> */
     public Collection $songs;
 }


### PR DESCRIPTION
Missing semicolon here