### PR TITLE
fix: support arrays when transforming paginator data

### DIFF
--- a/src/Resolvers/TransformedDataCollectableResolver.php
+++ b/src/Resolvers/TransformedDataCollectableResolver.php
@@ -82,7 +82,7 @@ class TransformedDataCollectableResolver
         Wrap $wrap,
         TransformationContext $nestedContext,
     ): array {
-        $paginator = $paginator->through(fn (BaseData $data) => $this->transformationClosure($nestedContext)($data));
+        $paginator = $paginator->through(fn (array|BaseData $data) => $this->transformationClosure($nestedContext)($data));
 
         if ($nestedContext->transformValues === false) {
             return $paginator->all();
@@ -105,7 +105,7 @@ class TransformedDataCollectableResolver
     protected function transformationClosure(
         TransformationContext $nestedContext,
     ): Closure {
-        return function (BaseData $data) use ($nestedContext) {
+        return function (array|BaseData $data) use ($nestedContext) {
             if (! $data instanceof TransformableData || ! $nestedContext->transformValues) {
                 return $data;
             }


### PR DESCRIPTION
This pull request fixes an error that I am encountering when serializing a paginated data collection: https://flareapp.io/share/LPdKl3dm

I haven't got to the bottom of it by lack of time, but the gist is that the following does not work:

```php
public function index()
{
    $chirps = Chirp::query()
        ->forHomePage()
        ->paginate();

    return hybridly('chirps.index', [
        'chirps' => ChirpData::collect($chirps, PaginatedDataCollection::class),
    ]);
}
```

While this does work:

```php
public function index()
{
    $chirps = Chirp::query()
        ->forHomePage()
        ->paginate();

    return hybridly('chirps.index', [
        'chirps' => ChirpData::collect($chirps, PaginatedDataCollection::class)->transform(),
    ]);
}
```

Notice how the collection is manually transformed there. 

I'm not sure yet why this happens, but I figured due to the condition in `transformationClosure` that the `$data` argument could be something else than a `BaseData` anyway, which would fix the issue.