### PR TITLE
Handle `null` for `fieldContext` within `resolvePotentialPartialArray`

### DIFF
--- a/src/Resolvers/TransformedDataResolver.php
+++ b/src/Resolvers/TransformedDataResolver.php
@@ -213,8 +213,12 @@ class TransformedDataResolver
 
     protected function resolvePotentialPartialArray(
         array $value,
-        TransformationContext $fieldContext,
+        ?TransformationContext $fieldContext,
     ): array {
+        if($fieldContext === null) {
+            return $value;
+        }
+
         if ($fieldContext->exceptPartials && $fieldContext->exceptPartials->count() > 0) {
             $partials = [];
 


### PR DESCRIPTION
When `resolvePropertyValue` calls `resolvePotentialPartialArray` there is an exception thrown if `$fieldContext` is null. This is possible because the parameters of `resolvePropertyValue` contain `?TransformationContext $fieldContext` which means it can be `null` but wasn't allowed to be null within `resolvePotentialPartialArray`.

**This fixes that and was tested by making our own test suite pass again and errors going away when using our application.**