### PR TITLE
Provide fallbacks for config values

### DIFF
--- a/src/Support/Caching/DataStructureCache.php
+++ b/src/Support/Caching/DataStructureCache.php
@@ -17,9 +17,9 @@ class DataStructureCache
     public function __construct(
         protected array $cacheConfig,
     ) {
-        $this->store = cache()->store($this->cacheConfig['store'])?->getStore();
-        $this->prefix = $this->cacheConfig['prefix'] ? "{$this->cacheConfig['prefix']}." : '';
-        $this->duration = $this->cacheConfig['duration'];
+        $this->store = cache()->store(($this->cacheConfig['store'] ?? null))?->getStore();
+        $this->prefix = ($this->cacheConfig['prefix'] ?? '') ? "{$this->cacheConfig['prefix']}." : '';
+        $this->duration = $this->cacheConfig['duration'] ?? null;
     }
 
     public function getConfig(): ?CachedDataConfig


### PR DESCRIPTION
I expected Laravel to fall back to the package config for the new `structure_caching.cache.duration` setting, but didn't realize that only applies to new top-level config values.

I provided a fallback setting in `DataStructureCache`, and added some for the other settings to to avoid misconfiguration in the future.