### PR TITLE
fix: avoid mutation during `DataCollectable` transformation

### DIFF
--- a/src/Resolvers/TransformedDataCollectableResolver.php
+++ b/src/Resolvers/TransformedDataCollectableResolver.php
@@ -82,7 +82,7 @@ class TransformedDataCollectableResolver
         Wrap $wrap,
         TransformationContext $nestedContext,
     ): array {
-        $paginator = $paginator->through(fn (BaseData $data) => $this->transformationClosure($nestedContext)($data));
+        $items = array_map(fn (BaseData $data) => $this->transformationClosure($nestedContext)($data), $paginator->items());
 
         if ($nestedContext->transformValues === false) {
             return $paginator->all();
@@ -93,7 +93,7 @@ class TransformedDataCollectableResolver
         $wrapKey = $wrap->getKey() ?? 'data';
 
         return [
-            $wrapKey => $paginated['data'],
+            $wrapKey => $items,
             'links' => $paginated['links'] ?? [],
             'meta' => Arr::except($paginated, [
                 'data',

--- a/src/Resolvers/TransformedDataCollectableResolver.php
+++ b/src/Resolvers/TransformedDataCollectableResolver.php
@@ -85,7 +85,7 @@ class TransformedDataCollectableResolver
         $items = array_map(fn (BaseData $data) => $this->transformationClosure($nestedContext)($data), $paginator->items());
 
         if ($nestedContext->transformValues === false) {
-            return $paginator->all();
+            return $items;
         }
 
         $paginated = $paginator->toArray();

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\LazyCollection;
 use Spatie\LaravelData\DataCollection;
 use Spatie\LaravelData\PaginatedDataCollection;
@@ -275,4 +276,34 @@ it('can use a custom collection extended from collection to collect a collection
     expect($collection)->toBeInstanceOf(CustomCollection::class);
     expect($collection[0])->toBeInstanceOf(SimpleData::class);
     expect($collection[1])->toBeInstanceOf(SimpleData::class);
+});
+
+it('does not mutate wrapped paginators during transformation', function () {
+    $paginatorOfSimpleData = new Paginator([
+        ['string' => 'A'],
+        ['string' => 'B'],
+    ], perPage: 15);
+
+    $collection = SimpleData::collect($paginatorOfSimpleData, PaginatedDataCollection::class);
+    $expect = [
+        'data' => [
+            ['string' => 'A'],
+            ['string' => 'B'],
+        ],
+        'links' => [],
+        'meta' => [
+            'current_page' => 1,
+            'first_page_url' => '/?page=1',
+            'from' => 1,
+            'next_page_url' => null,
+            'path' => '/',
+            'per_page' => 15,
+            'prev_page_url' => null,
+            'to' => 2,
+        ],
+    ];
+
+    // Perform the transformation twice, the second should not throw
+    expect($collection->toArray())->toBe($expect);
+    expect($collection->toArray())->toBe($expect);
 });


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/spatie/laravel-data/pull/682.

The issue was that paginators inside `DataCollection` classes were mutated upon transformation, resulting in an exception when trying to transform them again.