### PR TITLE
fix: not ignore magical creation for nested DTOs;

### DIFF
--- a/src/DataPipes/CastPropertiesDataPipe.php
+++ b/src/DataPipes/CastPropertiesDataPipe.php
@@ -85,11 +85,13 @@ class CastPropertiesDataPipe implements DataPipe
             $property->type->kind->isDataObject()
             || $property->type->kind->isDataCollectable()
         ) {
-            $context = $creationContext->next($property->type->dataClass, $property->name);
+            $propertyCreationContextFactory = CreationContextFactory::createFromConfig($property->type->dataClass);
+            $propertyCreationContext = $propertyCreationContextFactory->get();
+            $propertyCreationContext->next($property->type->dataClass, $property->name);
 
             return $property->type->kind->isDataObject()
-                ? $context->from($value)
-                : $context->collect($value, $property->type->iterableClass);
+                ? $propertyCreationContext->from($value)
+                : $propertyCreationContext->collect($value, $property->type->iterableClass);
         }
 
         if (

--- a/src/DataPipes/CastPropertiesDataPipe.php
+++ b/src/DataPipes/CastPropertiesDataPipe.php
@@ -9,6 +9,7 @@ use Spatie\LaravelData\Enums\DataTypeKind;
 use Spatie\LaravelData\Lazy;
 use Spatie\LaravelData\Optional;
 use Spatie\LaravelData\Support\Creation\CreationContext;
+use Spatie\LaravelData\Support\Creation\CreationContextFactory;
 use Spatie\LaravelData\Support\DataClass;
 use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelData\Support\DataProperty;


### PR DESCRIPTION
fixes #701;

I might not see the reasons for it to use the same CreationContext, but it seems to me that there's no one.

There's also some CreationContext next/previous jumping in the `Spatie\LaravelData\Resolvers\DataCollectableFromSomethingResolver::itemsToDataClosure` but I can't tell if it is connected to the issue. 
