### PR TITLE
Cast value to string for createFromFormat

### DIFF
--- a/src/Casts/DateTimeInterfaceCast.php
+++ b/src/Casts/DateTimeInterfaceCast.php
@@ -42,7 +42,7 @@ class DateTimeInterfaceCast implements Cast, IterableItemCast
         $datetime = $formats
             ->map(fn (string $format) => rescue(fn () => $type::createFromFormat(
                 $format,
-                $value,
+                (string) $value,
                 isset($this->timeZone) ? new DateTimeZone($this->timeZone) : null
             ), report: false))
             ->first(fn ($value) => (bool) $value);


### PR DESCRIPTION
Cast `$value` to `string` explictly because `DateTime::createFromFormat()` expects `string` since PHP 8

Fix #708