### PR TITLE
Add new section to the docs for package testing

### DIFF
--- a/docs/advanced-usage/in-packages.md
+++ b/docs/advanced-usage/in-packages.md
@@ -1,0 +1,23 @@
+---
+title: In Packages
+weight: 18
+---
+
+## Testing
+
+When you're developing a package, running into config access issues is quite common, especially when using the magic from factory method, which won't resolve the factory instance without the config. Simply include our Provider in your package's TestCase, and you're all set.
+
+```php
+use Orchestra\Testbench\TestCase as Orchestra;
+
+class TestCase extends Orchestra
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            LaravelDataServiceProvider::class,
+            // Register additional service providers to use with your tests
+        ];
+    }
+}
+``` 


### PR DESCRIPTION
Reference to #406 
This PR introduces a new section in the docs to guide developers on resolving config issues during package testing.