### PR TITLE
Fix pagination documentation

### DIFF
--- a/docs/as-a-resource/from-data-to-resource.md
+++ b/docs/as-a-resource/from-data-to-resource.md
@@ -52,7 +52,7 @@ Will return a collection automatically transformed to JSON:
 It is also possible to provide a paginator:
 
 ```php
-SongData::collect(Song::paginate());
+SongData::collect(Song::paginate(), PaginatedDataCollection::class);
 ```
 
 The data object is smart enough to create a paginated response from this with links to the next, previous, last, ... pages:


### PR DESCRIPTION
Without passing `PaginatedDataCollection::class` into collect since v4, the data would not be presented as in the documentation