### PR TITLE
Adds a config option to silently ignore when a Computed Property is being set

### DIFF
--- a/config/data.php
+++ b/config/data.php
@@ -136,6 +136,13 @@ return [
     'throw_when_max_transformation_depth_reached' => true,
 
     /**
+     * When trying to set a computed property value, the package will throw an exception.
+     * You can disable this behaviour by setting this option to false, which will then just
+     * ignore the value being passed into the computed property and recalculate it.
+     */
+    'throw_when_trying_to_set_computed_property_value' => true,
+
+    /**
     * When using the `make:data` command, the package will use these settings to generate
     * the data classes. You can override these settings by passing options to the command.
     */

--- a/config/data.php
+++ b/config/data.php
@@ -17,6 +17,13 @@ return [
      */
     'features' => [
         'cast_and_transform_iterables' => false,
+
+        /**
+         * When trying to set a computed property value, the package will throw an exception.
+         * You can disable this behaviour by setting this option to true, which will then just
+         * ignore the value being passed into the computed property and recalculate it.
+         */
+        'ignore_exception_when_trying_to_set_computed_property_value' => false,
     ],
 
     /**
@@ -134,13 +141,6 @@ return [
      * empty array.
      */
     'throw_when_max_transformation_depth_reached' => true,
-
-    /**
-     * When trying to set a computed property value, the package will throw an exception.
-     * You can disable this behaviour by setting this option to false, which will then just
-     * ignore the value being passed into the computed property and recalculate it.
-     */
-    'throw_when_trying_to_set_computed_property_value' => true,
 
     /**
     * When using the `make:data` command, the package will use these settings to generate

--- a/docs/as-a-data-transfer-object/computed.md
+++ b/docs/as-a-data-transfer-object/computed.md
@@ -34,5 +34,5 @@ Again there are a few conditions for this approach:
 
 - You must always use a sole property, a property within the constructor definition won't work
 - Computed properties cannot be defined in the payload, a `CannotSetComputedValue` will be thrown if this is the case
-- If the `throw_when_trying_to_set_computed_property_value` configuration option is set to `false`, the computed property will be silently ignored when trying to set it in the payload and no `CannotSetComputedValue` exception will be thrown.
+- If the `ignore_exception_when_trying_to_set_computed_property_value` configuration option is set to `true`, the computed property will be silently ignored when trying to set it in the payload and no `CannotSetComputedValue` exception will be thrown.
 

--- a/docs/as-a-data-transfer-object/computed.md
+++ b/docs/as-a-data-transfer-object/computed.md
@@ -34,4 +34,5 @@ Again there are a few conditions for this approach:
 
 - You must always use a sole property, a property within the constructor definition won't work
 - Computed properties cannot be defined in the payload, a `CannotSetComputedValue` will be thrown if this is the case
+- If the `throw_when_trying_to_set_computed_property_value` configuration option is set to `false`, the computed property will be silently ignored when trying to set it in the payload and no `CannotSetComputedValue` exception will be thrown.
 

--- a/src/Resolvers/DataFromArrayResolver.php
+++ b/src/Resolvers/DataFromArrayResolver.php
@@ -54,11 +54,11 @@ class DataFromArrayResolver
             }
 
             if ($property->computed) {
-                if (! config('data.throw_when_trying_to_set_computed_property_value')) {
-                    continue; // Ignore the value being passed into the computed property and let it be recalculated
+                if (config('data.throw_when_trying_to_set_computed_property_value')) {
+                    throw CannotSetComputedValue::create($property);
                 }
 
-                throw CannotSetComputedValue::create($property);
+                continue; // Ignore the value being passed into the computed property and let it be recalculated
             }
 
             $data->{$property->name} = $properties[$property->name];

--- a/src/Resolvers/DataFromArrayResolver.php
+++ b/src/Resolvers/DataFromArrayResolver.php
@@ -54,7 +54,7 @@ class DataFromArrayResolver
             }
 
             if ($property->computed) {
-                if (config('data.throw_when_trying_to_set_computed_property_value')) {
+                if (! config('data.features.ignore_exception_when_trying_to_set_computed_property_value')) {
                     throw CannotSetComputedValue::create($property);
                 }
 

--- a/src/Resolvers/DataFromArrayResolver.php
+++ b/src/Resolvers/DataFromArrayResolver.php
@@ -54,6 +54,10 @@ class DataFromArrayResolver
             }
 
             if ($property->computed) {
+                if (! config('data.throw_when_trying_to_set_computed_property_value')) {
+                    continue; // Ignore the value being passed into the computed property and let it be recalculated
+                }
+
                 throw CannotSetComputedValue::create($property);
             }
 

--- a/tests/CreationTest.php
+++ b/tests/CreationTest.php
@@ -657,6 +657,18 @@ it('can have a computed value when creating the data object', function () {
         }
     };
 
+    expect($dataObject::from(['first_name' => 'Ruben', 'last_name' => 'Van Assche', 'full_name' => 'Something to Be Ignored']))
+        ->first_name->toBe('Ruben')
+        ->last_name->toBe('Van Assche')
+        ->full_name->toBe('Ruben Van Assche');
+
+    expect($dataObject::validateAndCreate(['first_name' => 'Ruben', 'last_name' => 'Van Assche', 'full_name' => 'Something to Be Ignored']))
+        ->first_name->toBe('Ruben')
+        ->last_name->toBe('Van Assche')
+        ->full_name->toBe('Ruben Van Assche');
+
+    config()->set('data.features.ignore_exception_when_trying_to_set_computed_property_value', false);
+
     expect($dataObject::from(['first_name' => 'Ruben', 'last_name' => 'Van Assche']))
         ->first_name->toBe('Ruben')
         ->last_name->toBe('Van Assche')
@@ -669,18 +681,6 @@ it('can have a computed value when creating the data object', function () {
 
     expect(fn () => $dataObject::from(['first_name' => 'Ruben', 'last_name' => 'Van Assche', 'full_name' => 'Ruben Versieck']))
         ->toThrow(CannotSetComputedValue::class);
-
-    config()->set('data.throw_when_trying_to_set_computed_property_value', false);
-
-    expect($dataObject::from(['first_name' => 'Ruben', 'last_name' => 'Van Assche', 'full_name' => 'Something to Be Ignored']))
-        ->first_name->toBe('Ruben')
-        ->last_name->toBe('Van Assche')
-        ->full_name->toBe('Ruben Van Assche');
-
-    expect($dataObject::validateAndCreate(['first_name' => 'Ruben', 'last_name' => 'Van Assche', 'full_name' => 'Something to Be Ignored']))
-        ->first_name->toBe('Ruben')
-        ->last_name->toBe('Van Assche')
-        ->full_name->toBe('Ruben Van Assche');
 });
 
 it('can have a nullable computed value', function () {

--- a/tests/CreationTest.php
+++ b/tests/CreationTest.php
@@ -669,6 +669,18 @@ it('can have a computed value when creating the data object', function () {
 
     expect(fn () => $dataObject::from(['first_name' => 'Ruben', 'last_name' => 'Van Assche', 'full_name' => 'Ruben Versieck']))
         ->toThrow(CannotSetComputedValue::class);
+
+    config()->set('data.throw_when_trying_to_set_computed_property_value', false);
+
+    expect($dataObject::from(['first_name' => 'Ruben', 'last_name' => 'Van Assche', 'full_name' => 'Something to Be Ignored']))
+        ->first_name->toBe('Ruben')
+        ->last_name->toBe('Van Assche')
+        ->full_name->toBe('Ruben Van Assche');
+
+    expect($dataObject::validateAndCreate(['first_name' => 'Ruben', 'last_name' => 'Van Assche', 'full_name' => 'Something to Be Ignored']))
+        ->first_name->toBe('Ruben')
+        ->last_name->toBe('Van Assche')
+        ->full_name->toBe('Ruben Van Assche');
 });
 
 it('can have a nullable computed value', function () {


### PR DESCRIPTION
When creating a `Data` object, if the array contains a computed property, it'll throw an error.

This is a problem when casting a `Model` property into a `Data` if it contains a computed property.

Adding `#[Hidden]` may not be feasible for all scenarios.

In order to resolve this issue, I added a `throw_when_trying_to_set_computed_property_value` config option - which is `true` by default to avoid breaking backwards compatibility.

Setting that option as `false` will make the computed property attempted to be set to be silently ignored, allowing it to be recalculated.

----

Somewhat resolves #613 (It still stores the computed property in the DB, but doesn't error out when retrieving it).