### PR TITLE
Change default cache variable

### DIFF
--- a/config/data.php
+++ b/config/data.php
@@ -96,7 +96,7 @@ return [
         'enabled' => true,
         'directories' => [app_path('Data')],
         'cache' => [
-            'store' => env('CACHE_DRIVER', 'file'),
+            'store' => env('CACHE_STORE', 'file'),
             'prefix' => 'laravel-data',
             'duration' => null,
         ],


### PR DESCRIPTION
Small change:
Laravel 11 uses `CACHE_STORE` instead of old `CACHE_DRIVER` now
https://github.com/laravel/laravel/blob/11.x/.env.example#L39