### PR TITLE
Fix: nested collection lazy only includes the first element in the collection

### DIFF
--- a/src/DataPipes/CastPropertiesDataPipe.php
+++ b/src/DataPipes/CastPropertiesDataPipe.php
@@ -87,9 +87,13 @@ class CastPropertiesDataPipe implements DataPipe
         ) {
             $context = $creationContext->next($property->type->dataClass, $property->name);
 
-            return $property->type->kind->isDataObject()
+            $res = $property->type->kind->isDataObject()
                 ? $context->from($value)
                 : $context->collect($value, $property->type->iterableClass);
+
+            $creationContext->previous();
+
+            return $res;
         }
 
         if (

--- a/src/Resolvers/VisibleDataFieldsResolver.php
+++ b/src/Resolvers/VisibleDataFieldsResolver.php
@@ -134,7 +134,7 @@ class VisibleDataFieldsResolver
 
             if ($nested = $exceptPartial->getNested()) {
                 try {
-                    $fields[$nested]->addExceptPartial($exceptPartial->next());
+                    $fields[$nested]->addExceptPartial((clone $exceptPartial)->next());
                 } catch (ErrorException $exception) {
                     $this->handleNonExistingNestedField($exception, PartialType::Except, $nested, $dataClass, $transformationContext);
                 }
@@ -172,7 +172,7 @@ class VisibleDataFieldsResolver
 
             if ($nested = $onlyPartial->getNested()) {
                 try {
-                    $fields[$nested]->addOnlyPartial($onlyPartial->next());
+                    $fields[$nested]?->addOnlyPartial((clone $onlyPartial)->next());
                     $onlyFields[] = $nested;
                 } catch (ErrorException $exception) {
                     $this->handleNonExistingNestedField($exception, PartialType::Only, $nested, $dataClass, $transformationContext);
@@ -279,7 +279,7 @@ class VisibleDataFieldsResolver
 
             if ($nested = $excludePartial->getNested()) {
                 try {
-                    $fields[$nested]->addExcludedPartial($excludePartial->next());
+                    $fields[$nested]?->addExcludedPartial((clone $excludePartial)->next());
                 } catch (ErrorException $exception) {
                     $this->handleNonExistingNestedField($exception, PartialType::Exclude, $nested, $dataClass, $transformationContext);
                 }

--- a/src/Resolvers/VisibleDataFieldsResolver.php
+++ b/src/Resolvers/VisibleDataFieldsResolver.php
@@ -231,7 +231,7 @@ class VisibleDataFieldsResolver
 
             if ($nested = $includedPartial->getNested()) {
                 try {
-                    $fields[$nested]->addIncludedPartial($includedPartial->next());
+                    $fields[$nested]?->addIncludedPartial($includedPartial->next());
                     $includedFields[] = $nested;
                 } catch (ErrorException $exception) {
                     $this->handleNonExistingNestedField($exception, PartialType::Include, $nested, $dataClass, $transformationContext);

--- a/src/Resolvers/VisibleDataFieldsResolver.php
+++ b/src/Resolvers/VisibleDataFieldsResolver.php
@@ -231,7 +231,7 @@ class VisibleDataFieldsResolver
 
             if ($nested = $includedPartial->getNested()) {
                 try {
-                    $fields[$nested]?->addIncludedPartial($includedPartial->next());
+                    $fields[$nested]?->addIncludedPartial((clone $includedPartial)->next());
                     $includedFields[] = $nested;
                 } catch (ErrorException $exception) {
                     $this->handleNonExistingNestedField($exception, PartialType::Include, $nested, $dataClass, $transformationContext);

--- a/tests/Fakes/DummyDto.php
+++ b/tests/Fakes/DummyDto.php
@@ -20,4 +20,9 @@ class DummyDto
     {
         return new self('Bon Jovi', 'Living on a prayer', 1986);
     }
+
+    public static function darude(): static
+    {
+        return new self('Darude', 'sandstorm', 2000);
+    }
 }

--- a/tests/PartialsTest.php
+++ b/tests/PartialsTest.php
@@ -225,6 +225,53 @@ it('can conditionally include nested', function () {
         ]);
 });
 
+it('doesnt throw when nested collection lazy is not a data collection', function () {
+    $dataClass = new class () extends Data {
+        public Collection $nested;
+    };
+
+    $data = $dataClass::collect([
+        [
+            'nested' => [DummyDto::rick()],
+        ],
+    ], DataCollection::class);
+
+    expect($data->include('nested.artist')->toArray())
+        ->toMatchArray([
+            ['nested' => [DummyDto::rick()]],
+        ]);
+});
+
+it('can conditionally include nested collection', function () {
+    $dataClass = new class () extends Data {
+        #[DataCollectionOf(MultiLazyData::class)]
+        public Collection $nested;
+    };
+
+    $data = $dataClass::collect([
+        [
+            'nested' => [DummyDto::rick()],
+        ], [
+            'nested' => [DummyDto::darude()],
+        ], [
+            'nested' => [DummyDto::bon()],
+        ]
+    ], DataCollection::class);
+
+    expect($data->toArray())->toMatchArray([
+        ['nested' => [[]]],
+        ['nested' => [[]]],
+        ['nested' => [[]]]
+    ]);
+
+    expect($data->include('nested.{artist,year}')->toArray())
+        ->toMatchArray([
+            ['nested' => [['artist' => DummyDto::rick()->artist, 'year' => DummyDto::rick()->year]]],
+            ['nested' => [['artist' => DummyDto::darude()->artist, 'year' => DummyDto::darude()->year]]],
+            ['nested' => [['artist' => DummyDto::bon()->artist, 'year' => DummyDto::bon()->year]]]
+        ]);
+});
+
 it('can conditionally include using class defaults', function () {
     PartialClassConditionalData::setDefinitions(includeDefinitions: [
         'string' => fn (PartialClassConditionalData $data) => $data->enabled,


### PR DESCRIPTION
Might not be the exact same issue as #677 but definitely related

If you have a collection within a collection, including lazy keys will only include the key in the first item of the collection