### PR TITLE
Improve performance of CastPropertiesDataPipe by using

### DIFF
--- a/src/DataPipes/CastPropertiesDataPipe.php
+++ b/src/DataPipes/CastPropertiesDataPipe.php
@@ -27,7 +27,7 @@ class CastPropertiesDataPipe implements DataPipe
         CreationContext $creationContext
     ): array {
         foreach ($properties as $name => $value) {
-            $dataProperty = $class->properties->first(fn (DataProperty $dataProperty) => $dataProperty->name === $name);
+            $dataProperty = $class->properties[$name] ?? null;
 
             if ($dataProperty === null) {
                 continue;


### PR DESCRIPTION
Hi Spatie developers.

I was running into some performance issues when creating thousands of data objects from array payloads, which lead me to run the xdebug profiler.

I setup a local benchmark where I created and validated 10k data objects using the `::collect` method, the data class has 18 properties, most of which have casts in place (enums, Carbon, and other custom casts)

I noticed from my xdebug profile results that the closure in the deleted line is ran a whopping 1.710.000 times. By replacing with the new line, I managed to reduce my crude benchmark from an 11 seconds runtime, to 6.5 seconds. I thought you would be interested in this finding.

Unfortunately I am not very well versed in this project, and I am a bit uncertain if the `DataClass:properties` collection is always keyed by the data property name, but I am hoping we can collaborate into merging either this change, or a similar change, that introduces a hash lookup instead of the `->first` method currently in place. 