### PR TITLE
Allow to pass multiple formats to Laravel's `date_format` rule

### DIFF
--- a/src/Attributes/Validation/DateFormat.php
+++ b/src/Attributes/Validation/DateFormat.php
@@ -3,12 +3,17 @@
 namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
+use Illuminate\Support\Arr;
+use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class DateFormat extends StringValidationAttribute
 {
-    public function __construct(protected string $format)
+    protected string|array $format;
+
+    public function __construct(string|array|RouteParameterReference ...$format)
     {
+        $this->format = Arr::flatten($format);
     }
 
     public static function keyword(): string

--- a/tests/Datasets/RulesDataset.php
+++ b/tests/Datasets/RulesDataset.php
@@ -124,6 +124,7 @@ dataset('attributes', function () {
     yield from betweenAttributes();
     yield from currentPasswordAttributes();
     yield from dateEqualsAttributes();
+    yield from dateFormatAttributes();
     yield from dimensionsAttributes();
     yield from distinctAttributes();
     yield from doesntEndWithAttributes();
@@ -193,11 +194,6 @@ dataset('attributes', function () {
     yield fixature(
         attribute: new Date(),
         expected: 'date',
-    );
-
-    yield fixature(
-        attribute: new DateFormat('Y-m-d'),
-        expected: 'date_format:Y-m-d',
     );
 
     yield fixature(
@@ -581,6 +577,24 @@ function dateEqualsAttributes(): Generator
     yield fixature(
         attribute: new DateEquals('2020-05-15 00:00:00'),
         expected: 'date_equals:2020-05-15 00:00:00',
+    );
+}
+
+function dateFormatAttributes(): Generator
+{
+    yield fixature(
+        attribute: new DateFormat('Y-m-d'),
+        expected: 'date_format:Y-m-d',
+    );
+
+    yield fixature(
+        attribute: new DateFormat(['Y-m-d', 'Y-m-d H:i:s']),
+        expected: 'date_format:Y-m-d,Y-m-d H:i:s',
+    );
+
+    yield fixature(
+        attribute: new DateFormat('Y-m-d', 'Y-m-d H:i:s'),
+        expected: 'date_format:Y-m-d,Y-m-d H:i:s',
     );
 }
 


### PR DESCRIPTION
Laravel's [date_format validation rule](https://laravel.com/docs/11.x/validation#rule-date-format) accepts multiple date format arguments.