### PR TITLE
Add attribute for Laravel's `list` validation rule

### DIFF
--- a/src/Attributes/Validation/ListType.php
+++ b/src/Attributes/Validation/ListType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\LaravelData\Attributes\Validation;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+class ListType extends StringValidationAttribute
+{
+    public static function keyword(): string
+    {
+        return 'list';
+    }
+
+    public function parameters(): array
+    {
+        return [];
+    }
+}

--- a/src/Support/Validation/ValidationRuleFactory.php
+++ b/src/Support/Validation/ValidationRuleFactory.php
@@ -54,6 +54,7 @@ use Spatie\LaravelData\Attributes\Validation\IPv6;
 use Spatie\LaravelData\Attributes\Validation\Json;
 use Spatie\LaravelData\Attributes\Validation\LessThan;
 use Spatie\LaravelData\Attributes\Validation\LessThanOrEqualTo;
+use Spatie\LaravelData\Attributes\Validation\ListType;
 use Spatie\LaravelData\Attributes\Validation\Lowercase;
 use Spatie\LaravelData\Attributes\Validation\MacAddress;
 use Spatie\LaravelData\Attributes\Validation\Max;
@@ -164,6 +165,7 @@ class ValidationRuleFactory
             Json::keyword() => Json::class,
             LessThan::keyword() => LessThan::class,
             LessThanOrEqualTo::keyword() => LessThanOrEqualTo::class,
+            ListType::keyword() => ListType::class,
             Lowercase::keyword() => Lowercase::class,
             MacAddress::keyword() => MacAddress::class,
             Max::keyword() => Max::class,

--- a/tests/Datasets/RulesDataset.php
+++ b/tests/Datasets/RulesDataset.php
@@ -57,6 +57,7 @@ use Spatie\LaravelData\Attributes\Validation\IPv6;
 use Spatie\LaravelData\Attributes\Validation\Json;
 use Spatie\LaravelData\Attributes\Validation\LessThan;
 use Spatie\LaravelData\Attributes\Validation\LessThanOrEqualTo;
+use Spatie\LaravelData\Attributes\Validation\ListType;
 use Spatie\LaravelData\Attributes\Validation\Lowercase;
 use Spatie\LaravelData\Attributes\Validation\MacAddress;
 use Spatie\LaravelData\Attributes\Validation\Max;
@@ -312,6 +313,11 @@ dataset('attributes', function () {
     yield fixature(
         attribute: new LessThanOrEqualTo('field'),
         expected: 'lte:field',
+    );
+
+    yield fixature(
+        attribute: new ListType(),
+        expected: 'list',
     );
 
     yield fixature(


### PR DESCRIPTION
Attribute for the recently introduced [list validation rule](https://laravel.com/docs/11.x/validation#rule-list) in Laravel 11.