### PR TITLE
Fix: load model relations and attributes only if necessary 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,7 @@ Laravel-data 4.0.0 was released 5 hours ago, time for an update!
 
 - Make ValidationPath Stringable
 - Fix PHPStan
-- Improve performance when optional peoperty exists (#612)
+- Improve performance when optional property exists (#612)
 
 ## 3.10.0 - 2023-12-01
 

--- a/src/Concerns/BaseData.php
+++ b/src/Concerns/BaseData.php
@@ -16,6 +16,7 @@ use Spatie\LaravelData\DataPipes\AuthorizedDataPipe;
 use Spatie\LaravelData\DataPipes\CastPropertiesDataPipe;
 use Spatie\LaravelData\DataPipes\DefaultValuesDataPipe;
 use Spatie\LaravelData\DataPipes\FillRouteParameterPropertiesDataPipe;
+use Spatie\LaravelData\DataPipes\LoadsModelRelationsDataPipe;
 use Spatie\LaravelData\DataPipes\MapPropertiesDataPipe;
 use Spatie\LaravelData\DataPipes\ValidatePropertiesDataPipe;
 use Spatie\LaravelData\PaginatedDataCollection;
@@ -69,6 +70,7 @@ trait BaseData
     {
         return DataPipeline::create()
             ->into(static::class)
+            ->through(LoadsModelRelationsDataPipe::class)
             ->through(AuthorizedDataPipe::class)
             ->through(MapPropertiesDataPipe::class)
             ->through(FillRouteParameterPropertiesDataPipe::class)

--- a/src/DataPipes/LoadsModelRelationsDataPipe.php
+++ b/src/DataPipes/LoadsModelRelationsDataPipe.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Spatie\LaravelData\DataPipes;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\RelationNotFoundException;
+use Illuminate\Support\Str;
+use Spatie\LaravelData\Lazy;
+use Spatie\LaravelData\Optional;
+use Spatie\LaravelData\Support\Creation\CreationContext;
+use Spatie\LaravelData\Support\DataClass;
+
+class LoadsModelRelationsDataPipe implements DataPipe
+{
+    public function handle(mixed $payload, DataClass $class, array $properties, CreationContext $creationContext): array
+    {
+        if ($payload instanceof Model) {
+            foreach ($class->properties as $dataProperty) {
+                if (isset($properties[$dataProperty->name])) {
+                    continue;
+                }
+                $relation = $dataProperty->inputMappedName ?? $dataProperty->name;
+
+                $relationRetriever = function () use ($payload, $relation) {
+                    try {
+                        $relationName = $payload::$snakeAttributes ? Str::camel($relation) : $relation;
+                        return $payload->loadMissing($relationName)->{$relationName};
+                    } catch (RelationNotFoundException) {
+                        return $payload->{$relation};
+                    }
+                };
+
+                $properties[$dataProperty->name] = match(true) {
+                    (bool)$dataProperty->type->lazyType => Lazy::create($relationRetriever)->defaultIncluded(!$dataProperty->type->isOptional && !$dataProperty->type->isNullable),
+                    $dataProperty->type->isOptional => Optional::create(),
+                    !$dataProperty->type->isNullable => $relationRetriever(),
+                    default => null,
+                };
+            }
+        }
+
+        return $properties;
+    }
+}

--- a/src/Normalizers/ModelNormalizer.php
+++ b/src/Normalizers/ModelNormalizer.php
@@ -37,10 +37,6 @@ class ModelNormalizer implements Normalizer
             }
         }
 
-        foreach ($value->getMutatedAttributes() as $key) {
-            $properties[$key] = $value->getAttribute($key);
-        }
-
         return $properties;
     }
 

--- a/src/Resolvers/TransformedDataCollectableResolver.php
+++ b/src/Resolvers/TransformedDataCollectableResolver.php
@@ -112,7 +112,7 @@ class TransformedDataCollectableResolver
     protected function transformationClosure(
         TransformationContext $nestedContext,
     ): Closure {
-        return function (BaseData $data) use ($nestedContext) {
+        return function ($data) use ($nestedContext) {
             if (! $data instanceof TransformableData) {
                 return $data;
             }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -20,6 +20,7 @@ use Spatie\LaravelData\Contracts\WrappableData as WrappableDataContract;
 use Spatie\LaravelData\DataPipes\CastPropertiesDataPipe;
 use Spatie\LaravelData\DataPipes\DefaultValuesDataPipe;
 use Spatie\LaravelData\DataPipes\FillRouteParameterPropertiesDataPipe;
+use Spatie\LaravelData\DataPipes\LoadsModelRelationsDataPipe;
 use Spatie\LaravelData\DataPipes\MapPropertiesDataPipe;
 
 class Resource implements BaseDataContract, AppendableDataContract, IncludeableDataContract, TransformableDataContract, ResponsableDataContract, WrappableDataContract, EmptyDataContract
@@ -37,6 +38,7 @@ class Resource implements BaseDataContract, AppendableDataContract, IncludeableD
     {
         return DataPipeline::create()
             ->into(static::class)
+            ->through(LoadsModelRelationsDataPipe::class)
             ->through(MapPropertiesDataPipe::class)
             ->through(FillRouteParameterPropertiesDataPipe::class)
             ->through(DefaultValuesDataPipe::class)

--- a/tests/Fakes/Models/FakeModel.php
+++ b/tests/Fakes/Models/FakeModel.php
@@ -21,6 +21,11 @@ class FakeModel extends Model
         return $this->hasMany(FakeNestedModel::class);
     }
 
+    public function getFakeAttribute(): string
+    {
+        return 'this_is_fake';
+    }
+
     public function accessor(): Attribute
     {
         return Attribute::get(fn () => "accessor_{$this->string}");

--- a/tests/Normalizers/ModelNormalizerTest.php
+++ b/tests/Normalizers/ModelNormalizerTest.php
@@ -1,6 +1,13 @@
 <?php
 
+use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\DataCollection;
+use Spatie\LaravelData\Lazy;
+use Spatie\LaravelData\Optional;
+use Spatie\LaravelData\Support\Lazy\DefaultLazy;
 use Spatie\LaravelData\Tests\Fakes\FakeModelData;
+use Spatie\LaravelData\Tests\Fakes\FakeNestedModelData;
 use Spatie\LaravelData\Tests\Fakes\Models\FakeModel;
 use Spatie\LaravelData\Tests\Fakes\Models\FakeNestedModel;
 
@@ -37,6 +44,64 @@ it('can get a data object with nesting from model and relations', function () {
         ->string->toEqual($data->fake_nested_models[1]->string)
         ->nullable->toEqual($data->fake_nested_models[1]->nullable)
         ->date->toEqual($data->fake_nested_models[1]->date);
+});
+
+
+it('converts non loaded relations to either a lazy or load them if non nullable', function () {
+    $model = FakeModel::factory()->create();
+
+    FakeNestedModel::factory()->for($model)->create();
+    FakeNestedModel::factory()->for($model)->create();
+
+    $data = FakeModelData::from($model);
+
+    expect($data->toArray())->not()->toHaveKey('fake_nested_models')
+        ->and($data->fake_nested_models)->toBeInstanceOf(Optional::class);
+
+    class FakeModelDataNonNullable extends Data
+    {
+        #[DataCollectionOf(FakeNestedModelData::class)]
+        public DataCollection $fake_nested_models;
+    }
+    $data = FakeModelDataNonNullable::from($model->withoutRelations());
+
+    expect($data->toArray())->toHaveKey('fake_nested_models')
+        ->and($data->fake_nested_models)->toHaveCount(2);
+
+    class FakeModelDataLazyNonNullable extends Data
+    {
+        #[DataCollectionOf(FakeNestedModelData::class)]
+        public Lazy|DataCollection $fake_nested_models;
+    }
+
+    $data = FakeModelDataLazyNonNullable::from($model->withoutRelations());
+
+    expect($data->toArray())->toHaveKey('fake_nested_models')
+        ->and($data->fake_nested_models)->toBeInstanceOf(DefaultLazy::class);
+
+    class FakeModelDataLazyNullable extends Data
+    {
+        #[DataCollectionOf(FakeNestedModelData::class)]
+        public null|Lazy|DataCollection $fake_nested_models;
+    }
+
+    $data = FakeModelDataLazyNullable::from($model->withoutRelations());
+
+    expect($data->toArray())->not()->toHaveKey('fake_nested_models')
+        ->and($data->fake_nested_models)->toBeInstanceOf(Lazy::class)
+        ->and($data->fake_nested_models->resolve())->toHaveCount(2);
+
+
+    class FakeModelDataNullable extends Data
+    {
+        #[DataCollectionOf(FakeNestedModelData::class)]
+        public null|DataCollection $fake_nested_models;
+    }
+
+    $data = FakeModelDataNullable::from($model->withoutRelations());
+
+    expect($data->toArray())->toHaveKey('fake_nested_models')
+        ->and($data->fake_nested_models)->toBeNull();
 });
 
 it('can get a data object from model with accessors', function () {

--- a/tests/Normalizers/ModelNormalizerTest.php
+++ b/tests/Normalizers/ModelNormalizerTest.php
@@ -83,12 +83,24 @@ it('converts non loaded relations to either a lazy or load them if non nullable'
     {
         #[DataCollectionOf(FakeNestedModelData::class)]
         public null|Lazy|DataCollection $fake_nested_models;
+        public int $fake_nested_models_count;
+        public string $fake;
     }
 
-    $data = FakeModelDataLazyNullable::from($model->withoutRelations());
+    $model = $model->withoutRelations();
+    $data = FakeModelDataLazyNullable::from($model);
 
-    expect($data->toArray())->not()->toHaveKey('fake_nested_models')
-        ->and($data->fake_nested_models)->toBeInstanceOf(Lazy::class)
+    $dataArr = $data->toArray();
+
+    expect($dataArr)->toHaveKey('fake')->and($dataArr['fake'])->toBe('this_is_fake');
+
+    expect($dataArr)->toHaveKey('fake_nested_models_count')
+        ->and($data->fake_nested_models_count)->toBe(2);
+
+    expect($dataArr)->not()->toHaveKey('fake_nested_models')
+        ->and($data->fake_nested_models)->toBeInstanceOf(Lazy::class);
+
+    expect($model->relationLoaded('fakeNestedModels'))->toBe(false)
         ->and($data->fake_nested_models->resolve())->toHaveCount(2);
 
 


### PR DESCRIPTION
Fixes #729 

It also fixes the performance issue (https://github.com/spatie/laravel-data/discussions/713) of `$value->getMutatedAttributes()` which was used to load attributes into model, but the issue is it would load ALL of the attributes of the model irrespective of wether they are needed or not by the data class

Ideally the normalizer would also get the same parameters as a data pipe, but this would be a breaking change to the interface,

I don't know which makes more sense, passing the DataClass to the normalizers and only getting the needed property or doing the whole data extraction logic in the data pipe and getting rid of the model normalizer