### PR TITLE
Fix wrong link to using attributes page

### DIFF
--- a/docs/validation/introduction.md
+++ b/docs/validation/introduction.md
@@ -107,7 +107,7 @@ class SongData extends Data
 
 When you provide an artist with a length of more than 20 characters, the validation will fail.
 
-There's a complete [chapter](/docs/laravel-data/v4/validation/using-attributes) dedicated to validation attributes.
+There's a complete [chapter](/docs/laravel-data/v4/validation/using-validation-attributes) dedicated to validation attributes.
 
 ### Manual rules
 


### PR DESCRIPTION
This PR fixes a wrong link in the docs.