### PR TITLE
Fix for the use of built-in class names in Collection annotations

### DIFF
--- a/src/Support/Annotations/DataIterableAnnotationReader.php
+++ b/src/Support/Annotations/DataIterableAnnotationReader.php
@@ -170,19 +170,19 @@ class DataIterableAnnotationReader
             ];
         }
 
-        if (class_exists($class)) {
+        $fcqn = $this->resolveFcqn($reflection, $class);
+
+        if (is_subclass_of($fcqn, BaseData::class)) {
             return [
-                'type' => $class,
-                'isData' => false,
+                'type' => $fcqn,
+                'isData' => true,
             ];
         }
 
-        $class = $this->resolveFcqn($reflection, $class);
-
-        if (is_subclass_of($class, BaseData::class)) {
+        if (class_exists($fcqn)) {
             return [
-                'type' => $class,
-                'isData' => true,
+                'type' => $fcqn,
+                'isData' => false,
             ];
         }
 

--- a/tests/Fakes/CollectionNonDataAnnotationsData.php
+++ b/tests/Fakes/CollectionNonDataAnnotationsData.php
@@ -55,6 +55,9 @@ class CollectionNonDataAnnotationsData
 
     public array $propertyO;
 
+    /** @var \Illuminate\Support\Collection<Error> */
+    public Collection $propertyP;
+
     /**
      * @param \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum[]|null $paramA
      * @param null|\Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum[] $paramB

--- a/tests/Fakes/Error.php
+++ b/tests/Fakes/Error.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Data;
+
+class Error extends Data
+{
+}

--- a/tests/Support/Annotations/DataIterableAnnotationReaderTest.php
+++ b/tests/Support/Annotations/DataIterableAnnotationReaderTest.php
@@ -6,6 +6,7 @@ use Spatie\LaravelData\Support\Annotations\DataIterableAnnotationReader;
 use Spatie\LaravelData\Tests\Fakes\CollectionDataAnnotationsData;
 use Spatie\LaravelData\Tests\Fakes\CollectionNonDataAnnotationsData;
 use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
+use Spatie\LaravelData\Tests\Fakes\Error;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
 
 it(
@@ -178,6 +179,11 @@ it(
     yield 'propertyL' => [
         'property' => 'propertyL',
         'expected' => new DataIterableAnnotation(DummyBackedEnum::class, isData: false),
+    ];
+
+    yield 'propertyP' => [
+        'property' => 'propertyP',
+        'expected' => new DataIterableAnnotation(Error::class, isData: true),
     ];
 });
 


### PR DESCRIPTION
Hi, found this when upgrading from v3 to v4.

In v3 you could do

```php
#[DataCollectionOf(Error::class)]
```

which would correctly pick up a class with the right namespace, even if its basename matches a builtin like `\Error`.

In v4 the same syntax is:

```php
/** @var Collection<Error> */
public Collection $errors;
```

But due to the order in which the `DataIterableAnnotationReader` determines the correct class, it discovers `\Error` before `App\Stuff\Error` or similar.

This PR reorders the resolution code so that it finds properly qualified classes before builtins.