### PR TITLE
v3 support for Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require" : {
         "php": "^8.1",
-        "illuminate/contracts": "^9.30|^10.0",
+        "illuminate/contracts": "^9.30|^10.0|^11.0",
         "phpdocumentor/type-resolver": "^1.5",
         "spatie/laravel-package-tools": "^1.9.0",
         "spatie/php-structure-discoverer": "^2.0"


### PR DESCRIPTION
We are stuck on laravel-data v3 for a little while longer but are attempting a Laravel 11 upgrade. This PR allows us to continue using laravel-data with the latest version of Laravel.