### PR TITLE
Abstract data object as collection

### DIFF
--- a/docs/advanced-usage/eloquent-casting.md
+++ b/docs/advanced-usage/eloquent-casting.md
@@ -115,6 +115,19 @@ The child data object value of the model will be stored in the database as a JSO
 
 When retrieving the model, the data object will be instantiated based on the `type` key in the JSON string.
 
+#### Abstract data object with collection
+
+You can use with collection.
+
+```php
+class Record extends Model
+{
+    protected $casts = [
+        'configs' => DataCollection::class . ':' . RecordConfig::class,
+    ];
+}
+```
+
 #### Abstract data class morphs
 
 By default, the `type` key in the JSON string will be the fully qualified class name of the child data object. This can break your application quite easily when you refactor your code. To prevent this, you can add a morph map like with [Eloquent models](https://laravel.com/docs/eloquent-relationships#polymorphic-relationships). Within your `AppServiceProvivder` you can add the following mapping:

--- a/tests/Fakes/Models/DummyModelWithCasts.php
+++ b/tests/Fakes/Models/DummyModelWithCasts.php
@@ -15,6 +15,7 @@ class DummyModelWithCasts extends Model
         'data' => SimpleData::class,
         'data_collection' => DataCollection::class.':'.SimpleData::class,
         'abstract_data' => AbstractData::class,
+        'abstract_collection' => DataCollection::class . ':' . AbstractData::class,
     ];
 
     public $timestamps = false;
@@ -27,6 +28,7 @@ class DummyModelWithCasts extends Model
             $blueprint->text('data')->nullable();
             $blueprint->text('data_collection')->nullable();
             $blueprint->text('abstract_data')->nullable();
+            $blueprint->text('abstract_collection')->nullable();
         });
     }
 }

--- a/tests/Support/EloquentCasts/DataCollectionEloquentCastTest.php
+++ b/tests/Support/EloquentCasts/DataCollectionEloquentCastTest.php
@@ -2,6 +2,9 @@
 
 use Illuminate\Support\Facades\DB;
 
+use Spatie\LaravelData\Tests\Fakes\AbstractData\AbstractData;
+use Spatie\LaravelData\Tests\Fakes\AbstractData\AbstractDataA;
+use Spatie\LaravelData\Tests\Fakes\AbstractData\AbstractDataB;
 use function Pest\Laravel\assertDatabaseHas;
 
 use Spatie\LaravelData\DataCollection;
@@ -150,4 +153,19 @@ it('loads a custom data collection when nullable argument used and value is null
     expect($model->data_collection)
         ->toBeInstanceOf(SimpleDataCollection::class)
         ->toBeEmpty();
+});
+
+it('can use an abstract data collection with multiple children', function () {
+    $abstractA = new AbstractDataA('A\A');
+    $abstractB = new AbstractDataB('B\B');
+
+    $modelId = DummyModelWithCasts::create([
+        'abstract_collection' => [$abstractA, $abstractB],
+    ])->id;
+
+    $model = DummyModelWithCasts::find($modelId);
+
+    expect($model->abstract_collection)
+        ->toBeInstanceOf(DataCollection::class)
+        ->each->toBeInstanceOf(AbstractData::class);
 });


### PR DESCRIPTION
With this feature, abstract data objects can be used as collections.

Ps: [old comment](https://github.com/spatie/laravel-data/pull/526#issuecomment-1676603238)