### PR TITLE
Feature: private/protected data properties

### DIFF
--- a/src/Attributes/DataProperty.php
+++ b/src/Attributes/DataProperty.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\LaravelData\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class DataProperty
+{
+    public function __construct(public readonly ?string $getter = null, public readonly ?string $setter = null)
+    {
+    }
+}

--- a/src/Resolvers/DataFromArrayResolver.php
+++ b/src/Resolvers/DataFromArrayResolver.php
@@ -61,7 +61,11 @@ class DataFromArrayResolver
                 continue; // Ignore the value being passed into the computed property and let it be recalculated
             }
 
-            $data->{$property->name} = $properties[$property->name];
+            if ($setter = $property->setter) {
+                $data->{$setter}($properties[$property->name]);
+            } else {
+                $data->{$property->name} = $properties[$property->name];
+            }
         }
 
         return $data;

--- a/src/Resolvers/TransformedDataResolver.php
+++ b/src/Resolvers/TransformedDataResolver.php
@@ -70,7 +70,9 @@ class TransformedDataResolver
 
             $value = $this->resolvePropertyValue(
                 $property,
-                $data->{$name},
+                $property->getter
+                    ? Lazy::create(fn() => $data->{$property->getter}())->defaultIncluded()
+                    : $data->{$name},
                 $context,
                 $visibleFields[$name] ?? null,
             );

--- a/src/Support/DataProperty.php
+++ b/src/Support/DataProperty.php
@@ -27,6 +27,8 @@ class DataProperty
         public readonly ?string $inputMappedName,
         public readonly ?string $outputMappedName,
         public readonly Collection $attributes,
+        public readonly ?string $getter,
+        public readonly ?string $setter,
     ) {
     }
 }

--- a/src/Support/Factories/DataPropertyFactory.php
+++ b/src/Support/Factories/DataPropertyFactory.php
@@ -62,6 +62,10 @@ class DataPropertyFactory
             fn (object $attribute) => $attribute instanceof WithoutValidation
         ) && ! $computed;
 
+        $getterSetter = $attributes->first(
+            fn(object $attribute) => $attribute instanceof \Spatie\LaravelData\Attributes\DataProperty
+        );
+
         return new DataProperty(
             name: $reflectionProperty->name,
             className: $reflectionProperty->class,
@@ -84,6 +88,8 @@ class DataPropertyFactory
             inputMappedName: $inputMappedName,
             outputMappedName: $outputMappedName,
             attributes: $attributes,
+            getter: $getterSetter?->getter,
+            setter: $getterSetter?->setter
         );
     }
 }

--- a/tests/CreationTest.php
+++ b/tests/CreationTest.php
@@ -41,6 +41,7 @@ use Spatie\LaravelData\Tests\Fakes\ComplicatedData;
 use Spatie\LaravelData\Tests\Fakes\DataCollections\CustomCursorPaginatedDataCollection;
 use Spatie\LaravelData\Tests\Fakes\DataCollections\CustomDataCollection;
 use Spatie\LaravelData\Tests\Fakes\DataCollections\CustomPaginatedDataCollection;
+use Spatie\LaravelData\Tests\Fakes\DataWithProtectedProperty;
 use Spatie\LaravelData\Tests\Fakes\EnumData;
 use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
 use Spatie\LaravelData\Tests\Fakes\ModelData;
@@ -1067,3 +1068,20 @@ it('will cast iterables into the correct type', function () {
         ->toBeArray()
         ->toEqual(['a', 'collection']);
 })->skip(fn () => config('data.features.cast_and_transform_iterables') === false);
+
+it('can create data object with protected property via constructor', function () {
+    $data = DataWithProtectedProperty::from([
+        'string' => 'test'
+    ]);
+
+    expect($data->getString())->toEqual('test');
+});
+
+it('can create data object with protected property via setter', function () {
+    $data = DataWithProtectedProperty::from([
+        'string' => 'test',
+        'nonConstructorProperty' => 'test'
+    ]);
+
+    expect($data->getNonConstructorProperty())->toEqual('test');
+});

--- a/tests/Fakes/DataWithProtectedProperty.php
+++ b/tests/Fakes/DataWithProtectedProperty.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Attributes\DataProperty;
+use Spatie\LaravelData\Data;
+
+class DataWithProtectedProperty extends Data
+{
+    #[DataProperty(setter: 'setNonConstructorProperty')]
+    protected string $nonConstructorProperty;
+
+    public function __construct(
+        #[DataProperty(getter: 'getString')]
+        protected string $string,
+    ) {
+    }
+
+    public function getString(): string
+    {
+        return $this->string;
+    }
+
+    public function getNonConstructorProperty(): string
+    {
+        return $this->nonConstructorProperty;
+    }
+
+    public function setNonConstructorProperty(string $value): void
+    {
+        $this->nonConstructorProperty = $value;
+    }
+}

--- a/tests/Resolvers/VisibleDataFieldsResolverTest.php
+++ b/tests/Resolvers/VisibleDataFieldsResolverTest.php
@@ -288,10 +288,19 @@ it('will fail gracefully when a nested field does not exist', function () {
 
         public Lazy|string $string;
 
+        #[DataProperty(getter: 'getPrivateString')]
+        private string $privateString;
+
         public function __construct()
         {
             $this->simple = Lazy::create(fn () => new SimpleData('Hello'));
             $this->string = Lazy::create(fn () => 'World');
+            $this->privateString = '!';
+        }
+
+        public function getPrivateString(): string
+        {
+            return $this->privateString;
         }
     };
 
@@ -305,13 +314,15 @@ it('will fail gracefully when a nested field does not exist', function () {
 
     config()->set('data.ignore_invalid_partials', true);
 
-    expect(findVisibleFields($dataClass, TransformationContextFactory::create()->include('certainly-not-simple.string', 'string')))
+    expect(findVisibleFields($dataClass, TransformationContextFactory::create()->include('certainly-not-simple.string', 'string', 'privateString')))
         ->toEqual([
             'string' => null,
+            'privateString' => null,
         ]);
 
-    expect($dataClass->include('certainly-not-simple.string', 'string')->toArray())->toEqual([
+    expect($dataClass->include('certainly-not-simple.string', 'string', 'privateString')->toArray())->toEqual([
         'string' => 'World',
+        'privateString' => '!'
     ]);
 });
 

--- a/tests/Resolvers/VisibleDataFieldsResolverTest.php
+++ b/tests/Resolvers/VisibleDataFieldsResolverTest.php
@@ -330,13 +330,20 @@ class VisibleFieldsSingleData extends Data
 {
     public function __construct(
         public string $string,
-        public int $int
+        public int $int,
+        #[DataProperty(getter: 'getPrivateString')]
+        private string $privateString,
     ) {
+    }
+
+    public function getPrivateString(): string
+    {
+        return $this->privateString;
     }
 
     public static function instance(): self
     {
-        return new self('hello', 42);
+        return new self('hello', 42, 'worlds');
     }
 }
 
@@ -414,12 +421,12 @@ it('can execute excepts', function (
             'string' => 'hello',
             'int' => 42,
             'nested' => [
-                'a' => ['string' => 'hello', 'int' => 42],
-                'b' => ['string' => 'hello', 'int' => 42],
+                'a' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
+                'b' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
             ],
             'collection' => [
-                ['string' => 'hello', 'int' => 42],
-                ['string' => 'hello', 'int' => 42],
+                ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
+                ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
             ],
         ],
     ];
@@ -433,12 +440,12 @@ it('can execute excepts', function (
         ],
         'transformed' => [
             'nested' => [
-                'a' => ['string' => 'hello', 'int' => 42],
-                'b' => ['string' => 'hello', 'int' => 42],
+                'a' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
+                'b' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
             ],
             'collection' => [
-                ['string' => 'hello', 'int' => 42],
-                ['string' => 'hello', 'int' => 42],
+                ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
+                ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
             ],
         ],
     ];
@@ -463,7 +470,7 @@ it('can execute excepts', function (
         ],
         'transformed' => [
             'nested' => [
-                'b' => ['string' => 'hello', 'int' => 42],
+                'b' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
             ],
         ],
     ];
@@ -513,8 +520,8 @@ it('can execute excepts', function (
         ],
         'transformed' => [
             'collection' => [
-                ['int' => 42],
-                ['int' => 42],
+                ['int' => 42, 'privateString' => 'worlds'],
+                ['int' => 42, 'privateString' => 'worlds'],
             ],
         ],
     ];
@@ -522,11 +529,11 @@ it('can execute excepts', function (
     yield 'nested data collectable multiple fields' => [
         'factory' => fn () => TransformationContextFactory::create()
             ->except('string', 'int', 'single', 'nested') // ignore non collection fields
-            ->except('collection.{string,int}'),
+            ->except('collection.{string,int,privateString}'),
         'fields' => [
             'collection' => new TransformationContext(
                 exceptPartials: PartialsCollection::create(
-                    new Partial([new NestedPartialSegment('collection'), new FieldsPartialSegment(['string', 'int'])], pointer: 1)
+                    new Partial([new NestedPartialSegment('collection'), new FieldsPartialSegment(['string', 'int', 'privateString'])], pointer: 1)
                 ),
             ),
         ],
@@ -580,14 +587,14 @@ it('can execute excepts', function (
             ),
         ],
         'transformed' => [
-            'single' => ['int' => 42],
+            'single' => ['int' => 42, 'privateString' => 'worlds'],
             'collection' => [
-                ['int' => 42],
-                ['int' => 42],
+                ['int' => 42, 'privateString' => 'worlds'],
+                ['int' => 42, 'privateString' => 'worlds'],
             ],
             'nested' => [
-                'a' => ['int' => 42],
-                'b' => ['string' => 'hello', 'int' => 42],
+                'a' => ['int' => 42, 'privateString' => 'worlds'],
+                'b' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
             ],
         ],
     ];
@@ -616,7 +623,7 @@ it("can execute only's", function (
             'single' => new TransformationContext(),
         ],
         'transformed' => [
-            'single' => ['string' => 'hello', 'int' => 42,],
+            'single' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
         ],
     ];
 
@@ -631,7 +638,7 @@ it("can execute only's", function (
         'transformed' => [
             'string' => 'hello',
             'int' => 42,
-            'single' => ['string' => 'hello', 'int' => 42,],
+            'single' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
         ],
     ];
 
@@ -648,14 +655,14 @@ it("can execute only's", function (
         'transformed' => [
             'string' => 'hello',
             'int' => 42,
-            'single' => ['string' => 'hello', 'int' => 42,],
+            'single' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
             'nested' => [
-                'a' => ['string' => 'hello', 'int' => 42],
-                'b' => ['string' => 'hello', 'int' => 42],
+                'a' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
+                'b' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
             ],
             'collection' => [
-                ['string' => 'hello', 'int' => 42],
-                ['string' => 'hello', 'int' => 42],
+                ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
+                ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
             ],
         ],
     ];
@@ -672,7 +679,7 @@ it("can execute only's", function (
         ],
         'transformed' => [
             'nested' => [
-                'a' => ['string' => 'hello', 'int' => 42],
+                'a' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
             ],
         ],
     ];
@@ -689,8 +696,8 @@ it("can execute only's", function (
         ],
         'transformed' => [
             'nested' => [
-                'a' => ['string' => 'hello', 'int' => 42],
-                'b' => ['string' => 'hello', 'int' => 42],
+                'a' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
+                'b' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
             ],
         ],
     ];
@@ -707,8 +714,8 @@ it("can execute only's", function (
         ],
         'transformed' => [
             'nested' => [
-                'a' => ['string' => 'hello', 'int' => 42],
-                'b' => ['string' => 'hello', 'int' => 42],
+                'a' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
+                'b' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
             ],
         ],
     ];
@@ -733,18 +740,18 @@ it("can execute only's", function (
 
     yield 'nested data collectable multiple fields' => [
         'factory' => fn () => TransformationContextFactory::create()
-            ->only('collection.{string,int}'),
+            ->only('collection.{string,int,privateString}'),
         'fields' => [
             'collection' => new TransformationContext(
                 onlyPartials: PartialsCollection::create(
-                    new Partial([new NestedPartialSegment('collection'), new FieldsPartialSegment(['string', 'int'])], pointer: 1)
+                    new Partial([new NestedPartialSegment('collection'), new FieldsPartialSegment(['string', 'int', 'privateString'])], pointer: 1)
                 ),
             ),
         ],
         'transformed' => [
             'collection' => [
-                ['string' => 'hello', 'int' => 42],
-                ['string' => 'hello', 'int' => 42],
+                ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
+                ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
             ],
         ],
     ];
@@ -761,8 +768,8 @@ it("can execute only's", function (
         ],
         'transformed' => [
             'collection' => [
-                ['string' => 'hello', 'int' => 42],
-                ['string' => 'hello', 'int' => 42],
+                ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
+                ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
             ],
         ],
     ];

--- a/tests/Resolvers/VisibleDataFieldsResolverTest.php
+++ b/tests/Resolvers/VisibleDataFieldsResolverTest.php
@@ -2,6 +2,7 @@
 
 use Inertia\LazyProp;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Attributes\DataProperty;
 use Spatie\LaravelData\Attributes\Hidden;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Exceptions\CannotPerformPartialOnDataField;
@@ -63,6 +64,36 @@ it('will hide fields which are uninitialized', function () {
     ]);
 
     expect($dataClass->toArray())->toBe([
+        'visible' => 'visible',
+    ]);
+});
+
+it('will hide private fields that are not data properties', function () {
+    $dataClass = new class () extends Data {
+        private string $visible = 'visible';
+    };
+
+    expect(findVisibleFields($dataClass, TransformationContextFactory::create()))->toBeEmpty();
+
+    expect($dataClass->toArray())->toBeEmpty();
+});
+
+it('will show private fields that are data properties', function () {
+    $dataClass = new class () extends Data {
+        #[DataProperty(getter: 'isVisible')]
+        private string $visible = 'visible';
+
+        public function isVisible(): string
+        {
+            return $this->visible;
+        }
+    };
+
+    expect(findVisibleFields($dataClass, TransformationContextFactory::create()))->toEqual([
+        'visible' => null,
+    ]);
+
+    expect($dataClass->toArray())->toEqual([
         'visible' => 'visible',
     ]);
 });

--- a/tests/Resolvers/VisibleDataFieldsResolverTest.php
+++ b/tests/Resolvers/VisibleDataFieldsResolverTest.php
@@ -369,6 +369,8 @@ class VisibleFieldsData extends Data
     public function __construct(
         public string $string,
         public int $int,
+        #[DataProperty(getter: 'getPrivateString')]
+        private string $privateString,
         public VisibleFieldsSingleData $single,
         public VisibleFieldsNestedData $nested,
         #[DataCollectionOf(VisibleFieldsSingleData::class)]
@@ -376,11 +378,17 @@ class VisibleFieldsData extends Data
     ) {
     }
 
+    public function getPrivateString(): string
+    {
+        return $this->privateString;
+    }
+
     public static function instance(): self
     {
         return new self(
             'hello',
             42,
+            'worlds',
             VisibleFieldsSingleData::instance(),
             VisibleFieldsNestedData::instance(),
             [
@@ -414,12 +422,14 @@ it('can execute excepts', function (
         'fields' => [
             'string' => null,
             'int' => null,
+            'privateString' => null,
             'nested' => new TransformationContext(),
             'collection' => new TransformationContext(),
         ],
         'transformed' => [
             'string' => 'hello',
             'int' => 42,
+            'privateString' => 'worlds',
             'nested' => [
                 'a' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
                 'b' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
@@ -433,7 +443,7 @@ it('can execute excepts', function (
 
     yield 'multiple fields' => [
         'factory' => fn () => TransformationContextFactory::create()
-            ->except('{string,int,single}'),
+            ->except('{string,int,privateString,single}'),
         'fields' => [
             'nested' => new TransformationContext(),
             'collection' => new TransformationContext(),
@@ -459,7 +469,7 @@ it('can execute excepts', function (
 
     yield 'nested data object single field' => [
         'factory' => fn () => TransformationContextFactory::create()
-            ->except('string', 'int', 'single', 'collection') // ignore non nested object fields
+            ->except('string', 'int', 'privateString', 'single', 'collection') // ignore non nested object fields
             ->except('nested.a'),
         'fields' => [
             'nested' => new TransformationContext(
@@ -477,7 +487,7 @@ it('can execute excepts', function (
 
     yield 'nested data object multiple fields' => [
         'factory' => fn () => TransformationContextFactory::create()
-            ->except('string', 'int', 'single', 'collection') // ignore non nested object fields
+            ->except('string', 'int', 'privateString', 'single', 'collection') // ignore non nested object fields
             ->except('nested.{a,b}'),
         'fields' => [
             'nested' => new TransformationContext(
@@ -493,7 +503,7 @@ it('can execute excepts', function (
 
     yield 'nested data object all' => [
         'factory' => fn () => TransformationContextFactory::create()
-            ->except('string', 'int', 'single', 'collection') // ignore non nested object fields
+            ->except('string', 'int', 'privateString', 'single', 'collection') // ignore non nested object fields
             ->except('nested.*'),
         'fields' => [
             'nested' => new TransformationContext(
@@ -509,7 +519,7 @@ it('can execute excepts', function (
 
     yield 'nested data collectable single field' => [
         'factory' => fn () => TransformationContextFactory::create()
-            ->except('string', 'int', 'single', 'nested') // ignore non collection fields
+            ->except('string', 'int', 'privateString', 'single', 'nested') // ignore non collection fields
             ->except('collection.string'),
         'fields' => [
             'collection' => new TransformationContext(
@@ -528,7 +538,7 @@ it('can execute excepts', function (
 
     yield 'nested data collectable multiple fields' => [
         'factory' => fn () => TransformationContextFactory::create()
-            ->except('string', 'int', 'single', 'nested') // ignore non collection fields
+            ->except('string', 'int', 'privateString', 'single', 'nested') // ignore non collection fields
             ->except('collection.{string,int,privateString}'),
         'fields' => [
             'collection' => new TransformationContext(
@@ -547,7 +557,7 @@ it('can execute excepts', function (
 
     yield 'nested data collectable all' => [
         'factory' => fn () => TransformationContextFactory::create()
-            ->except('string', 'int', 'single', 'nested') // ignore non collection fields
+            ->except('string', 'int', 'privateString', 'single', 'nested') // ignore non collection fields
             ->except('collection.*'),
         'fields' => [
             'collection' => new TransformationContext(
@@ -566,7 +576,7 @@ it('can execute excepts', function (
 
     yield 'combination' => [
         'factory' => fn () => TransformationContextFactory::create()
-            ->except('string', 'int', 'single.string')
+            ->except('string', 'int', 'privateString', 'single.string')
             ->except('collection.string')
             ->except('nested.a.string'),
         'fields' => [
@@ -648,6 +658,7 @@ it("can execute only's", function (
         'fields' => [
             'string' => null,
             'int' => null,
+            'privateString' => null,
             'single' => new TransformationContext(),
             'nested' => new TransformationContext(),
             'collection' => new TransformationContext(),
@@ -655,6 +666,7 @@ it("can execute only's", function (
         'transformed' => [
             'string' => 'hello',
             'int' => 42,
+            'privateString' => 'worlds',
             'single' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],
             'nested' => [
                 'a' => ['string' => 'hello', 'int' => 42, 'privateString' => 'worlds'],

--- a/tests/TransformationTest.php
+++ b/tests/TransformationTest.php
@@ -196,18 +196,35 @@ it('can use a custom transformer for a data object and/or data collectable', fun
 });
 
 it('can transform built it types with custom transformers', function () {
-    $data = new class ('Hello World', 'Hello World') extends Data {
+    $data = new class ('Hello World', 'Hello World', 'Hello World', 'Hello World') extends Data {
         public function __construct(
             public string $without_transformer,
             #[WithTransformer(StringToUpperTransformer::class)]
-            public string $with_transformer
+            public string $with_transformer,
+            #[\Spatie\LaravelData\Attributes\DataProperty(getter: 'getPrivateWithoutTransformer')]
+            private string $privateWithoutTransformer,
+            #[\Spatie\LaravelData\Attributes\DataProperty(getter: 'getPrivateWithTransformer')]
+            #[WithTransformer(StringToUpperTransformer::class)]
+            private string $privateWithTransformer,
         ) {
+        }
+
+        public function getPrivateWithoutTransformer(): string
+        {
+            return $this->privateWithoutTransformer;
+        }
+
+        public function getPrivateWithTransformer(): string
+        {
+            return $this->privateWithoutTransformer;
         }
     };
 
     expect($data->toArray())->toMatchArray([
         'without_transformer' => 'Hello World',
         'with_transformer' => 'HELLO WORLD',
+        'privateWithoutTransformer' => 'Hello World',
+        'privateWithTransformer' => 'HELLO WORLD',
     ]);
 });
 

--- a/tests/TransformationTest.php
+++ b/tests/TransformationTest.php
@@ -134,17 +134,24 @@ it('can transform to JSON', function () {
 });
 
 it('can use a custom transformer for a data object and/or data collectable', function () {
-    $nestedData = new class (42, 'Hello World') extends Data {
+    $nestedData = new class (42, 'Hello World', '!') extends Data {
         public function __construct(
             public int $integer,
             public string $string,
+            #[\Spatie\LaravelData\Attributes\DataProperty(getter: 'getPrivateString')]
+            private string $privateString,
         ) {
+        }
+
+        public function getPrivateString(): string
+        {
+            return $this->privateString;
         }
     };
 
     $nestedDataCollection = $nestedData::collect([
-        ['integer' => 314, 'string' => 'pi'],
-        ['integer' => '69', 'string' => 'Laravel after hours'],
+        ['integer' => 314, 'string' => 'pi', 'privateString' => '3.14'],
+        ['integer' => '69', 'string' => 'Laravel after hours', 'privateString' => '80085'],
     ]);
 
     $dataWithDefaultTransformers = new class ($nestedData, $nestedDataCollection) extends Data {
@@ -171,19 +178,19 @@ it('can use a custom transformer for a data object and/or data collectable', fun
 
     expect($dataWithDefaultTransformers->toArray())
         ->toMatchArray([
-            'nestedData' => ['integer' => 42, 'string' => 'Hello World'],
+            'nestedData' => ['integer' => 42, 'string' => 'Hello World', 'privateString' => '!'],
             'nestedDataCollection' => [
-                ['integer' => 314, 'string' => 'pi'],
-                ['integer' => '69', 'string' => 'Laravel after hours'],
+                ['integer' => 314, 'string' => 'pi', 'privateString' => '3.14'],
+                ['integer' => '69', 'string' => 'Laravel after hours', 'privateString' => '80085'],
             ],
         ]);
 
     expect($dataWithSpecificTransformers->toArray())
         ->toMatchArray([
-            'nestedData' => ['integer' => 'CONFIDENTIAL', 'string' => 'CONFIDENTIAL'],
+            'nestedData' => ['integer' => 'CONFIDENTIAL', 'string' => 'CONFIDENTIAL', 'privateString' => 'CONFIDENTIAL'],
             'nestedDataCollection' => [
-                ['integer' => 'CONFIDENTIAL', 'string' => 'CONFIDENTIAL'],
-                ['integer' => 'CONFIDENTIAL', 'string' => 'CONFIDENTIAL'],
+                ['integer' => 'CONFIDENTIAL', 'string' => 'CONFIDENTIAL', 'privateString' => 'CONFIDENTIAL'],
+                ['integer' => 'CONFIDENTIAL', 'string' => 'CONFIDENTIAL', 'privateString' => 'CONFIDENTIAL'],
             ],
         ]);
 });


### PR DESCRIPTION
## Description

This PR attempts to add the ability to mark private/protected properties as data properties. This would allow using Laravel Data functionality within more traditional classes that encapsulate their data and only expose it via public getter/setter methods.

Data properties are still determined in the same way and transformations can be applied even to values obtained from getter calls.

## Questions

1. Does applying Laravel Data traits to other, non-DTO-like classes stray too far from the original intent of the package?
1. Are there other places where data is get/set that need to be updated?
