### PR TITLE
Avoid loading already loaded relations and allow loading non studly relation names

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,4 +46,4 @@ jobs:
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/pest --enforce-time-limit --fail-on-risky

--- a/src/Normalizers/Normalized/NormalizedModel.php
+++ b/src/Normalizers/Normalized/NormalizedModel.php
@@ -26,7 +26,7 @@ class NormalizedModel implements Normalized
 
     protected function initialize(Model $model): void
     {
-        $this->properties = $model->toArray();
+        $this->properties = $model->withoutRelations()->toArray();
 
         foreach ($model->getDates() as $key) {
             if (isset($this->properties[$key])) {
@@ -39,14 +39,6 @@ class NormalizedModel implements Normalized
                 if (isset($this->properties[$key])) {
                     $this->properties[$key] = $model->getAttribute($key);
                 }
-            }
-        }
-
-        foreach ($model->getRelations() as $key => $relation) {
-            $key = $model::$snakeAttributes ? Str::snake($key) : $key;
-
-            if (isset($this->properties[$key])) {
-                $this->properties[$key] = $relation;
             }
         }
     }
@@ -69,21 +61,21 @@ class NormalizedModel implements Normalized
             return $this->properties[$name] = $this->model->getAttribute($name);
         }
 
-        $studlyName = Str::studly($name);
+        $camelName = Str::camel($name);
 
         if ($dataProperty->attributes->contains(fn (object $attribute) => $attribute::class === LoadRelation::class)) {
             if (method_exists($this->model, $name)) {
                 $this->model->loadMissing($name);
-            } elseif (method_exists($this->model, $studlyName)) {
-                $this->model->loadMissing($studlyName);
+            } else if (method_exists($this->model, $camelName)) {
+                $this->model->loadMissing($camelName);
             }
         }
 
         if ($this->model->relationLoaded($name)) {
             return $this->properties[$name] = $this->model->getRelation($name);
         }
-        if ($this->model->relationLoaded($studlyName)) {
-            return $this->properties[$name] = $this->model->getRelation($studlyName);
+        if ($this->model->relationLoaded($camelName)) {
+            return $this->properties[$name] = $this->model->getRelation($camelName);
         }
 
         return $this->properties[$name] = UnknownProperty::create();

--- a/src/Normalizers/Normalized/NormalizedModel.php
+++ b/src/Normalizers/Normalized/NormalizedModel.php
@@ -66,7 +66,7 @@ class NormalizedModel implements Normalized
         if ($dataProperty->attributes->contains(fn (object $attribute) => $attribute::class === LoadRelation::class)) {
             if (method_exists($this->model, $name)) {
                 $this->model->loadMissing($name);
-            } else if (method_exists($this->model, $camelName)) {
+            } elseif (method_exists($this->model, $camelName)) {
                 $this->model->loadMissing($camelName);
             }
         }

--- a/src/Normalizers/Normalized/NormalizedModel.php
+++ b/src/Normalizers/Normalized/NormalizedModel.php
@@ -86,6 +86,6 @@ class NormalizedModel implements Normalized
             return $this->properties[$name] = $this->model->getRelation($studlyName);
         }
 
-        return UnknownProperty::create();
+        return $this->properties[$name] = UnknownProperty::create();
     }
 }

--- a/src/Normalizers/Normalized/NormalizedModel.php
+++ b/src/Normalizers/Normalized/NormalizedModel.php
@@ -74,7 +74,7 @@ class NormalizedModel implements Normalized
         if ($dataProperty->attributes->contains(fn (object $attribute) => $attribute::class === LoadRelation::class)) {
             if (method_exists($this->model, $name)) {
                 $this->model->loadMissing($name);
-            } else if (method_exists($this->model, $studlyName)) {
+            } elseif (method_exists($this->model, $studlyName)) {
                 $this->model->loadMissing($studlyName);
             }
         }

--- a/tests/Fakes/Models/FakeModel.php
+++ b/tests/Fakes/Models/FakeModel.php
@@ -22,6 +22,11 @@ class FakeModel extends Model
         return $this->hasMany(FakeNestedModel::class);
     }
 
+    public function alt_fake_nested_models(): HasMany
+    {
+        return $this->hasMany(FakeNestedModel::class);
+    }
+
     public function accessor(): Attribute
     {
         return Attribute::get(fn () => "accessor_{$this->string}");

--- a/tests/Normalizers/ModelNormalizerTest.php
+++ b/tests/Normalizers/ModelNormalizerTest.php
@@ -23,12 +23,18 @@ it('can get a data object from model', function () {
 });
 
 it('does not loop infinitely on relations', function () {
-    $m1 = new FakeModel();
-    $m2 = new FakeNestedModel();
+    $m1 = FakeModel::factory()->makeOne();
+    $m2 = FakeNestedModel::factory()->makeOne();
     $m2->setRelation('parent', $m1);
     $m1->setRelation('pivot', $m2);
 
-    FakeModelData::from($m1);
+    $data = FakeModelData::from($m1);
+
+    expect($m1)
+        ->string->toEqual($data->string)
+        ->nullable->toEqual($data->nullable)
+        ->date->toEqual($data->date);
+
 });
 
 it('can get a data object with nesting from model and relations when loaded', function () {

--- a/tests/Normalizers/ModelNormalizerTest.php
+++ b/tests/Normalizers/ModelNormalizerTest.php
@@ -22,6 +22,15 @@ it('can get a data object from model', function () {
         ->date->toEqual($data->date);
 });
 
+it('does not loop infinitely on relations', function () {
+    $m1 = new FakeModel();
+    $m2 = new FakeNestedModel();
+    $m2->setRelation('parent', $m1);
+    $m1->setRelation('pivot', $m2);
+
+    FakeModelData::from($m1);
+});
+
 it('can get a data object with nesting from model and relations when loaded', function () {
     $model = FakeModel::factory()->create();
 

--- a/tests/Normalizers/ModelNormalizerTest.php
+++ b/tests/Normalizers/ModelNormalizerTest.php
@@ -103,8 +103,12 @@ it('can load relations on a model when required and the LoadRelation attribute i
     $dataClass = new class () extends Data {
         #[LoadRelation, DataCollectionOf(FakeNestedModelData::class)]
         public array $fake_nested_models;
+
+        #[LoadRelation, DataCollectionOf(FakeNestedModelData::class)]
+        public array $alt_fake_nested_models;
     };
 
+    $model->load('alt_fake_nested_models');
     DB::enableQueryLog();
 
     $data = $dataClass::from($model);
@@ -112,6 +116,10 @@ it('can load relations on a model when required and the LoadRelation attribute i
     $queryLog = DB::getQueryLog();
 
     expect($data->fake_nested_models)
+        ->toHaveCount(2)
+        ->each->toBeInstanceOf(FakeNestedModelData::class);
+
+    expect($data->alt_fake_nested_models)
         ->toHaveCount(2)
         ->each->toBeInstanceOf(FakeNestedModelData::class);
     expect($queryLog)->toHaveCount(1);
@@ -154,8 +162,8 @@ it('will not automatically load relation when the LoadRelation attribute is not 
 it('can use mappers to map the names', function () {
     $model = FakeModel::factory()->create();
 
-    $nestedModelA = FakeNestedModel::factory()->for($model)->create();
-    $nestedModelB = FakeNestedModel::factory()->for($model)->create();
+    FakeNestedModel::factory()->for($model)->create();
+    FakeNestedModel::factory()->for($model)->create();
 
     $dataClass = new class () extends Data {
         #[DataCollectionOf(FakeNestedModelData::class), MapInputName(SnakeCaseMapper::class)]


### PR DESCRIPTION
`load` would load relations even if they were already loaded in the model

But we might not even need to do that explicitely because `$this->model->{$studlyName}` would also load it

Added a fix for #787 as well