### PR TITLE
Add Support for Predefined Enum Collections in DataObject Initialization

### DIFF
--- a/src/Casts/EnumCast.php
+++ b/src/Casts/EnumCast.php
@@ -38,7 +38,7 @@ class EnumCast implements Cast, IterableItemCast
 
         /** @var class-string<\BackedEnum> $type */
         try {
-            return $type::from($value);
+            return $value instanceof $type && $value === $type::from($value->value) ? $value : $type::from($value);
         } catch (Throwable $e) {
             throw CannotCastEnum::create($type, $value);
         }

--- a/tests/Casts/EnumCastTest.php
+++ b/tests/Casts/EnumCastTest.php
@@ -71,3 +71,19 @@ it('fails with other types', function () {
     )
         ->toEqual(Uncastable::create());
 });
+
+
+it('it can create data when enum is already casted', function () {
+    $class = new class () {
+        public DummyBackedEnum $enum;
+    };
+
+    expect(
+        $this->caster->cast(
+            FakeDataStructureFactory::property($class, 'enum'),
+            DummyBackedEnum::FOO,
+            [],
+            CreationContextFactory::createFromConfig($class::class)->get()
+        )
+    )->toEqual(DummyBackedEnum::FOO);
+});


### PR DESCRIPTION
Hey there,

I encountered an issue while trying to create a `DataObject` that already incorporates an enum. Specifically, I found myself in situations where I needed to initialize my `DataObject` with a predefined enum collection.

For instance, let's consider an enum collection named `SourceOfFunds`:

```php
[
  SourceOfFunds::Employment,
  1, // SourceOfFunds::Business,
  2, // SourceOfFunds::FamilySupport
]
```

To address this need, I've implemented changes in this pull request to support such scenarios. This enhancement will facilitate smoother integration of predefined enum collections into `DataObject`.

Looking forward to your feedback!

P.S. If I might be wrong on implementing this feature, could you please be able to provide me some information? Thank you.