### PR TITLE
Fix dataCastUsing method signature

### DIFF
--- a/docs/advanced-usage/creating-a-cast.md
+++ b/docs/advanced-usage/creating-a-cast.md
@@ -71,6 +71,7 @@ namespace Spatie\LaravelData\Tests\Fakes\Castables;
 
 use Spatie\LaravelData\Casts\Cast;
 use Spatie\LaravelData\Casts\Castable;
+use Spatie\LaravelData\Support\Creation\CreationContext;
 use Spatie\LaravelData\Support\DataProperty;
 
 class Email implements Castable
@@ -82,7 +83,7 @@ class Email implements Castable
   public static function dataCastUsing(...$arguments): Cast
   {
     return new class implements Cast {
-        public function cast(DataProperty $property, mixed $value, array $context): mixed {
+        public function cast(DataProperty $property, mixed $value, array $properties, CreationContext $context): mixed
             return new Email($value);
         }
     };


### PR DESCRIPTION
The dataCastUsing method doesn't follow the Cast interface signature.