### PR TITLE
Fix Parsing of Optional Types Annotations in DataIterableAnnotation

### DIFF
--- a/src/Support/Annotations/DataIterableAnnotationReader.php
+++ b/src/Support/Annotations/DataIterableAnnotationReader.php
@@ -51,6 +51,7 @@ class DataIterableAnnotationReader
         $kindPattern = '(?:@property|@var|@param)\s*';
         $fqsenPattern = '[\\\\a-z0-9_\|]+';
         $typesPattern = '[\\\\a-z0-9_\\|\\[\\]]+';
+        $optionalTypesPattern = '(?:'.$typesPattern.')*';
         $keyPattern = '(?<key>int|string|int\|string|string\|int|array-key)';
         $parameterPattern = '\s*\$?(?<parameter>[a-z0-9_]+)?';
 
@@ -61,7 +62,7 @@ class DataIterableAnnotationReader
         );
 
         preg_match_all(
-            "/{$kindPattern}(?<collectionClass>{$fqsenPattern})<(?:{$keyPattern}\s*?,\s*?)?(?<dataClass>{$fqsenPattern})>{$parameterPattern}/i",
+            "/{$kindPattern}(?<collectionClass>{$fqsenPattern})<(?:{$keyPattern}\s*?,\s*?)?(?<dataClass>{$fqsenPattern})>{$optionalTypesPattern}{$parameterPattern}/i",
             $comment,
             $collectionMatches,
         );

--- a/src/Support/Annotations/DataIterableAnnotationReader.php
+++ b/src/Support/Annotations/DataIterableAnnotationReader.php
@@ -51,7 +51,6 @@ class DataIterableAnnotationReader
         $kindPattern = '(?:@property|@var|@param)\s*';
         $fqsenPattern = '[\\\\a-z0-9_\|]+';
         $typesPattern = '[\\\\a-z0-9_\\|\\[\\]]+';
-        $optionalTypesPattern = '(?:'.$typesPattern.')*';
         $keyPattern = '(?<key>int|string|int\|string|string\|int|array-key)';
         $parameterPattern = '\s*\$?(?<parameter>[a-z0-9_]+)?';
 
@@ -62,7 +61,7 @@ class DataIterableAnnotationReader
         );
 
         preg_match_all(
-            "/{$kindPattern}(?<collectionClass>{$fqsenPattern})<(?:{$keyPattern}\s*?,\s*?)?(?<dataClass>{$fqsenPattern})>{$optionalTypesPattern}{$parameterPattern}/i",
+            "/{$kindPattern}(?<collectionClass>{$fqsenPattern})<(?:{$keyPattern}\s*?,\s*?)?(?<dataClass>{$fqsenPattern})>(?:{$typesPattern})*{$parameterPattern}/i",
             $comment,
             $collectionMatches,
         );

--- a/tests/Fakes/CollectionDataAnnotationsData.php
+++ b/tests/Fakes/CollectionDataAnnotationsData.php
@@ -14,6 +14,7 @@ use Spatie\LaravelData\DataCollection;
  * @property array<\Spatie\LaravelData\Tests\Fakes\SimpleData> $propertyQ
  * @property \Spatie\LaravelData\Tests\Fakes\SimpleData[] $propertyR
  * @property array<SimpleData> $propertyS
+ * @property \Illuminate\Support\Collection<\Spatie\LaravelData\Tests\Fakes\SimpleData>|null $propertyT
  */
 class CollectionDataAnnotationsData
 {
@@ -67,6 +68,11 @@ class CollectionDataAnnotationsData
 
     public array $propertyS;
 
+    public ?array $propertyT;
+
+    /** @var \Illuminate\Support\Collection<\Spatie\LaravelData\Tests\Fakes\SimpleData>|null */
+    public ?array $propertyU;
+
     /**
      * @param \Spatie\LaravelData\Tests\Fakes\SimpleData[]|null $paramA
      * @param null|\Spatie\LaravelData\Tests\Fakes\SimpleData[] $paramB
@@ -78,6 +84,7 @@ class CollectionDataAnnotationsData
      * @param array<SimpleData> $paramH
      * @param array<int,SimpleData> $paramJ
      * @param array<int, SimpleData> $paramI
+     * @param \Spatie\LaravelData\DataCollection<\Spatie\LaravelData\Tests\Fakes\SimpleData>|null $paramK
      */
     public function method(
         array $paramA,
@@ -89,6 +96,7 @@ class CollectionDataAnnotationsData
         array $paramG,
         array $paramJ,
         array $paramI,
+        ?array $paramK,
     ) {
 
     }

--- a/tests/Fakes/CollectionNonDataAnnotationsData.php
+++ b/tests/Fakes/CollectionNonDataAnnotationsData.php
@@ -11,6 +11,7 @@ use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
  * @property \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum[] $propertyM
  * @property array<\Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum> $propertyN
  * @property array<DummyBackedEnum> $propertyO
+ * @property array<DummyBackedEnum>|null $propertyQ
  */
 class CollectionNonDataAnnotationsData
 {
@@ -58,6 +59,11 @@ class CollectionNonDataAnnotationsData
     /** @var \Illuminate\Support\Collection<Error> */
     public Collection $propertyP;
 
+    public array $propertyQ;
+
+    /** @var \Illuminate\Support\Collection<Error>|null */
+    public ?Collection $propertyR;
+
     /**
      * @param \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum[]|null $paramA
      * @param null|\Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum[] $paramB
@@ -69,6 +75,7 @@ class CollectionNonDataAnnotationsData
      * @param array<DummyBackedEnum> $paramH
      * @param array<int,DummyBackedEnum> $paramJ
      * @param array<int, DummyBackedEnum> $paramI
+     * @param \Spatie\LaravelData\DataCollection<\Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum>|null $paramK
      */
     public function method(
         array $paramA,
@@ -80,6 +87,7 @@ class CollectionNonDataAnnotationsData
         array $paramG,
         array $paramJ,
         array $paramI,
+        ?array $paramK,
     ) {
 
     }

--- a/tests/Support/Annotations/DataIterableAnnotationReaderTest.php
+++ b/tests/Support/Annotations/DataIterableAnnotationReaderTest.php
@@ -81,6 +81,11 @@ it(
         'property' => 'propertyM',
         'expected' => new DataIterableAnnotation(SimpleData::class, isData: true),
     ];
+
+    yield 'propertyU' => [
+        'property' => 'propertyU',
+        'expected' => new DataIterableAnnotation(SimpleData::class, isData: true),
+    ];
 });
 
 it('can get the data class for a data collection by class annotation', function () {
@@ -93,6 +98,7 @@ it('can get the data class for a data collection by class annotation', function 
         new DataIterableAnnotation(SimpleData::class, isData: true, property: 'propertyQ'),
         new DataIterableAnnotation(SimpleData::class, isData: true, property: 'propertyR'),
         new DataIterableAnnotation(SimpleData::class, isData: true, property: 'propertyS'),
+        new DataIterableAnnotation(SimpleData::class, isData: true, property: 'propertyT'),
     ]);
 });
 
@@ -110,6 +116,7 @@ it('can get data class for a data collection by method annotation', function () 
         new DataIterableAnnotation(SimpleData::class, isData: true, property: 'paramH'),
         new DataIterableAnnotation(SimpleData::class, isData: true, keyType: 'int', property: 'paramJ'),
         new DataIterableAnnotation(SimpleData::class, isData: true, keyType: 'int', property: 'paramI'),
+        new DataIterableAnnotation(SimpleData::class, isData: true, property: 'paramK'),
     ]);
 });
 
@@ -185,6 +192,11 @@ it(
         'property' => 'propertyP',
         'expected' => new DataIterableAnnotation(Error::class, isData: true),
     ];
+
+    yield 'propertyR' => [
+        'property' => 'propertyR',
+        'expected' => new DataIterableAnnotation(Error::class, isData: true),
+    ];
 });
 
 it('can get the iterable class for a collection by class annotation', function () {
@@ -194,6 +206,7 @@ it('can get the iterable class for a collection by class annotation', function (
         new DataIterableAnnotation(DummyBackedEnum::class, isData: false, property: 'propertyM'),
         new DataIterableAnnotation(DummyBackedEnum::class, isData: false, property: 'propertyN'),
         new DataIterableAnnotation(DummyBackedEnum::class, isData: false, property: 'propertyO'),
+        new DataIterableAnnotation(DummyBackedEnum::class, isData: false, property: 'propertyQ'),
     ]);
 });
 
@@ -211,6 +224,7 @@ it('can get iterable class for a data by method annotation', function () {
         new DataIterableAnnotation(DummyBackedEnum::class, isData: false, property: 'paramH'),
         new DataIterableAnnotation(DummyBackedEnum::class, isData: false, keyType: 'int', property: 'paramJ'),
         new DataIterableAnnotation(DummyBackedEnum::class, isData: false, keyType: 'int', property: 'paramI'),
+        new DataIterableAnnotation(DummyBackedEnum::class, isData: false, property: 'paramK'),
     ]);
 });
 


### PR DESCRIPTION
This PR fixes an issue where DataIterableAnnotation couldn't correctly identify data types with optional parameters. 

Previously, the test for "is data" returned:

```
// Previously failed
@param \Spatie\LaravelData\DataCollection<\Spatie\LaravelData\Tests\Fakes\SimpleData>|null $paramK (false)

// Previously worked
@param null|\Spatie\LaravelData\DataCollection<\Spatie\LaravelData\Tests\Fakes\SimpleData> $paramK (true)

```

Now, the test returns `true` for both cases, ensuring accurate data type identification regardless of optional parameters like `|null`.