### PR TITLE
Detect data from collection

### DIFF
--- a/docs/as-a-data-transfer-object/nesting.md
+++ b/docs/as-a-data-transfer-object/nesting.md
@@ -124,6 +124,29 @@ class AlbumData extends Data
 }
 ```
 
+If the collection is well-typed, you don't need to use annotations:
+
+```php
+/**
+ * @template TKey of array-key
+ * @template TValue of \App\Data\SongData
+ *
+ * @extends \Illuminate\Support\Collection<TKey, TValue>
+ */
+class SongDataCollection
+{
+}
+
+class AlbumData extends Data
+{
+    public function __construct(
+        public string $title,
+        public SongDataCollection $songs,
+    ) {
+    }
+}
+```
+
 You can also use an attribute to define the type of data objects that will be stored within a collection:
 
 ```php

--- a/src/Support/Annotations/CollectionAnnotation.php
+++ b/src/Support/Annotations/CollectionAnnotation.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\LaravelData\Support\Annotations;
+
+class CollectionAnnotation
+{
+    public function __construct(
+        public string $type,
+        public bool $isData,
+        public string $keyType = 'array-key',
+    ) {
+    }
+}

--- a/src/Support/Annotations/CollectionAnnotationReader.php
+++ b/src/Support/Annotations/CollectionAnnotationReader.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Spatie\LaravelData\Support\Annotations;
+
+use Countable;
+use Iterator;
+use IteratorAggregate;
+use phpDocumentor\Reflection\DocBlock\Tags\Generic;
+use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\TypeResolver;
+use phpDocumentor\Reflection\Types\Context;
+use phpDocumentor\Reflection\Types\ContextFactory;
+use ReflectionClass;
+use Spatie\LaravelData\Data;
+use Traversable;
+
+class CollectionAnnotationReader
+{
+    public function __construct(
+        protected readonly TypeResolver $typeResolver,
+        protected readonly ContextFactory $contextFactory,
+    ) {}
+
+    protected Context $context;
+
+    public function getForClass(ReflectionClass $class): ?CollectionAnnotation
+    {
+        if (! $this->isCollection($class)) {
+            return null;
+        }
+
+        $type = $this->getCollectionReturnType($class);
+
+        if ($type === null || $type['valueType'] === null) {
+            return null;
+        }
+
+        $isData = false;
+
+        if (is_subclass_of($type['valueType'], Data::class)) {
+            $isData = true;
+        }
+
+        return new CollectionAnnotation(
+            type: $type['valueType'],
+            isData: $isData,
+            keyType: $type['keyType'] ?? 'array-key',
+        );
+    }
+
+    /**
+     * @return array{keyType: string|null, valueType: string|null}|null
+     */
+    protected function getCollectionReturnType(ReflectionClass $class): ?array
+    {
+        // Initialize TypeResolver and DocBlockFactory
+        $docBlockFactory = DocBlockFactory::createInstance();
+
+        // Extract the namespace and uses from the file content
+        $namespace = $class->getNamespaceName();
+        $fileContent = file_get_contents($class->getFileName());
+        $this->context = $this->contextFactory->createForNamespace($namespace, $fileContent);
+
+        // Get the PHPDoc comment of the class
+        $docComment = $class->getDocComment();
+        if ($docComment === false) {
+            return null;
+        }
+
+        // Create the DocBlock instance
+        $docBlock = $docBlockFactory->create($docComment, $this->context);
+
+        // Initialize variables
+        $templateTypes = [];
+        $keyType = null;
+        $valueType = null;
+
+        foreach ($docBlock->getTags() as $tag) {
+
+            if (! $tag instanceof Generic) {
+                continue;
+            }
+
+            if ($tag->getName() === 'template') {
+                $description = $tag->getDescription();
+
+                if (preg_match('/^(\w+)\s+of\s+([^\s]+)/', $description, $matches)) {
+                    $templateTypes[$matches[1]] = $this->resolve($matches[2]);
+                }
+
+                continue;
+            }
+
+            if ($tag->getName() === 'extends') {
+                $description = $tag->getDescription();
+
+                if (preg_match('/<\s*([^,]+)\s*,\s*([^>]+)\s*>/', $description, $matches)) {
+                    $keyType = $templateTypes[$matches[1]] ?? $this->resolve($matches[1]);
+                    $valueType = $templateTypes[$matches[2]] ?? $this->resolve($matches[2]);
+
+                    return [
+                        'keyType' => $keyType,
+                        'valueType' => $valueType
+                    ];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    protected function isCollection(ReflectionClass $class): bool
+    {
+        // Check if the class implements common collection interfaces
+        $collectionInterfaces = [
+            Traversable::class,
+            Iterator::class,
+            IteratorAggregate::class,
+            Countable::class,
+        ];
+
+        foreach ($collectionInterfaces as $interface) {
+            if ($class->implementsInterface($interface)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function resolve(string $type): ?string
+    {
+        $type = (string) $this->typeResolver->resolve($type, $this->context);
+
+        return $type ? ltrim($type, '\\') : null;
+    }
+}

--- a/src/Support/Annotations/DataIterableAnnotationReader.php
+++ b/src/Support/Annotations/DataIterableAnnotationReader.php
@@ -51,6 +51,7 @@ class DataIterableAnnotationReader
         $kindPattern = '(?:@property|@var|@param)\s*';
         $fqsenPattern = '[\\\\a-z0-9_\|]+';
         $typesPattern = '[\\\\a-z0-9_\\|\\[\\]]+';
+        $optionalTypesPattern = '(?:'.$typesPattern.')*';
         $keyPattern = '(?<key>int|string|int\|string|string\|int|array-key)';
         $parameterPattern = '\s*\$?(?<parameter>[a-z0-9_]+)?';
 
@@ -61,7 +62,7 @@ class DataIterableAnnotationReader
         );
 
         preg_match_all(
-            "/{$kindPattern}(?<collectionClass>{$fqsenPattern})<(?:{$keyPattern}\s*?,\s*?)?(?<dataClass>{$fqsenPattern})>{$parameterPattern}/i",
+            "/{$kindPattern}(?<collectionClass>{$fqsenPattern})<(?:{$keyPattern}\s*?,\s*?)?(?<dataClass>{$fqsenPattern})>{$optionalTypesPattern}{$parameterPattern}/i",
             $comment,
             $collectionMatches,
         );

--- a/src/Support/Annotations/DataIterableAnnotationReader.php
+++ b/src/Support/Annotations/DataIterableAnnotationReader.php
@@ -51,7 +51,6 @@ class DataIterableAnnotationReader
         $kindPattern = '(?:@property|@var|@param)\s*';
         $fqsenPattern = '[\\\\a-z0-9_\|]+';
         $typesPattern = '[\\\\a-z0-9_\\|\\[\\]]+';
-        $optionalTypesPattern = '(?:'.$typesPattern.')*';
         $keyPattern = '(?<key>int|string|int\|string|string\|int|array-key)';
         $parameterPattern = '\s*\$?(?<parameter>[a-z0-9_]+)?';
 
@@ -62,7 +61,7 @@ class DataIterableAnnotationReader
         );
 
         preg_match_all(
-            "/{$kindPattern}(?<collectionClass>{$fqsenPattern})<(?:{$keyPattern}\s*?,\s*?)?(?<dataClass>{$fqsenPattern})>{$optionalTypesPattern}{$parameterPattern}/i",
+            "/{$kindPattern}(?<collectionClass>{$fqsenPattern})<(?:{$keyPattern}\s*?,\s*?)?(?<dataClass>{$fqsenPattern})>(?:{$typesPattern})*{$parameterPattern}/i",
             $comment,
             $collectionMatches,
         );

--- a/src/Support/Factories/DataTypeFactory.php
+++ b/src/Support/Factories/DataTypeFactory.php
@@ -17,6 +17,7 @@ use Spatie\LaravelData\Enums\DataTypeKind;
 use Spatie\LaravelData\Exceptions\CannotFindDataClass;
 use Spatie\LaravelData\Lazy;
 use Spatie\LaravelData\Optional;
+use Spatie\LaravelData\Support\Annotations\CollectionAnnotationReader;
 use Spatie\LaravelData\Support\Annotations\DataIterableAnnotation;
 use Spatie\LaravelData\Support\Annotations\DataIterableAnnotationReader;
 use Spatie\LaravelData\Support\DataPropertyType;
@@ -36,6 +37,7 @@ class DataTypeFactory
 {
     public function __construct(
         protected DataIterableAnnotationReader $iterableAnnotationReader,
+        protected CollectionAnnotationReader $collectionAnnotationReader,
     ) {
     }
 
@@ -348,6 +350,17 @@ class DataTypeFactory
             $iterableItemType === null
             && $typeable instanceof ReflectionProperty
             && $annotation = $this->iterableAnnotationReader->getForProperty($typeable)
+        ) {
+            $isData = $annotation->isData;
+            $iterableItemType = $annotation->type;
+            $iterableKeyType = $annotation->keyType;
+        }
+
+        if (
+            $iterableItemType === null
+            && $typeable instanceof ReflectionProperty
+            && class_exists($name)
+            && $annotation = $this->collectionAnnotationReader->getForClass(new ReflectionClass($name))
         ) {
             $isData = $annotation->isData;
             $iterableItemType = $annotation->type;

--- a/tests/Fakes/CollectionDataAnnotationsData.php
+++ b/tests/Fakes/CollectionDataAnnotationsData.php
@@ -14,6 +14,7 @@ use Spatie\LaravelData\DataCollection;
  * @property array<\Spatie\LaravelData\Tests\Fakes\SimpleData> $propertyQ
  * @property \Spatie\LaravelData\Tests\Fakes\SimpleData[] $propertyR
  * @property array<SimpleData> $propertyS
+ * @property \Illuminate\Support\Collection<\Spatie\LaravelData\Tests\Fakes\SimpleData>|null $propertyT
  */
 class CollectionDataAnnotationsData
 {
@@ -67,6 +68,11 @@ class CollectionDataAnnotationsData
 
     public array $propertyS;
 
+    public ?array $propertyT;
+
+    /** @var \Illuminate\Support\Collection<\Spatie\LaravelData\Tests\Fakes\SimpleData>|null */
+    public ?array $propertyU;
+
     /**
      * @param \Spatie\LaravelData\Tests\Fakes\SimpleData[]|null $paramA
      * @param null|\Spatie\LaravelData\Tests\Fakes\SimpleData[] $paramB
@@ -78,6 +84,7 @@ class CollectionDataAnnotationsData
      * @param array<SimpleData> $paramH
      * @param array<int,SimpleData> $paramJ
      * @param array<int, SimpleData> $paramI
+     * @param \Spatie\LaravelData\DataCollection<\Spatie\LaravelData\Tests\Fakes\SimpleData>|null $paramK
      */
     public function method(
         array $paramA,
@@ -89,6 +96,7 @@ class CollectionDataAnnotationsData
         array $paramG,
         array $paramJ,
         array $paramI,
+        ?array $paramK,
     ) {
 
     }

--- a/tests/Fakes/CollectionNonDataAnnotationsData.php
+++ b/tests/Fakes/CollectionNonDataAnnotationsData.php
@@ -11,6 +11,7 @@ use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
  * @property \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum[] $propertyM
  * @property array<\Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum> $propertyN
  * @property array<DummyBackedEnum> $propertyO
+ * @property array<DummyBackedEnum>|null $propertyQ
  */
 class CollectionNonDataAnnotationsData
 {
@@ -58,6 +59,11 @@ class CollectionNonDataAnnotationsData
     /** @var \Illuminate\Support\Collection<Error> */
     public Collection $propertyP;
 
+    public array $propertyQ;
+
+    /** @var \Illuminate\Support\Collection<Error>|null */
+    public ?Collection $propertyR;
+
     /**
      * @param \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum[]|null $paramA
      * @param null|\Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum[] $paramB
@@ -69,6 +75,7 @@ class CollectionNonDataAnnotationsData
      * @param array<DummyBackedEnum> $paramH
      * @param array<int,DummyBackedEnum> $paramJ
      * @param array<int, DummyBackedEnum> $paramI
+     * @param \Spatie\LaravelData\DataCollection<\Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum>|null $paramK
      */
     public function method(
         array $paramA,
@@ -80,6 +87,7 @@ class CollectionNonDataAnnotationsData
         array $paramG,
         array $paramJ,
         array $paramI,
+        ?array $paramK,
     ) {
 
     }

--- a/tests/Support/Annotations/CollectionAnnotationReaderTest.php
+++ b/tests/Support/Annotations/CollectionAnnotationReaderTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Spatie\LaravelData\Support\Annotations\CollectionAnnotation;
+use Spatie\LaravelData\Support\Annotations\CollectionAnnotationReader;
+use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
+use Spatie\LaravelData\Tests\Fakes\SimpleData;
+
+it(
+    'can get the data class for a collection by annotation',
+    function (string $className, ?CollectionAnnotation $expected) {
+        $annotations = app(CollectionAnnotationReader::class)->getForClass(new ReflectionClass($className));
+
+        expect($annotations)->toEqual($expected);
+    }
+)->with(function () {
+    yield DataCollectionWithTemplate::class => [
+        'className' => DataCollectionWithTemplate::class,
+        'expected' => new CollectionAnnotation(type: SimpleData::class, isData: true),
+    ];
+
+    yield DataCollectionWithoutTemplate::class => [
+        'className' => DataCollectionWithoutTemplate::class,
+        'expected' => new CollectionAnnotation(type: SimpleData::class, isData: true),
+    ];
+
+    yield DataCollectionWithoutExtends::class => [
+        'className' => DataCollectionWithoutExtends::class,
+        'expected' => null,
+    ];
+
+    yield NonDataCollectionWithTemplate::class => [
+        'className' => NonDataCollectionWithTemplate::class,
+        'expected' => new CollectionAnnotation(type: DummyBackedEnum::class, isData: false),
+    ];
+
+    yield NonDataCollectionWithoutTemplate::class => [
+        'className' => NonDataCollectionWithoutTemplate::class,
+        'expected' => new CollectionAnnotation(type: DummyBackedEnum::class, isData: false),
+    ];
+
+    yield NonDataCollectionWithoutExtends::class => [
+        'className' => NonDataCollectionWithoutExtends::class,
+        'expected' => null,
+    ];
+
+    yield NonCollectionWithTemplate::class => [
+        'className' => NonCollectionWithTemplate::class,
+        'expected' => null,
+    ];
+});
+
+
+/**
+ * @template TKey of array-key
+ * @template TValue of \Spatie\LaravelData\Tests\Fakes\SimpleData
+ *
+ * @extends \Illuminate\Support\Collection<TKey, TValue>
+ */
+class DataCollectionWithTemplate extends Collection
+{
+}
+
+/**
+ * @extends \Illuminate\Support\Collection<array-key, \Spatie\LaravelData\Tests\Fakes\SimpleData>
+ */
+class DataCollectionWithoutTemplate extends Collection
+{
+}
+
+class DataCollectionWithoutExtends extends Collection
+{
+}
+
+/**
+ * @template TKey of array-key
+ * @template TValue of \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum
+ *
+ * @extends \Illuminate\Support\Collection<TKey, TValue>
+ */
+class NonDataCollectionWithTemplate extends Collection
+{
+}
+
+/**
+ * @extends \Illuminate\Support\Collection<array-key, \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum>
+ */
+class NonDataCollectionWithoutTemplate extends Collection
+{
+}
+
+class NonDataCollectionWithoutExtends extends Collection
+{
+}
+
+/**
+ * @extends \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum
+ */
+class NonCollectionWithTemplate
+{
+}

--- a/tests/Support/Annotations/DataIterableAnnotationReaderTest.php
+++ b/tests/Support/Annotations/DataIterableAnnotationReaderTest.php
@@ -81,6 +81,11 @@ it(
         'property' => 'propertyM',
         'expected' => new DataIterableAnnotation(SimpleData::class, isData: true),
     ];
+
+    yield 'propertyU' => [
+        'property' => 'propertyU',
+        'expected' => new DataIterableAnnotation(SimpleData::class, isData: true),
+    ];
 });
 
 it('can get the data class for a data collection by class annotation', function () {
@@ -93,6 +98,7 @@ it('can get the data class for a data collection by class annotation', function 
         new DataIterableAnnotation(SimpleData::class, isData: true, property: 'propertyQ'),
         new DataIterableAnnotation(SimpleData::class, isData: true, property: 'propertyR'),
         new DataIterableAnnotation(SimpleData::class, isData: true, property: 'propertyS'),
+        new DataIterableAnnotation(SimpleData::class, isData: true, property: 'propertyT'),
     ]);
 });
 
@@ -110,6 +116,7 @@ it('can get data class for a data collection by method annotation', function () 
         new DataIterableAnnotation(SimpleData::class, isData: true, property: 'paramH'),
         new DataIterableAnnotation(SimpleData::class, isData: true, keyType: 'int', property: 'paramJ'),
         new DataIterableAnnotation(SimpleData::class, isData: true, keyType: 'int', property: 'paramI'),
+        new DataIterableAnnotation(SimpleData::class, isData: true, property: 'paramK'),
     ]);
 });
 
@@ -185,6 +192,11 @@ it(
         'property' => 'propertyP',
         'expected' => new DataIterableAnnotation(Error::class, isData: true),
     ];
+
+    yield 'propertyR' => [
+        'property' => 'propertyR',
+        'expected' => new DataIterableAnnotation(Error::class, isData: true),
+    ];
 });
 
 it('can get the iterable class for a collection by class annotation', function () {
@@ -194,6 +206,7 @@ it('can get the iterable class for a collection by class annotation', function (
         new DataIterableAnnotation(DummyBackedEnum::class, isData: false, property: 'propertyM'),
         new DataIterableAnnotation(DummyBackedEnum::class, isData: false, property: 'propertyN'),
         new DataIterableAnnotation(DummyBackedEnum::class, isData: false, property: 'propertyO'),
+        new DataIterableAnnotation(DummyBackedEnum::class, isData: false, property: 'propertyQ'),
     ]);
 });
 
@@ -211,6 +224,7 @@ it('can get iterable class for a data by method annotation', function () {
         new DataIterableAnnotation(DummyBackedEnum::class, isData: false, property: 'paramH'),
         new DataIterableAnnotation(DummyBackedEnum::class, isData: false, keyType: 'int', property: 'paramJ'),
         new DataIterableAnnotation(DummyBackedEnum::class, isData: false, keyType: 'int', property: 'paramI'),
+        new DataIterableAnnotation(DummyBackedEnum::class, isData: false, property: 'paramK'),
     ]);
 });
 

--- a/tests/Support/DataPropertyTypeTest.php
+++ b/tests/Support/DataPropertyTypeTest.php
@@ -572,6 +572,54 @@ it('can deduce an enumerable data collection union type', function () {
         ->iterableClass->toBe(Collection::class);
 });
 
+it('can deduce an enumerable data collection type from collection', function () {
+    $type = resolveDataType(new class () {
+        public DataCollectionWithTemplate $property;
+    });
+
+    expect($type)
+        ->isOptional->toBeFalse()
+        ->isNullable->toBeFalse()
+        ->isMixed->toBeFalse()
+        ->lazyType->toBeNull()
+        ->kind->toBe(DataTypeKind::DataEnumerable)
+        ->dataClass->toBe(SimpleData::class)
+        ->iterableClass->toBe(DataCollectionWithTemplate::class)
+        ->getAcceptedTypes()->toHaveKeys([DataCollectionWithTemplate::class]);
+
+    expect($type->type)
+        ->toBeInstanceOf(NamedType::class)
+        ->name->toBe(DataCollectionWithTemplate::class)
+        ->builtIn->toBeFalse()
+        ->kind->toBe(DataTypeKind::DataEnumerable)
+        ->dataClass->toBe(SimpleData::class)
+        ->iterableClass->toBe(DataCollectionWithTemplate::class);
+});
+
+it('can deduce an enumerable data collection union type from collection', function () {
+    $type = resolveDataType(new class () {
+        public DataCollectionWithTemplate|Lazy $property;
+    });
+
+    expect($type)
+        ->isOptional->toBeFalse()
+        ->isNullable->toBeFalse()
+        ->isMixed->toBeFalse()
+        ->lazyType->toBe(Lazy::class)
+        ->kind->toBe(DataTypeKind::DataEnumerable)
+        ->dataClass->toBe(SimpleData::class)
+        ->iterableClass->toBe(DataCollectionWithTemplate::class)
+        ->getAcceptedTypes()->toHaveKeys([DataCollectionWithTemplate::class]);
+
+    expect($type->type)
+        ->toBeInstanceOf(NamedType::class)
+        ->name->toBe(DataCollectionWithTemplate::class)
+        ->builtIn->toBeFalse()
+        ->kind->toBe(DataTypeKind::DataEnumerable)
+        ->dataClass->toBe(SimpleData::class)
+        ->iterableClass->toBe(DataCollectionWithTemplate::class);
+});
+
 it('can deduce a paginator data collection type', function () {
     $type = resolveDataType(new class () {
         #[DataCollectionOf(SimpleData::class)]


### PR DESCRIPTION
This PR introduces a new feature that allows the use of well-typed collections without the need for annotations.

For example:

```php
// before
use App\Data\SongData;
use Illuminate\Support\Collection;

class AlbumData extends Data
{    
    /** @var Collection<int, SongData> */
    public Collection $songs;
}

// after
use App\Collection\SongDataCollection;

class AlbumData extends Data
{    
    public SongDataCollection $songs;
}
```