### PR TITLE
Detect data from collection

### DIFF
--- a/docs/as-a-data-transfer-object/nesting.md
+++ b/docs/as-a-data-transfer-object/nesting.md
@@ -124,6 +124,29 @@ class AlbumData extends Data
 }
 ```
 
+If the collection is well-typed, you don't need to use annotations:
+
+```php
+/**
+ * @template TKey of array-key
+ * @template TValue of \App\Data\SongData
+ *
+ * @extends \Illuminate\Support\Collection<TKey, TValue>
+ */
+class SongDataCollection
+{
+}
+
+class AlbumData extends Data
+{
+    public function __construct(
+        public string $title,
+        public SongDataCollection $songs,
+    ) {
+    }
+}
+```
+
 You can also use an attribute to define the type of data objects that will be stored within a collection:
 
 ```php

--- a/docs/as-a-data-transfer-object/nesting.md
+++ b/docs/as-a-data-transfer-object/nesting.md
@@ -124,7 +124,7 @@ class AlbumData extends Data
 }
 ```
 
-If the collection is well-typed, you don't need to use annotations:
+If the collection is well-annotated, the `Data` class doesn't need to use annotations:
 
 ```php
 /**

--- a/docs/as-a-data-transfer-object/nesting.md
+++ b/docs/as-a-data-transfer-object/nesting.md
@@ -129,9 +129,9 @@ If the collection is well-annotated, the `Data` class doesn't need to use annota
 ```php
 /**
  * @template TKey of array-key
- * @template TValue of \App\Data\SongData
+ * @template TData of \App\Data\SongData
  *
- * @extends \Illuminate\Support\Collection<TKey, TValue>
+ * @extends \Illuminate\Support\Collection<TKey, TData>
  */
 class SongDataCollection extends Collection
 {

--- a/docs/as-a-data-transfer-object/nesting.md
+++ b/docs/as-a-data-transfer-object/nesting.md
@@ -133,7 +133,7 @@ If the collection is well-typed, you don't need to use annotations:
  *
  * @extends \Illuminate\Support\Collection<TKey, TValue>
  */
-class SongDataCollection
+class SongDataCollection extends Collection
 {
 }
 

--- a/src/LaravelDataServiceProvider.php
+++ b/src/LaravelDataServiceProvider.php
@@ -6,6 +6,7 @@ use Livewire\Livewire;
 use Spatie\LaravelData\Commands\DataMakeCommand;
 use Spatie\LaravelData\Commands\DataStructuresCacheCommand;
 use Spatie\LaravelData\Contracts\BaseData;
+use Spatie\LaravelData\Resolvers\ContextResolver;
 use Spatie\LaravelData\Support\Caching\DataStructureCache;
 use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelData\Support\Livewire\LivewireDataCollectionSynth;
@@ -42,6 +43,8 @@ class LaravelDataServiceProvider extends PackageServiceProvider
                 return $this->app->make(DataStructureCache::class)->getConfig() ?? DataConfig::createFromConfig(config('data'));
             }
         );
+
+        $this->app->singleton(ContextResolver::class);
 
         $this->app->beforeResolving(BaseData::class, function ($class, $parameters, $app) {
             if ($app->has($class)) {

--- a/src/Resolvers/ContextResolver.php
+++ b/src/Resolvers/ContextResolver.php
@@ -13,7 +13,7 @@ class ContextResolver
     /** @var array<string, Context> */
     protected array $contexts = [];
 
-    public function get(ReflectionProperty|ReflectionClass|ReflectionMethod $reflection): Context
+    public function execute(ReflectionProperty|ReflectionClass|ReflectionMethod $reflection): Context
     {
         $reflectionClass = $reflection instanceof ReflectionProperty || $reflection instanceof ReflectionMethod
             ? $reflection->getDeclaringClass()

--- a/src/Resolvers/ContextResolver.php
+++ b/src/Resolvers/ContextResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\LaravelData\Resolvers;
+
+use phpDocumentor\Reflection\Types\Context;
+use phpDocumentor\Reflection\Types\ContextFactory;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+class ContextResolver
+{
+    /** @var array<string, Context> */
+    protected array $contexts = [];
+
+    public function get(ReflectionProperty|ReflectionClass|ReflectionMethod $reflection): Context
+    {
+        $reflectionClass = $reflection instanceof ReflectionProperty || $reflection instanceof ReflectionMethod
+            ? $reflection->getDeclaringClass()
+            : $reflection;
+
+        return $this->contexts[$reflectionClass->getName()] ??= (new ContextFactory())->createFromReflector($reflectionClass);
+    }
+}

--- a/src/Support/Annotations/CollectionAnnotation.php
+++ b/src/Support/Annotations/CollectionAnnotation.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\LaravelData\Support\Annotations;
+
+class CollectionAnnotation
+{
+    public function __construct(
+        public string $type,
+        public bool $isData,
+        public string $keyType = 'array-key',
+    ) {
+    }
+}

--- a/src/Support/Annotations/CollectionAnnotationReader.php
+++ b/src/Support/Annotations/CollectionAnnotationReader.php
@@ -8,15 +8,15 @@ use phpDocumentor\Reflection\DocBlock\Tags\Generic;
 use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context;
-use phpDocumentor\Reflection\Types\ContextFactory;
 use ReflectionClass;
 use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Resolvers\ContextResolver;
 
 class CollectionAnnotationReader
 {
     public function __construct(
+        protected readonly ContextResolver $contextResolver,
         protected readonly TypeResolver $typeResolver,
-        protected readonly ContextFactory $contextFactory,
     ) {
     }
 
@@ -55,10 +55,7 @@ class CollectionAnnotationReader
         // Initialize TypeResolver and DocBlockFactory
         $docBlockFactory = DocBlockFactory::createInstance();
 
-        // Extract the namespace and uses from the file content
-        $namespace = $class->getNamespaceName();
-        $fileContent = file_get_contents($class->getFileName());
-        $this->context = $this->contextFactory->createForNamespace($namespace, $fileContent);
+        $this->context = $this->contextResolver->get($class);
 
         // Get the PHPDoc comment of the class
         $docComment = $class->getDocComment();

--- a/src/Support/Annotations/CollectionAnnotationReader.php
+++ b/src/Support/Annotations/CollectionAnnotationReader.php
@@ -19,7 +19,8 @@ class CollectionAnnotationReader
     public function __construct(
         protected readonly TypeResolver $typeResolver,
         protected readonly ContextFactory $contextFactory,
-    ) {}
+    ) {
+    }
 
     protected Context $context;
 
@@ -109,7 +110,7 @@ class CollectionAnnotationReader
 
                     return [
                         'keyType' => $keyType,
-                        'valueType' => $valueType
+                        'valueType' => $valueType,
                     ];
                 }
             }

--- a/src/Support/Annotations/CollectionAnnotationReader.php
+++ b/src/Support/Annotations/CollectionAnnotationReader.php
@@ -25,6 +25,9 @@ class CollectionAnnotationReader
 
     protected Context $context;
 
+    /**
+     * @param class-string $className
+     */
     public function getForClass(string $className): ?CollectionAnnotation
     {
         // Check the cache first
@@ -33,7 +36,7 @@ class CollectionAnnotationReader
         }
 
         // Create ReflectionClass from class string
-        $class = new ReflectionClass($className);
+        $class = $this->getReflectionClass($className);
 
         // Determine if the class is a collection
         if (! $this->isCollection($class)) {
@@ -59,6 +62,36 @@ class CollectionAnnotationReader
         self::$cache[$className] = $annotation;
 
         return $annotation;
+    }
+
+    public static function clearCache(): void
+    {
+        self::$cache = [];
+    }
+
+    /**
+     * @param class-string $className
+     */
+    protected function getReflectionClass(string $className): ReflectionClass
+    {
+        return new ReflectionClass($className);
+    }
+
+    protected function isCollection(ReflectionClass $class): bool
+    {
+        // Check if the class implements common collection interfaces
+        $collectionInterfaces = [
+            Iterator::class,
+            IteratorAggregate::class,
+        ];
+
+        foreach ($collectionInterfaces as $interface) {
+            if ($class->implementsInterface($interface)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -126,23 +159,6 @@ class CollectionAnnotationReader
         }
 
         return null;
-    }
-
-    protected function isCollection(ReflectionClass $class): bool
-    {
-        // Check if the class implements common collection interfaces
-        $collectionInterfaces = [
-            Iterator::class,
-            IteratorAggregate::class,
-        ];
-
-        foreach ($collectionInterfaces as $interface) {
-            if ($class->implementsInterface($interface)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     protected function resolve(string $type): ?string

--- a/src/Support/Annotations/CollectionAnnotationReader.php
+++ b/src/Support/Annotations/CollectionAnnotationReader.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Spatie\LaravelData\Support\Annotations;
+
+use Countable;
+use Iterator;
+use IteratorAggregate;
+use phpDocumentor\Reflection\DocBlock\Tags\Generic;
+use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\TypeResolver;
+use phpDocumentor\Reflection\Types\Context;
+use phpDocumentor\Reflection\Types\ContextFactory;
+use ReflectionClass;
+use Spatie\LaravelData\Data;
+use Traversable;
+
+class CollectionAnnotationReader
+{
+    public function __construct(
+        protected readonly TypeResolver $typeResolver,
+        protected readonly ContextFactory $contextFactory,
+    ) {}
+
+    protected Context $context;
+
+    public function getForClass(ReflectionClass $class): ?CollectionAnnotation
+    {
+        if (! $this->isCollection($class)) {
+            return null;
+        }
+
+        $type = $this->getCollectionReturnType($class);
+
+        if ($type === null || $type['valueType'] === null) {
+            return null;
+        }
+
+        $isData = false;
+
+        if (is_subclass_of($type['valueType'], Data::class)) {
+            $isData = true;
+        }
+
+        return new CollectionAnnotation(
+            type: $type['valueType'],
+            isData: $isData,
+            keyType: $type['keyType'] ?? 'array-key',
+        );
+    }
+
+    /**
+     * @return array{keyType: string|null, valueType: string|null}|null
+     */
+    protected function getCollectionReturnType(ReflectionClass $class): ?array
+    {
+        // Initialize TypeResolver and DocBlockFactory
+        $docBlockFactory = DocBlockFactory::createInstance();
+
+        // Extract the namespace and uses from the file content
+        $namespace = $class->getNamespaceName();
+        $fileContent = file_get_contents($class->getFileName());
+        $this->context = $this->contextFactory->createForNamespace($namespace, $fileContent);
+
+        // Get the PHPDoc comment of the class
+        $docComment = $class->getDocComment();
+        if ($docComment === false) {
+            return null;
+        }
+
+        // Create the DocBlock instance
+        $docBlock = $docBlockFactory->create($docComment, $this->context);
+
+        // Initialize variables
+        $templateTypes = [];
+        $keyType = null;
+        $valueType = null;
+
+        foreach ($docBlock->getTags() as $tag) {
+
+            if (! $tag instanceof Generic) {
+                continue;
+            }
+
+            if ($tag->getName() === 'template') {
+                $description = $tag->getDescription();
+
+                if (preg_match('/^(\w+)\s+of\s+([^\s]+)/', $description, $matches)) {
+                    $templateTypes[$matches[1]] = $this->resolve($matches[2]);
+                }
+
+                continue;
+            }
+
+            if ($tag->getName() === 'extends') {
+                $description = $tag->getDescription();
+
+                if (preg_match('/<\s*([^,]+)\s*,\s*([^>]+)\s*>/', $description, $matches)) {
+                    $keyType = $templateTypes[$matches[1]] ?? $this->resolve($matches[1]);
+                    $valueType = $templateTypes[$matches[2]] ?? $this->resolve($matches[2]);
+
+                    return [
+                        'keyType' => $keyType,
+                        'valueType' => $valueType
+                    ];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    protected function isCollection(ReflectionClass $class): bool
+    {
+        // Check if the class implements common collection interfaces
+        $collectionInterfaces = [
+            Traversable::class,
+            Iterator::class,
+            IteratorAggregate::class,
+            Countable::class,
+        ];
+
+        foreach ($collectionInterfaces as $interface) {
+            if ($class->implementsInterface($interface)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function resolve(string $type): ?string
+    {
+        $type = (string) $this->typeResolver->resolve($type, $this->context);
+
+        return $type ? ltrim($type, '\\') : null;
+    }
+}

--- a/src/Support/Annotations/CollectionAnnotationReader.php
+++ b/src/Support/Annotations/CollectionAnnotationReader.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\LaravelData\Support\Annotations;
 
-use Countable;
 use Iterator;
 use IteratorAggregate;
 use phpDocumentor\Reflection\DocBlock\Tags\Generic;
@@ -12,7 +11,6 @@ use phpDocumentor\Reflection\Types\Context;
 use phpDocumentor\Reflection\Types\ContextFactory;
 use ReflectionClass;
 use Spatie\LaravelData\Data;
-use Traversable;
 
 class CollectionAnnotationReader
 {
@@ -123,10 +121,8 @@ class CollectionAnnotationReader
     {
         // Check if the class implements common collection interfaces
         $collectionInterfaces = [
-            Traversable::class,
             Iterator::class,
             IteratorAggregate::class,
-            Countable::class,
         ];
 
         foreach ($collectionInterfaces as $interface) {

--- a/src/Support/Annotations/CollectionAnnotationReader.php
+++ b/src/Support/Annotations/CollectionAnnotationReader.php
@@ -104,8 +104,8 @@ class CollectionAnnotationReader
                         $valueType = $templateTypes[$matches[1]] ?? $this->resolve($matches[1]);
                     }
 
-                    $valueType = explode('|', $valueType)[0];
                     $keyType = $keyType ? explode('|', $keyType)[0] : null;
+                    $valueType = explode('|', $valueType)[0];
 
                     return [
                         'keyType' => $keyType,

--- a/src/Support/Annotations/CollectionAnnotationReader.php
+++ b/src/Support/Annotations/CollectionAnnotationReader.php
@@ -94,9 +94,18 @@ class CollectionAnnotationReader
             if ($tag->getName() === 'extends') {
                 $description = $tag->getDescription();
 
-                if (preg_match('/<\s*([^,]+)\s*,\s*([^>]+)\s*>/', $description, $matches)) {
-                    $keyType = $templateTypes[$matches[1]] ?? $this->resolve($matches[1]);
-                    $valueType = $templateTypes[$matches[2]] ?? $this->resolve($matches[2]);
+                if (preg_match('/<\s*([^,\s]+)?\s*(?:,\s*([^>\s]+))?\s*>/', $description, $matches)) {
+
+                    if (count($matches) === 3) {
+                        $keyType = $templateTypes[$matches[1]] ?? $this->resolve($matches[1]);
+                        $valueType = $templateTypes[$matches[2]] ?? $this->resolve($matches[2]);
+                    } else {
+                        $keyType = null;
+                        $valueType = $templateTypes[$matches[1]] ?? $this->resolve($matches[1]);
+                    }
+
+                    $valueType = explode('|', $valueType)[0];
+                    $keyType = $keyType ? explode('|', $keyType)[0] : null;
 
                     return [
                         'keyType' => $keyType,

--- a/src/Support/Annotations/CollectionAnnotationReader.php
+++ b/src/Support/Annotations/CollectionAnnotationReader.php
@@ -102,7 +102,7 @@ class CollectionAnnotationReader
         // Initialize TypeResolver and DocBlockFactory
         $docBlockFactory = DocBlockFactory::createInstance();
 
-        $this->context = $this->contextResolver->get($class);
+        $this->context = $this->contextResolver->execute($class);
 
         // Get the PHPDoc comment of the class
         $docComment = $class->getDocComment();

--- a/src/Support/Annotations/DataIterableAnnotationReader.php
+++ b/src/Support/Annotations/DataIterableAnnotationReader.php
@@ -197,7 +197,7 @@ class DataIterableAnnotationReader
         ReflectionProperty|ReflectionClass|ReflectionMethod $reflection,
         string $class
     ): ?string {
-        $context = $this->contextResolver->get($reflection);
+        $context = $this->contextResolver->execute($reflection);
 
         $type = (new FqsenResolver())->resolve($class, $context);
 

--- a/src/Support/Annotations/DataIterableAnnotationReader.php
+++ b/src/Support/Annotations/DataIterableAnnotationReader.php
@@ -4,20 +4,21 @@ namespace Spatie\LaravelData\Support\Annotations;
 
 use Illuminate\Support\Arr;
 use phpDocumentor\Reflection\FqsenResolver;
-use phpDocumentor\Reflection\Types\Context;
-use phpDocumentor\Reflection\Types\ContextFactory;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
 use Spatie\LaravelData\Contracts\BaseData;
+use Spatie\LaravelData\Resolvers\ContextResolver;
 
 /**
  * @note To myself, always use the fully qualified class names in pest tests when using anonymous classes
  */
 class DataIterableAnnotationReader
 {
-    /** @var array<string, Context> */
-    protected static array $contexts = [];
+    public function __construct(
+        protected readonly ContextResolver $contextResolver,
+    ) {
+    }
 
     /** @return array<string, DataIterableAnnotation> */
     public function getForClass(ReflectionClass $class): array
@@ -196,19 +197,10 @@ class DataIterableAnnotationReader
         ReflectionProperty|ReflectionClass|ReflectionMethod $reflection,
         string $class
     ): ?string {
-        $context = $this->getContext($reflection);
+        $context = $this->contextResolver->get($reflection);
 
         $type = (new FqsenResolver())->resolve($class, $context);
 
         return ltrim((string) $type, '\\');
-    }
-
-    protected function getContext(ReflectionProperty|ReflectionClass|ReflectionMethod $reflection): Context
-    {
-        $reflectionClass = $reflection instanceof ReflectionProperty || $reflection instanceof ReflectionMethod
-            ? $reflection->getDeclaringClass()
-            : $reflection;
-
-        return static::$contexts[$reflectionClass->getName()] ??= (new ContextFactory())->createFromReflector($reflectionClass);
     }
 }

--- a/src/Support/Factories/DataTypeFactory.php
+++ b/src/Support/Factories/DataTypeFactory.php
@@ -360,7 +360,7 @@ class DataTypeFactory
             $iterableItemType === null
             && $typeable instanceof ReflectionProperty
             && class_exists($name)
-            && $annotation = $this->collectionAnnotationReader->getForClass(new ReflectionClass($name))
+            && $annotation = $this->collectionAnnotationReader->getForClass($name)
         ) {
             $isData = $annotation->isData;
             $iterableItemType = $annotation->type;

--- a/src/Support/Factories/DataTypeFactory.php
+++ b/src/Support/Factories/DataTypeFactory.php
@@ -17,6 +17,7 @@ use Spatie\LaravelData\Enums\DataTypeKind;
 use Spatie\LaravelData\Exceptions\CannotFindDataClass;
 use Spatie\LaravelData\Lazy;
 use Spatie\LaravelData\Optional;
+use Spatie\LaravelData\Support\Annotations\CollectionAnnotationReader;
 use Spatie\LaravelData\Support\Annotations\DataIterableAnnotation;
 use Spatie\LaravelData\Support\Annotations\DataIterableAnnotationReader;
 use Spatie\LaravelData\Support\DataPropertyType;
@@ -36,6 +37,7 @@ class DataTypeFactory
 {
     public function __construct(
         protected DataIterableAnnotationReader $iterableAnnotationReader,
+        protected CollectionAnnotationReader $collectionAnnotationReader,
     ) {
     }
 
@@ -348,6 +350,17 @@ class DataTypeFactory
             $iterableItemType === null
             && $typeable instanceof ReflectionProperty
             && $annotation = $this->iterableAnnotationReader->getForProperty($typeable)
+        ) {
+            $isData = $annotation->isData;
+            $iterableItemType = $annotation->type;
+            $iterableKeyType = $annotation->keyType;
+        }
+
+        if (
+            $iterableItemType === null
+            && $typeable instanceof ReflectionProperty
+            && class_exists($name)
+            && $annotation = $this->collectionAnnotationReader->getForClass(new ReflectionClass($name))
         ) {
             $isData = $annotation->isData;
             $iterableItemType = $annotation->type;

--- a/tests/CollectionAttributeWithAnotationsTest.php
+++ b/tests/CollectionAttributeWithAnotationsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Spatie\LaravelData\Tests\Fakes\Collections\SimpleDataCollectionWithAnotations;
+use Spatie\LaravelData\Tests\Fakes\DataWithSimpleDataCollectionWithAnotations;
+use Spatie\LaravelData\Tests\Fakes\SimpleData;
+use Spatie\LaravelData\Tests\TestSupport\DataValidationAsserter;
+
+beforeEach(function () {
+    $this->payload = [
+        'collection' => [
+            ['string' => 'string1'],
+            ['string' => 'string2'],
+            ['string' => 'string3'],
+        ],
+    ];
+});
+
+it('can create a data object with a collection attribute from array and back', function () {
+
+    $data = DataWithSimpleDataCollectionWithAnotations::from($this->payload);
+
+    expect($data)->toEqual(new DataWithSimpleDataCollectionWithAnotations(
+        collection: new SimpleDataCollectionWithAnotations([
+            new SimpleData(string: 'string1'),
+            new SimpleData(string: 'string2'),
+            new SimpleData(string: 'string3'),
+        ])
+    ));
+
+    expect($data->toArray())->toBe($this->payload);
+});
+
+it('can validate a data object with a collection attribute', function () {
+
+    DataValidationAsserter::for(DataWithSimpleDataCollectionWithAnotations::class)
+        ->assertOk($this->payload)
+        ->assertErrors(['collection' => [
+            ['notExistingAttribute' => 'xxx'],
+        ]])
+        ->assertRules(
+            rules: [
+                'collection' => ['present', 'array'],
+                'collection.0.string' => ['required', 'string'],
+                'collection.1.string' => ['required', 'string'],
+                'collection.2.string' => ['required', 'string'],
+            ],
+            payload: $this->payload
+        );
+});

--- a/tests/Fakes/Collections/SimpleDataCollectionWithAnotations.php
+++ b/tests/Fakes/Collections/SimpleDataCollectionWithAnotations.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes\Collections;
+
+use Illuminate\Support\Collection;
+
+/**
+ * @template TKey of array-key
+ * @template TData of \Spatie\LaravelData\Tests\Fakes\SimpleData
+ *
+ * @extends \Illuminate\Support\Collection<TKey, TData>
+ */
+class SimpleDataCollectionWithAnotations extends Collection
+{
+}

--- a/tests/Fakes/DataWithSimpleDataCollectionWithAnotations.php
+++ b/tests/Fakes/DataWithSimpleDataCollectionWithAnotations.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Tests\Fakes\Collections\SimpleDataCollectionWithAnotations;
+
+class DataWithSimpleDataCollectionWithAnotations extends Data
+{
+    public function __construct(
+        public SimpleDataCollectionWithAnotations $collection
+    ) {
+    }
+}

--- a/tests/Resolvers/ContextResolverTest.php
+++ b/tests/Resolvers/ContextResolverTest.php
@@ -11,7 +11,7 @@ it('can resolve context from property', function () {
     $reflectionProperty = new ReflectionProperty(TestContextResolverClass::class, 'testProperty');
 
     // Resolve the context
-    $context = $resolver->get($reflectionProperty);
+    $context = $resolver->execute($reflectionProperty);
 
     // Create expected context
     $expectedContext = (new ContextFactory())->createFromReflector($reflectionProperty->getDeclaringClass());
@@ -28,7 +28,7 @@ it('can resolve context from class', function () {
     $reflectionClass = new ReflectionClass(TestContextResolverClass::class);
 
     // Resolve the context
-    $context = $resolver->get($reflectionClass);
+    $context = $resolver->execute($reflectionClass);
 
     // Create expected context
     $expectedContext = (new ContextFactory())->createFromReflector($reflectionClass);
@@ -45,7 +45,7 @@ it('can resolve context from method', function () {
     $reflectionMethod = new ReflectionMethod(TestContextResolverClass::class, 'testMethod');
 
     // Resolve the context
-    $context = $resolver->get($reflectionMethod);
+    $context = $resolver->execute($reflectionMethod);
 
     // Create expected context
     $expectedContext = (new ContextFactory())->createFromReflector($reflectionMethod->getDeclaringClass());
@@ -62,10 +62,10 @@ it('uses cache when resolving the same class multiple times', function () {
     $reflectionClass = new ReflectionClass(TestContextResolverClass::class);
 
     // Resolve the context the first time
-    $context1 = $resolver->get($reflectionClass);
+    $context1 = $resolver->execute($reflectionClass);
 
     // Resolve the context the second time
-    $context2 = $resolver->get($reflectionClass);
+    $context2 = $resolver->execute($reflectionClass);
 
     // Assertions
     expect($context1)->toBeInstanceOf(Context::class);

--- a/tests/Resolvers/ContextResolverTest.php
+++ b/tests/Resolvers/ContextResolverTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use phpDocumentor\Reflection\Types\Context;
+use phpDocumentor\Reflection\Types\ContextFactory;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+use Spatie\LaravelData\Resolvers\ContextResolver;
+
+it('can resolve context from property', function () {
+    $resolver = new ContextResolver();
+
+    // Create a ReflectionProperty for the test class
+    $reflectionProperty = new ReflectionProperty(TestContextResolverClass::class, 'testProperty');
+
+    // Resolve the context
+    $context = $resolver->get($reflectionProperty);
+
+    // Create expected context
+    $expectedContext = (new ContextFactory())->createFromReflector($reflectionProperty->getDeclaringClass());
+
+    // Assertions
+    expect($context)->toBeInstanceOf(Context::class);
+    expect($context)->toEqual($expectedContext);
+});
+
+it('can resolve context from class', function () {
+    $resolver = new ContextResolver();
+
+    // Create a ReflectionClass for the test class
+    $reflectionClass = new ReflectionClass(TestContextResolverClass::class);
+
+    // Resolve the context
+    $context = $resolver->get($reflectionClass);
+
+    // Create expected context
+    $expectedContext = (new ContextFactory())->createFromReflector($reflectionClass);
+
+    // Assertions
+    expect($context)->toBeInstanceOf(Context::class);
+    expect($context)->toEqual($expectedContext);
+});
+
+it('can resolve context from method', function () {
+    $resolver = new ContextResolver();
+
+    // Create a ReflectionMethod for the test class method
+    $reflectionMethod = new ReflectionMethod(TestContextResolverClass::class, 'testMethod');
+
+    // Resolve the context
+    $context = $resolver->get($reflectionMethod);
+
+    // Create expected context
+    $expectedContext = (new ContextFactory())->createFromReflector($reflectionMethod->getDeclaringClass());
+
+    // Assertions
+    expect($context)->toBeInstanceOf(Context::class);
+    expect($context)->toEqual($expectedContext);
+});
+
+it('uses cache when resolving the same class multiple times', function () {
+    $resolver = new ContextResolver();
+
+    // Create a ReflectionClass for the test class
+    $reflectionClass = new ReflectionClass(TestContextResolverClass::class);
+
+    // Resolve the context the first time
+    $context1 = $resolver->get($reflectionClass);
+
+    // Resolve the context the second time
+    $context2 = $resolver->get($reflectionClass);
+
+    // Assertions
+    expect($context1)->toBeInstanceOf(Context::class);
+    expect($context2)->toBeInstanceOf(Context::class);
+    expect($context1)->toBe($context2); // They should be the same instance, indicating the cache was used
+});
+
+// Test class
+class TestContextResolverClass
+{
+    public $testProperty;
+
+    public function testMethod()
+    {
+    }
+}

--- a/tests/Resolvers/ContextResolverTest.php
+++ b/tests/Resolvers/ContextResolverTest.php
@@ -2,9 +2,6 @@
 
 use phpDocumentor\Reflection\Types\Context;
 use phpDocumentor\Reflection\Types\ContextFactory;
-use ReflectionClass;
-use ReflectionMethod;
-use ReflectionProperty;
 use Spatie\LaravelData\Resolvers\ContextResolver;
 
 it('can resolve context from property', function () {

--- a/tests/Support/Annotations/CollectionAnnotationReaderTest.php
+++ b/tests/Support/Annotations/CollectionAnnotationReaderTest.php
@@ -93,6 +93,11 @@ it(
         'className' => CollectionWithoutDocBlock::class,
         'expected' => null,
     ];
+
+    yield CollectionWithoutType::class => [
+        'className' => CollectionWithoutType::class,
+        'expected' => null,
+    ];
 });
 
 
@@ -228,5 +233,12 @@ class CollectionWhoImplementsNothing
 }
 
 class CollectionWithoutDocBlock extends Collection
+{
+}
+
+/**
+ * @extends \Illuminate\Support\Collection
+ */
+class CollectionWithoutType extends Collection
 {
 }

--- a/tests/Support/Annotations/CollectionAnnotationReaderTest.php
+++ b/tests/Support/Annotations/CollectionAnnotationReaderTest.php
@@ -44,11 +44,6 @@ it(
         'expected' => new CollectionAnnotation(type: SimpleData::class, isData: true),
     ];
 
-    yield DataCollectionWithoutExtends::class => [
-        'className' => DataCollectionWithoutExtends::class,
-        'expected' => null,
-    ];
-
     yield NonDataCollectionWithTemplate::class => [
         'className' => NonDataCollectionWithTemplate::class,
         'expected' => new CollectionAnnotation(type: DummyBackedEnum::class, isData: false),
@@ -79,13 +74,23 @@ it(
         'expected' => new CollectionAnnotation(type: DummyBackedEnum::class, isData: false),
     ];
 
-    yield NonDataCollectionWithoutExtends::class => [
-        'className' => NonDataCollectionWithoutExtends::class,
+    yield CollectionWhoImplementsIterator::class => [
+        'className' => CollectionWhoImplementsIterator::class,
+        'expected' => new CollectionAnnotation(type: DummyBackedEnum::class, isData: false),
+    ];
+
+    yield CollectionWhoImplementsIteratorAggregate::class => [
+        'className' => CollectionWhoImplementsIteratorAggregate::class,
+        'expected' => new CollectionAnnotation(type: DummyBackedEnum::class, isData: false),
+    ];
+
+    yield CollectionWhoImplementsNothing::class => [
+        'className' => CollectionWhoImplementsNothing::class,
         'expected' => null,
     ];
 
-    yield NonCollectionWithTemplate::class => [
-        'className' => NonCollectionWithTemplate::class,
+    yield CollectionWithoutDocBlock::class => [
+        'className' => CollectionWithoutDocBlock::class,
         'expected' => null,
     ];
 });
@@ -136,10 +141,6 @@ class DataCollectionWithoutKey extends Collection
 {
 }
 
-class DataCollectionWithoutExtends extends Collection
-{
-}
-
 /**
  * @template TKey of array-key
  * @template TValue of \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum
@@ -185,13 +186,47 @@ class NonDataCollectionWithoutKey extends Collection
 {
 }
 
-class NonDataCollectionWithoutExtends extends Collection
+/**
+ * @extends \Illuminate\Support\Collection<array-key, \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum>
+ */
+class CollectionWhoImplementsIterator implements Iterator
 {
+    public function current(): mixed
+    {
+    }
+    public function next(): void
+    {
+    }
+    public function key(): mixed
+    {
+    }
+    public function valid(): bool
+    {
+        return true;
+    }
+    public function rewind(): void
+    {
+    }
 }
 
 /**
- * @extends \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum
+ * @extends \Illuminate\Support\Collection<array-key, \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum>
  */
-class NonCollectionWithTemplate
+class CollectionWhoImplementsIteratorAggregate implements IteratorAggregate
+{
+    public function getIterator(): Traversable
+    {
+        return $this;
+    }
+}
+
+/**
+ * @extends \Illuminate\Support\Collection<array-key, \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum>
+ */
+class CollectionWhoImplementsNothing
+{
+}
+
+class CollectionWithoutDocBlock extends Collection
 {
 }

--- a/tests/Support/Annotations/CollectionAnnotationReaderTest.php
+++ b/tests/Support/Annotations/CollectionAnnotationReaderTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Spatie\LaravelData\Support\Annotations\CollectionAnnotation;
+use Spatie\LaravelData\Support\Annotations\CollectionAnnotationReader;
+use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
+use Spatie\LaravelData\Tests\Fakes\SimpleData;
+
+it(
+    'can get the data class for a collection by annotation',
+    function (string $className, ?CollectionAnnotation $expected) {
+        $annotations = app(CollectionAnnotationReader::class)->getForClass(new ReflectionClass($className));
+
+        expect($annotations)->toEqual($expected);
+    }
+)->with(function () {
+    yield DataCollectionWithTemplate::class => [
+        'className' => DataCollectionWithTemplate::class,
+        'expected' => new CollectionAnnotation(type: SimpleData::class, isData: true),
+    ];
+
+    yield DataCollectionWithoutTemplate::class => [
+        'className' => DataCollectionWithoutTemplate::class,
+        'expected' => new CollectionAnnotation(type: SimpleData::class, isData: true),
+    ];
+
+    yield DataCollectionWithoutExtends::class => [
+        'className' => DataCollectionWithoutExtends::class,
+        'expected' => null,
+    ];
+
+    yield NonDataCollectionWithTemplate::class => [
+        'className' => NonDataCollectionWithTemplate::class,
+        'expected' => new CollectionAnnotation(type: DummyBackedEnum::class, isData: false),
+    ];
+
+    yield NonDataCollectionWithoutTemplate::class => [
+        'className' => NonDataCollectionWithoutTemplate::class,
+        'expected' => new CollectionAnnotation(type: DummyBackedEnum::class, isData: false),
+    ];
+
+    yield NonDataCollectionWithoutExtends::class => [
+        'className' => NonDataCollectionWithoutExtends::class,
+        'expected' => null,
+    ];
+
+    yield NonCollectionWithTemplate::class => [
+        'className' => NonCollectionWithTemplate::class,
+        'expected' => null,
+    ];
+});
+
+
+/**
+ * @template TKey of array-key
+ * @template TValue of \Spatie\LaravelData\Tests\Fakes\SimpleData
+ *
+ * @extends \Illuminate\Support\Collection<TKey, TValue>
+ */
+class DataCollectionWithTemplate extends Collection
+{
+}
+
+/**
+ * @extends \Illuminate\Support\Collection<array-key, \Spatie\LaravelData\Tests\Fakes\SimpleData>
+ */
+class DataCollectionWithoutTemplate extends Collection
+{
+}
+
+class DataCollectionWithoutExtends extends Collection
+{
+}
+
+/**
+ * @template TKey of array-key
+ * @template TValue of \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum
+ *
+ * @extends \Illuminate\Support\Collection<TKey, TValue>
+ */
+class NonDataCollectionWithTemplate extends Collection
+{
+}
+
+/**
+ * @extends \Illuminate\Support\Collection<array-key, \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum>
+ */
+class NonDataCollectionWithoutTemplate extends Collection
+{
+}
+
+class NonDataCollectionWithoutExtends extends Collection
+{
+}
+
+/**
+ * @extends \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum
+ */
+class NonCollectionWithTemplate
+{
+}

--- a/tests/Support/Annotations/CollectionAnnotationReaderTest.php
+++ b/tests/Support/Annotations/CollectionAnnotationReaderTest.php
@@ -93,9 +93,9 @@ it(
 
 /**
  * @template TKey of array-key
- * @template TValue of \Spatie\LaravelData\Tests\Fakes\SimpleData
+ * @template TData of \Spatie\LaravelData\Tests\Fakes\SimpleData
  *
- * @extends \Illuminate\Support\Collection<TKey, TValue>
+ * @extends \Illuminate\Support\Collection<TKey, TData>
  */
 class DataCollectionWithTemplate extends Collection
 {

--- a/tests/Support/Annotations/CollectionAnnotationReaderTest.php
+++ b/tests/Support/Annotations/CollectionAnnotationReaderTest.php
@@ -7,7 +7,7 @@ use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
 
 it(
-    'can get the data class for a collection by annotation',
+    'verifies the correct CollectionAnnotation is returned for a given class',
     function (string $className, ?CollectionAnnotation $expected) {
         $annotations = app(CollectionAnnotationReader::class)->getForClass(new ReflectionClass($className));
 
@@ -24,6 +24,26 @@ it(
         'expected' => new CollectionAnnotation(type: SimpleData::class, isData: true),
     ];
 
+    yield DataCollectionWithCombinationType::class => [
+        'className' => DataCollectionWithCombinationType::class,
+        'expected' => new CollectionAnnotation(type: SimpleData::class, isData: true),
+    ];
+
+    yield DataCollectionWithIntegerKey::class => [
+        'className' => DataCollectionWithIntegerKey::class,
+        'expected' => new CollectionAnnotation(type: SimpleData::class, isData: true, keyType: 'int'),
+    ];
+
+    yield DataCollectionWithCombinationKey::class => [
+        'className' => DataCollectionWithCombinationKey::class,
+        'expected' => new CollectionAnnotation(type: SimpleData::class, isData: true, keyType: 'int'),
+    ];
+
+    yield DataCollectionWithoutKey::class => [
+        'className' => DataCollectionWithoutKey::class,
+        'expected' => new CollectionAnnotation(type: SimpleData::class, isData: true),
+    ];
+
     yield DataCollectionWithoutExtends::class => [
         'className' => DataCollectionWithoutExtends::class,
         'expected' => null,
@@ -36,6 +56,26 @@ it(
 
     yield NonDataCollectionWithoutTemplate::class => [
         'className' => NonDataCollectionWithoutTemplate::class,
+        'expected' => new CollectionAnnotation(type: DummyBackedEnum::class, isData: false),
+    ];
+
+    yield NonDataCollectionWithCombinationType::class => [
+        'className' => NonDataCollectionWithCombinationType::class,
+        'expected' => new CollectionAnnotation(type: DummyBackedEnum::class, isData: false),
+    ];
+
+    yield NonDataCollectionWithIntegerKey::class => [
+        'className' => NonDataCollectionWithIntegerKey::class,
+        'expected' => new CollectionAnnotation(type: DummyBackedEnum::class, isData: false, keyType: 'int'),
+    ];
+
+    yield NonDataCollectionWithCombinationKey::class => [
+        'className' => NonDataCollectionWithCombinationKey::class,
+        'expected' => new CollectionAnnotation(type: DummyBackedEnum::class, isData: false, keyType: 'int'),
+    ];
+
+    yield NonDataCollectionWithoutKey::class => [
+        'className' => NonDataCollectionWithoutKey::class,
         'expected' => new CollectionAnnotation(type: DummyBackedEnum::class, isData: false),
     ];
 
@@ -68,6 +108,34 @@ class DataCollectionWithoutTemplate extends Collection
 {
 }
 
+/**
+ * @extends \Illuminate\Support\Collection<array-key, \Spatie\LaravelData\Tests\Fakes\SimpleData|\Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum>
+ */
+class DataCollectionWithCombinationType extends Collection
+{
+}
+
+/**
+ * @extends \Illuminate\Support\Collection<int, \Spatie\LaravelData\Tests\Fakes\SimpleData>
+ */
+class DataCollectionWithIntegerKey extends Collection
+{
+}
+
+/**
+ * @extends \Illuminate\Support\Collection<int|string, \Spatie\LaravelData\Tests\Fakes\SimpleData>
+ */
+class DataCollectionWithCombinationKey extends Collection
+{
+}
+
+/**
+ * @extends \Illuminate\Support\Collection<\Spatie\LaravelData\Tests\Fakes\SimpleData>
+ */
+class DataCollectionWithoutKey extends Collection
+{
+}
+
 class DataCollectionWithoutExtends extends Collection
 {
 }
@@ -86,6 +154,34 @@ class NonDataCollectionWithTemplate extends Collection
  * @extends \Illuminate\Support\Collection<array-key, \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum>
  */
 class NonDataCollectionWithoutTemplate extends Collection
+{
+}
+
+/**
+ * @extends \Illuminate\Support\Collection<array-key, \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum|\Spatie\LaravelData\Tests\Fakes\SimpleData>
+ */
+class NonDataCollectionWithCombinationType extends Collection
+{
+}
+
+/**
+ * @extends \Illuminate\Support\Collection<int, \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum>
+ */
+class NonDataCollectionWithIntegerKey extends Collection
+{
+}
+
+/**
+ * @extends \Illuminate\Support\Collection<int|string, \Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum>
+ */
+class NonDataCollectionWithCombinationKey extends Collection
+{
+}
+
+/**
+ * @extends \Illuminate\Support\Collection<\Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum>
+ */
+class NonDataCollectionWithoutKey extends Collection
 {
 }
 

--- a/tests/Support/Annotations/CollectionAnnotationReaderTest.php
+++ b/tests/Support/Annotations/CollectionAnnotationReaderTest.php
@@ -9,7 +9,7 @@ use Spatie\LaravelData\Tests\Fakes\SimpleData;
 it(
     'verifies the correct CollectionAnnotation is returned for a given class',
     function (string $className, ?CollectionAnnotation $expected) {
-        $annotations = app(CollectionAnnotationReader::class)->getForClass(new ReflectionClass($className));
+        $annotations = app(CollectionAnnotationReader::class)->getForClass($className);
 
         expect($annotations)->toEqual($expected);
     }

--- a/tests/Support/DataPropertyTypeTest.php
+++ b/tests/Support/DataPropertyTypeTest.php
@@ -572,6 +572,54 @@ it('can deduce an enumerable data collection union type', function () {
         ->iterableClass->toBe(Collection::class);
 });
 
+it('can deduce an enumerable data collection type from collection', function () {
+    $type = resolveDataType(new class () {
+        public DataCollectionWithTemplate $property;
+    });
+
+    expect($type)
+        ->isOptional->toBeFalse()
+        ->isNullable->toBeFalse()
+        ->isMixed->toBeFalse()
+        ->lazyType->toBeNull()
+        ->kind->toBe(DataTypeKind::DataEnumerable)
+        ->dataClass->toBe(SimpleData::class)
+        ->iterableClass->toBe(DataCollectionWithTemplate::class)
+        ->getAcceptedTypes()->toHaveKeys([DataCollectionWithTemplate::class]);
+
+    expect($type->type)
+        ->toBeInstanceOf(NamedType::class)
+        ->name->toBe(DataCollectionWithTemplate::class)
+        ->builtIn->toBeFalse()
+        ->kind->toBe(DataTypeKind::DataEnumerable)
+        ->dataClass->toBe(SimpleData::class)
+        ->iterableClass->toBe(DataCollectionWithTemplate::class);
+});
+
+it('can deduce an enumerable data collection union type from collection', function () {
+    $type = resolveDataType(new class () {
+        public DataCollectionWithTemplate|Lazy $property;
+    });
+
+    expect($type)
+        ->isOptional->toBeFalse()
+        ->isNullable->toBeFalse()
+        ->isMixed->toBeFalse()
+        ->lazyType->toBe(Lazy::class)
+        ->kind->toBe(DataTypeKind::DataEnumerable)
+        ->dataClass->toBe(SimpleData::class)
+        ->iterableClass->toBe(DataCollectionWithTemplate::class)
+        ->getAcceptedTypes()->toHaveKeys([DataCollectionWithTemplate::class]);
+
+    expect($type->type)
+        ->toBeInstanceOf(NamedType::class)
+        ->name->toBe(DataCollectionWithTemplate::class)
+        ->builtIn->toBeFalse()
+        ->kind->toBe(DataTypeKind::DataEnumerable)
+        ->dataClass->toBe(SimpleData::class)
+        ->iterableClass->toBe(DataCollectionWithTemplate::class);
+});
+
 it('can deduce a paginator data collection type', function () {
     $type = resolveDataType(new class () {
         #[DataCollectionOf(SimpleData::class)]

--- a/tests/Support/DataPropertyTypeTest.php
+++ b/tests/Support/DataPropertyTypeTest.php
@@ -35,6 +35,7 @@ use Spatie\LaravelData\Support\Types\IntersectionType;
 use Spatie\LaravelData\Support\Types\NamedType;
 use Spatie\LaravelData\Support\Types\UnionType;
 use Spatie\LaravelData\Tests\Factories\FakeDataStructureFactory;
+use Spatie\LaravelData\Tests\Fakes\Collections\SimpleDataCollectionWithAnotations;
 use Spatie\LaravelData\Tests\Fakes\ComplicatedData;
 use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
@@ -574,7 +575,7 @@ it('can deduce an enumerable data collection union type', function () {
 
 it('can deduce an enumerable data collection type from collection', function () {
     $type = resolveDataType(new class () {
-        public DataCollectionWithTemplate $property;
+        public SimpleDataCollectionWithAnotations $property;
     });
 
     expect($type)
@@ -584,21 +585,21 @@ it('can deduce an enumerable data collection type from collection', function () 
         ->lazyType->toBeNull()
         ->kind->toBe(DataTypeKind::DataEnumerable)
         ->dataClass->toBe(SimpleData::class)
-        ->iterableClass->toBe(DataCollectionWithTemplate::class)
-        ->getAcceptedTypes()->toHaveKeys([DataCollectionWithTemplate::class]);
+        ->iterableClass->toBe(SimpleDataCollectionWithAnotations::class)
+        ->getAcceptedTypes()->toHaveKeys([SimpleDataCollectionWithAnotations::class]);
 
     expect($type->type)
         ->toBeInstanceOf(NamedType::class)
-        ->name->toBe(DataCollectionWithTemplate::class)
+        ->name->toBe(SimpleDataCollectionWithAnotations::class)
         ->builtIn->toBeFalse()
         ->kind->toBe(DataTypeKind::DataEnumerable)
         ->dataClass->toBe(SimpleData::class)
-        ->iterableClass->toBe(DataCollectionWithTemplate::class);
+        ->iterableClass->toBe(SimpleDataCollectionWithAnotations::class);
 });
 
 it('can deduce an enumerable data collection union type from collection', function () {
     $type = resolveDataType(new class () {
-        public DataCollectionWithTemplate|Lazy $property;
+        public SimpleDataCollectionWithAnotations|Lazy $property;
     });
 
     expect($type)
@@ -608,16 +609,16 @@ it('can deduce an enumerable data collection union type from collection', functi
         ->lazyType->toBe(Lazy::class)
         ->kind->toBe(DataTypeKind::DataEnumerable)
         ->dataClass->toBe(SimpleData::class)
-        ->iterableClass->toBe(DataCollectionWithTemplate::class)
-        ->getAcceptedTypes()->toHaveKeys([DataCollectionWithTemplate::class]);
+        ->iterableClass->toBe(SimpleDataCollectionWithAnotations::class)
+        ->getAcceptedTypes()->toHaveKeys([SimpleDataCollectionWithAnotations::class]);
 
     expect($type->type)
         ->toBeInstanceOf(NamedType::class)
-        ->name->toBe(DataCollectionWithTemplate::class)
+        ->name->toBe(SimpleDataCollectionWithAnotations::class)
         ->builtIn->toBeFalse()
         ->kind->toBe(DataTypeKind::DataEnumerable)
         ->dataClass->toBe(SimpleData::class)
-        ->iterableClass->toBe(DataCollectionWithTemplate::class);
+        ->iterableClass->toBe(SimpleDataCollectionWithAnotations::class);
 });
 
 it('can deduce a paginator data collection type', function () {


### PR DESCRIPTION
This PR introduces a new feature that allows the use of well-annotated collections without the need for annotations inside the `Data` class. By ensuring that collections are well-annotated, we can achieve strong typing and better static analysis, eliminating the need to redundantly annotate properties in classes that utilize these collections.

For example:

```php
// before
use App\Data\SongData;
use Illuminate\Support\Collection;

class AlbumData extends Data
{    
    /** @var Collection<int, SongData> */
    public Collection $songs;
}
```

```php
// after
use App\Collection\SongDataCollection;

class AlbumData extends Data
{    
    public SongDataCollection $songs;
}
```