### PR TITLE
Add integer_rule_for_integers option

### DIFF
--- a/config/data.php
+++ b/config/data.php
@@ -67,6 +67,11 @@ return [
     ],
 
     /**
+     * By default, integer attributes validation accepts both float and integer values. In some cases, it can be useful to only accept integers.
+     */
+    'integer_rule_for_integers' => false,
+
+    /**
      * Normalizers return an array representation of the payload, or null if
      * it cannot normalize the payload. The normalizers below are used for
      * every data object, unless overridden in a specific data object class.

--- a/src/RuleInferrers/BuiltInTypesRuleInferrer.php
+++ b/src/RuleInferrers/BuiltInTypesRuleInferrer.php
@@ -6,6 +6,7 @@ use BackedEnum;
 use Spatie\LaravelData\Attributes\Validation\ArrayType;
 use Spatie\LaravelData\Attributes\Validation\BooleanType;
 use Spatie\LaravelData\Attributes\Validation\Enum;
+use Spatie\LaravelData\Attributes\Validation\IntegerType;
 use Spatie\LaravelData\Attributes\Validation\Numeric;
 use Spatie\LaravelData\Attributes\Validation\StringType;
 use Spatie\LaravelData\Support\DataProperty;
@@ -22,6 +23,10 @@ class BuiltInTypesRuleInferrer implements RuleInferrer
     ): PropertyRules {
         if ($property->type->type->acceptsType('int')) {
             $rules->add(new Numeric());
+
+            if (config('data.integer_rule_for_integers')) {
+                $rules->add(new IntegerType());
+            }
         }
 
         if ($property->type->type->acceptsType('string')) {

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -88,17 +88,25 @@ it('can validate a float', function () {
         ]);
 });
 
-it('can validate an integer', function () {
+it('can validate an integer', function (bool $integerRuleForIntegers) {
     $dataClass = new class () extends Data {
         public int $property;
     };
 
+    config()->set('data.integer_rule_for_integers', $integerRuleForIntegers);
+
+    $rules = ['required', 'numeric'];
+
+    if ($integerRuleForIntegers) {
+        $rules[] = 'integer';
+    }
+
     DataValidationAsserter::for($dataClass)
         ->assertOk(['property' => 10.0])
         ->assertRules([
-            'property' => ['required', 'numeric'],
+            'property' => $rules,
         ]);
-});
+})->with([true, false]);
 
 it('can validate an array', function () {
     $dataClass = new class () extends Data {


### PR DESCRIPTION
By default, integer attributes validation accepts both float and integer values. In some cases, it can be useful to only accept integers.
