### PR TITLE
Support TypeScript Hidden Properties

### DIFF
--- a/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
+++ b/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
@@ -20,6 +20,7 @@ use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelData\Support\DataProperty;
 use Spatie\LaravelData\Support\Lazy\ClosureLazy;
 use Spatie\LaravelTypeScriptTransformer\Transformers\DtoTransformer;
+use Spatie\TypeScriptTransformer\Attributes\Hidden;
 use Spatie\TypeScriptTransformer\Attributes\Optional as TypeScriptOptional;
 use Spatie\TypeScriptTransformer\Structures\MissingSymbolsCollection;
 use Spatie\TypeScriptTransformer\TypeProcessors\DtoCollectionTypeProcessor;
@@ -65,6 +66,12 @@ class DataTypeScriptTransformer extends DtoTransformer
                 $type = $this->resolveTypeForProperty($property, $dataProperty, $missingSymbols);
 
                 if ($type === null) {
+                    return $carry;
+                }
+
+                $isHidden = ! empty($property->getAttributes(Hidden::class));
+
+                if ($isHidden) {
                     return $carry;
                 }
 

--- a/tests/Support/TypeScriptTransformer/DataTypeScriptTransformerTest.php
+++ b/tests/Support/TypeScriptTransformer/DataTypeScriptTransformerTest.php
@@ -20,6 +20,7 @@ use function Spatie\Snapshots\assertMatchesSnapshot as baseAssertMatchesSnapshot
 
 use Spatie\Snapshots\Driver;
 use Spatie\TypeScriptTransformer\Attributes\Optional as TypeScriptOptional;
+use Spatie\TypeScriptTransformer\Attributes\Hidden as TypeScriptHidden;
 use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 
 function assertMatchesSnapshot($actual, Driver $driver = null): void
@@ -242,6 +243,32 @@ it('it respects a TypeScript class optional attribute', function () {
         {
         id?: number;
         name?: string;
+        }
+        TXT,
+        $transformer->transform($reflection, 'DataObject')->transformed
+    );
+});
+
+it('it respects a TypeScript property hidden attribute', function () {
+    $config = TypeScriptTransformerConfig::create();
+
+    $data = new class (10, 'Ruben') extends Data {
+        public function __construct(
+            #[TypeScriptHidden]
+            public int $id,
+            public string $name,
+        ) {
+        }
+    };
+
+    $transformer = new DataTypeScriptTransformer($config);
+    $reflection = new ReflectionClass($data);
+
+    $this->assertTrue($transformer->canTransform($reflection));
+    $this->assertEquals(
+        <<<TXT
+        {
+        name: string;
         }
         TXT,
         $transformer->transform($reflection, 'DataObject')->transformed


### PR DESCRIPTION
When using the `typescript-transformer` package, it's possible to describe properties as `Hidden`: https://spatie.be/docs/typescript-transformer/v2/dtos/typing-properties#content-hidden-types

That doesn't work at the moment when using Data classes from `laravel-data` because the `DataTypeScriptTransformer` doesn't look for that attribute.

This PR address this issue.