### PR TITLE
Passing an enum to caster handle without an error

### DIFF
--- a/src/Casts/EnumCast.php
+++ b/src/Casts/EnumCast.php
@@ -36,6 +36,10 @@ class EnumCast implements Cast, IterableItemCast
             return Uncastable::create();
         }
 
+        if ($value instanceof $type) {
+            return $value;
+        }
+
         /** @var class-string<\BackedEnum> $type */
         try {
             return $type::from($value);

--- a/tests/Casts/EnumCastTest.php
+++ b/tests/Casts/EnumCastTest.php
@@ -11,7 +11,7 @@ beforeEach(function () {
     $this->caster = new EnumCast();
 });
 
-it('can cast enum', function () {
+it('can cast enum', function (mixed $value) {
     $class = new class () {
         public DummyBackedEnum $enum;
     };
@@ -19,12 +19,12 @@ it('can cast enum', function () {
     expect(
         $this->caster->cast(
             FakeDataStructureFactory::property($class, 'enum'),
-            'foo',
+            $value,
             [],
             CreationContextFactory::createFromConfig($class::class)->get()
         )
     )->toEqual(DummyBackedEnum::FOO);
-});
+})->with(['foo', DummyBackedEnum::FOO]);
 
 it('fails when it cannot cast an enum from value', function () {
     $class = new class () {


### PR DESCRIPTION
Allow to pass an enum to `Structure::validateAndCreate` method.

Previously below code didn't work.

```
Structure::validateAndCreate([
    'enum' => DummyBackedEnum::FOO
])
```

Some libraries (ex: [Lighthouse PHP](https://lighthouse-php.com/)) which is a GraphQL implementation, sends Enum types through the request. I think we don't need to send the Enum string value again to the validate method. It should accept Enum types also.