### PR TITLE
feat: Add default name mappers

### DIFF
--- a/config/data.php
+++ b/config/data.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Enumerable;
+use Spatie\LaravelData\Mappers\NameMapper;
 
 return [
     /**
@@ -127,6 +128,15 @@ return [
      * behaviour can be changed to always validate or to completely disable validation.
      */
     'validation_strategy' => \Spatie\LaravelData\Support\Creation\ValidationStrategy::OnlyRequests->value,
+
+    /**
+     * The default name mapping strategy for data objects' keys.
+     * This has to be a class implementing the `Spatie\LaravelData\Mappers\NameMapper` interface.
+     */
+    'naming_strategy' => [
+        'input' => null,
+        'output' => null,
+    ],
 
     /**
      * When using an invalid include, exclude, only or except partial, the package will

--- a/src/Resolvers/NameMappersResolver.php
+++ b/src/Resolvers/NameMappersResolver.php
@@ -91,7 +91,7 @@ class NameMappersResolver
 
     private function resolveDefaultNameMapper(bool $input): null|MapInputName|MapOutputName
     {
-        $nameMapper = config('data.naming_strategy.'.($input ? 'input' : 'output'));
+        $nameMapper = $input ? config('data.naming_strategy.input') : config('data.naming_strategy.output');
 
         if ($nameMapper === null) {
             return null;

--- a/src/Resolvers/NameMappersResolver.php
+++ b/src/Resolvers/NameMappersResolver.php
@@ -34,7 +34,8 @@ class NameMappersResolver
     ): ?NameMapper {
         /** @var \Spatie\LaravelData\Attributes\MapInputName|\Spatie\LaravelData\Attributes\MapName|null $mapper */
         $mapper = $attributes->first(fn (object $attribute) => $attribute instanceof MapInputName)
-            ?? $attributes->first(fn (object $attribute) => $attribute instanceof MapName);
+            ?? $attributes->first(fn (object $attribute) => $attribute instanceof MapName)
+            ?? $this->resolveDefaultNameMapper(input: true);
 
         if ($mapper) {
             return $this->resolveMapper($mapper->input);
@@ -48,7 +49,8 @@ class NameMappersResolver
     ): ?NameMapper {
         /** @var \Spatie\LaravelData\Attributes\MapOutputName|\Spatie\LaravelData\Attributes\MapName|null $mapper */
         $mapper = $attributes->first(fn (object $attribute) => $attribute instanceof MapOutputName)
-            ?? $attributes->first(fn (object $attribute) => $attribute instanceof MapName);
+            ?? $attributes->first(fn (object $attribute) => $attribute instanceof MapName)
+            ?? $this->resolveDefaultNameMapper(input: false);
 
         if ($mapper) {
             return $this->resolveMapper($mapper->output);
@@ -85,5 +87,19 @@ class NameMappersResolver
         }
 
         return new ProvidedNameMapper($value);
+    }
+
+    private function resolveDefaultNameMapper(bool $input): null|MapInputName|MapOutputName
+    {
+        $nameMapper = config('data.naming_strategy.'.($input ? 'input' : 'output'));
+
+        if ($nameMapper === null) {
+            return null;
+        }
+
+        return match ($input) {
+            true => new MapInputName($nameMapper),
+            false => new MapOutputName($nameMapper),
+        };
     }
 }

--- a/tests/Resolvers/NameMappersResolverTest.php
+++ b/tests/Resolvers/NameMappersResolverTest.php
@@ -117,6 +117,36 @@ it('can have default mappers', function () {
     ]);
 });
 
+it('input name mappers only work when no mappers are specified', function () {
+    config()->set('data.naming_strategy.input', CamelCaseMapper::class);
+    config()->set('data.naming_strategy.output', SnakeCaseMapper::class);
+
+    $attributes = getAttributes(new class () {
+        #[MapInputName(StudlyCaseMapper::class)]
+        public $property;
+    });
+
+    expect($this->resolver->execute($attributes))->toMatchArray([
+        'inputNameMapper' => new StudlyCaseMapper(),
+        'outputNameMapper' => new SnakeCaseMapper(),
+    ]);
+});
+
+it('output name mappers only work when no mappers are specified', function () {
+    config()->set('data.naming_strategy.input', CamelCaseMapper::class);
+    config()->set('data.naming_strategy.output', SnakeCaseMapper::class);
+
+    $attributes = getAttributes(new class () {
+        #[MapOutputName(StudlyCaseMapper::class)]
+        public $property;
+    });
+
+    expect($this->resolver->execute($attributes))->toMatchArray([
+        'inputNameMapper' => new CamelCaseMapper(),
+        'outputNameMapper' => new StudlyCaseMapper(),
+    ]);
+});
+
 it('can ignore certain mapper types', function () {
     $attributes = getAttributes(new class () {
         #[MapInputName('input'), MapOutputName(CamelCaseMapper::class)]

--- a/tests/Resolvers/NameMappersResolverTest.php
+++ b/tests/Resolvers/NameMappersResolverTest.php
@@ -5,6 +5,7 @@ use Spatie\LaravelData\Attributes\MapInputName;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\MapOutputName;
 use Spatie\LaravelData\Mappers\CamelCaseMapper;
+use Spatie\LaravelData\Mappers\StudlyCaseMapper;
 use Spatie\LaravelData\Mappers\ProvidedNameMapper;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 use Spatie\LaravelData\Resolvers\NameMappersResolver;
@@ -93,6 +94,20 @@ it('can map a string', function () {
 it('can map a mapper class', function () {
     $attributes = getAttributes(new class () {
         #[MapName(CamelCaseMapper::class, SnakeCaseMapper::class)]
+        public $property;
+    });
+
+    expect($this->resolver->execute($attributes))->toMatchArray([
+        'inputNameMapper' => new CamelCaseMapper(),
+        'outputNameMapper' => new SnakeCaseMapper(),
+    ]);
+});
+
+it('can have default mappers', function () {
+    config()->set('data.naming_strategy.input', CamelCaseMapper::class);
+    config()->set('data.naming_strategy.output', SnakeCaseMapper::class);
+
+    $attributes = getAttributes(new class () {
         public $property;
     });
 


### PR DESCRIPTION
The goal of this PR is to allow for specifying the default mapping of keys for data objects.

It's an opt-in feature that can be overriden by inline attribute whenever needed