### PR TITLE
Add array type annotations on Cast interfaces

### DIFF
--- a/src/Casts/Cast.php
+++ b/src/Casts/Cast.php
@@ -7,5 +7,8 @@ use Spatie\LaravelData\Support\DataProperty;
 
 interface Cast
 {
+    /**
+     * @param array<string, mixed> $properties
+     */
     public function cast(DataProperty $property, mixed $value, array $properties, CreationContext $context): mixed;
 }

--- a/src/Casts/IterableItemCast.php
+++ b/src/Casts/IterableItemCast.php
@@ -7,5 +7,8 @@ use Spatie\LaravelData\Support\DataProperty;
 
 interface IterableItemCast
 {
+    /**
+     * @param array<string, mixed> $properties
+     */
     public function castIterableItem(DataProperty $property, mixed $value, array $properties, CreationContext $context): mixed;
 }


### PR DESCRIPTION
Add type annotations for the `$properties` array on the public Cast interfaces, making it clearer what kind of array to expect, and preventing phpstan errors like these:

```
 ------ -------------------------------------------------------------------------------------------------------------------------
  Line   app/Data/Casts/MyCast.php
 ------ -------------------------------------------------------------------------------------------------------------------------
  22     Method App\Data\Casts\MyCast::cast() has parameter $properties with no value type specified in iterable type array.
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type
 ------ -------------------------------------------------------------------------------------------------------------------------
```