### PR TITLE
feat: support "null to optional"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "phpstan/extension-installer": "^1.1",
         "phpunit/phpunit": "^10.0",
         "spatie/invade": "^1.0",
-        "spatie/laravel-typescript-transformer": "^2.3",
+        "spatie/laravel-typescript-transformer": "^2.5",
         "spatie/pest-plugin-snapshots": "^2.1",
         "spatie/test-time": "^1.2"
     },

--- a/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
+++ b/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
@@ -80,11 +80,13 @@ class DataTypeScriptTransformer extends DtoTransformer
                         fn (object $attribute) => $attribute instanceof TypeScriptOptional
                     )
                     || ($dataProperty->type->lazyType && $dataProperty->type->lazyType !== ClosureLazy::class)
-                    || $dataProperty->type->isOptional;
+                    || $dataProperty->type->isOptional
+                    || ($dataProperty->type->isNullable && $this->config->shouldConsiderNullAsOptional());
 
                 $transformed = $this->typeToTypeScript(
                     $type,
                     $missingSymbols,
+                    $this->config->shouldConsiderNullAsOptional(),
                     currentClass: $property->getDeclaringClass()->getName(),
                 );
 

--- a/tests/Support/TypeScriptTransformer/DataTypeScriptTransformerTest.php
+++ b/tests/Support/TypeScriptTransformer/DataTypeScriptTransformerTest.php
@@ -322,3 +322,21 @@ it('will transform a collection with int key as an array', function () {
         $transformer->transform($reflection, 'DataObject')->transformed
     );
 });
+
+it('supports converting nullable types to optional properties', function () {
+    $config = TypeScriptTransformerConfig::create();
+    $config->nullToOptional(true);
+
+    $data = new class ('foo') extends Data {
+        public function __construct(
+            public ?string $nullable,
+        ) {
+        }
+    };
+
+    $transformer = new DataTypeScriptTransformer($config);
+    $reflection = new ReflectionClass($data);
+
+    expect($transformer->canTransform($reflection))->toBeTrue();
+    assertMatchesSnapshot($transformer->transform($reflection, 'DataObject')->transformed);
+});

--- a/tests/__snapshots__/DataTypeScriptTransformerTest__it_supports_converting_nullable_types_to_optional_properties__1.txt
+++ b/tests/__snapshots__/DataTypeScriptTransformerTest__it_supports_converting_nullable_types_to_optional_properties__1.txt
@@ -1,0 +1,3 @@
+{
+nullable?: string;
+}


### PR DESCRIPTION
This pull request adds support to Laravel Data for the recently-merged "null to optional" feature from `spatie/typescript-transformer`.

See: https://github.com/spatie/typescript-transformer/pull/88
See: https://github.com/spatie/typescript-transformer/issues/23
See: https://github.com/spatie/typescript-transformer/pull/30