### PR TITLE
Fix retrieval of property to work for Astrotomic/translatable

### DIFF
--- a/src/DataPipes/FillRouteParameterPropertiesDataPipe.php
+++ b/src/DataPipes/FillRouteParameterPropertiesDataPipe.php
@@ -24,10 +24,7 @@ class FillRouteParameterPropertiesDataPipe implements DataPipe
         }
 
         foreach ($class->properties as $dataProperty) {
-            /** @var FromRouteParameter|null $attribute */
-            $attribute = $dataProperty->attributes->first(
-                fn (object $attribute) => $attribute instanceof FromRouteParameter
-            );
+            $attribute = $dataProperty->attributes->getAttribute(FromRouteParameter::class);
 
             if ($attribute === null) {
                 continue;

--- a/src/Normalizers/Normalized/NormalizedModel.php
+++ b/src/Normalizers/Normalized/NormalizedModel.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelData\Normalizers\Normalized;
 
+use Illuminate\Database\Eloquent\MissingAttributeException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use ReflectionProperty;
@@ -23,11 +24,9 @@ class NormalizedModel implements Normalized
 
     public function getProperty(string $name, DataProperty $dataProperty): mixed
     {
-        $propertyName = $this->model::$snakeAttributes ? Str::snake($name) : $name;
-
-        $value = array_key_exists($propertyName, $this->properties)
-            ? $this->properties[$propertyName]
-            : $this->fetchNewProperty($propertyName, $dataProperty);
+        $value = array_key_exists($name, $this->properties)
+            ? $this->properties[$name]
+            : $this->fetchNewProperty($name, $dataProperty);
 
         if ($value === null && ! $dataProperty->type->isNullable) {
             return UnknownProperty::create();
@@ -38,25 +37,23 @@ class NormalizedModel implements Normalized
 
     protected function fetchNewProperty(string $name, DataProperty $dataProperty): mixed
     {
-        if ($this->hasModelAttribute($name)) {
-            return $this->properties[$name] = $this->model->getAttributeValue($name);
-        }
-
-        $camelName = Str::camel($name);
-
         if ($dataProperty->attributes->contains(fn (object $attribute) => $attribute::class === LoadRelation::class)) {
             if (method_exists($this->model, $name)) {
                 $this->model->loadMissing($name);
-            } elseif (method_exists($this->model, $camelName)) {
-                $this->model->loadMissing($camelName);
             }
         }
 
         if ($this->model->relationLoaded($name)) {
             return $this->properties[$name] = $this->model->getRelation($name);
         }
-        if ($this->model->relationLoaded($camelName)) {
-            return $this->properties[$name] = $this->model->getRelation($camelName);
+
+        if (!$this->model->isRelation($name)) {
+            try {
+                $propertyName = $this->model::$snakeAttributes ? Str::snake($name) : $name;
+                return $this->properties[$name] = $this->model->getAttribute($propertyName);
+            } catch (MissingAttributeException) {
+                // Fallback if missing Attribute
+            }
         }
 
         return $this->properties[$name] = UnknownProperty::create();
@@ -68,16 +65,13 @@ class NormalizedModel implements Normalized
             return $this->model->hasAttribute($name);
         }
 
-        // TODO: to use that one once we stop supporting Laravel 10
-
+        // TODO: remove this once we stop supporting Laravel 10
         if (! isset($this->attributesProperty)) {
             $this->attributesProperty = new ReflectionProperty($this->model, 'attributes');
-            $this->attributesProperty->setAccessible(true);
         }
 
         if (! isset($this->castsProperty)) {
             $this->castsProperty = new ReflectionProperty($this->model, 'casts');
-            $this->castsProperty->setAccessible(true);
         }
 
         return array_key_exists($name, $this->attributesProperty->getValue($this->model)) ||

--- a/src/Resolvers/DataValidationRulesResolver.php
+++ b/src/Resolvers/DataValidationRulesResolver.php
@@ -242,9 +242,7 @@ class DataValidationRulesResolver
         );
 
         $overwrittenRules = app()->call([$class->name, 'rules'], ['context' => $validationContext]);
-        $shouldMergeRules = $class->attributes->contains(
-            fn (object $attribute) => $attribute::class === MergeValidationRules::class
-        );
+        $shouldMergeRules = $class->attributes->hasAttribute(MergeValidationRules::class);
 
         foreach ($overwrittenRules as $key => $rules) {
             if (in_array($key, $withoutValidationProperties)) {

--- a/src/Resolvers/NameMappersResolver.php
+++ b/src/Resolvers/NameMappersResolver.php
@@ -2,12 +2,12 @@
 
 namespace Spatie\LaravelData\Resolvers;
 
-use Illuminate\Support\Collection;
 use Spatie\LaravelData\Attributes\MapInputName;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\MapOutputName;
 use Spatie\LaravelData\Mappers\NameMapper;
 use Spatie\LaravelData\Mappers\ProvidedNameMapper;
+use Spatie\LaravelData\Support\AttributeCollection;
 
 class NameMappersResolver
 {
@@ -21,7 +21,7 @@ class NameMappersResolver
     }
 
     public function execute(
-        Collection $attributes
+        AttributeCollection $attributes
     ): array {
         return [
             'inputNameMapper' => $this->resolveInputNameMapper($attributes),
@@ -30,11 +30,10 @@ class NameMappersResolver
     }
 
     protected function resolveInputNameMapper(
-        Collection $attributes
+        AttributeCollection $attributes
     ): ?NameMapper {
-        /** @var MapInputName|MapName|null $mapper */
-        $mapper = $attributes->first(fn (object $attribute) => $attribute instanceof MapInputName)
-            ?? $attributes->first(fn (object $attribute) => $attribute instanceof MapName);
+        $mapper = $attributes->getAttribute(MapInputName::class)
+            ?? $attributes->getAttribute(MapName::class);
 
         if ($mapper) {
             return $this->resolveMapper($mapper->input);
@@ -44,11 +43,10 @@ class NameMappersResolver
     }
 
     protected function resolveOutputNameMapper(
-        Collection $attributes
+        AttributeCollection $attributes
     ): ?NameMapper {
-        /** @var MapOutputName|MapName|null $mapper */
-        $mapper = $attributes->first(fn (object $attribute) => $attribute instanceof MapOutputName)
-            ?? $attributes->first(fn (object $attribute) => $attribute instanceof MapName);
+        $mapper = $attributes->getAttribute(MapOutputName::class)
+            ?? $attributes->getAttribute(MapName::class);
 
         if ($mapper) {
             return $this->resolveMapper($mapper->output);

--- a/src/RuleInferrers/AttributesRuleInferrer.php
+++ b/src/RuleInferrers/AttributesRuleInferrer.php
@@ -24,7 +24,7 @@ class AttributesRuleInferrer implements RuleInferrer
     ): PropertyRules {
         $property
             ->attributes
-            ->filter(fn (object $attribute) => $attribute instanceof ValidationRule)
+            ->getAttributes(ValidationRule::class)
             ->each(function (ValidationRule $rule) use ($rules) {
                 if ($rule instanceof Present && $rules->hasType(RequiringRule::class)) {
                     $rules->removeType(RequiringRule::class);

--- a/src/Support/AttributeCollection.php
+++ b/src/Support/AttributeCollection.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Spatie\LaravelData\Support;
+
+use Illuminate\Support\Collection;
+use ReflectionAttribute;
+
+class AttributeCollection extends Collection
+{
+    private array $groups;
+
+    public static function makeFromReflectionAttributes(array $attributes): self
+    {
+        return new self(
+            array_map(
+                fn (ReflectionAttribute $attribute) => $attribute->newInstance(),
+                array_filter($attributes, fn (ReflectionAttribute $attribute) => class_exists($attribute->getName()))
+            )
+        );
+    }
+
+    public function add($item): static
+    {
+        unset($this->groups);
+
+        return parent::add($item);
+    }
+
+    public function offsetSet($key, $value): void
+    {
+        unset($this->groups);
+        parent::offsetSet($key, $value);
+    }
+
+    private function maybeProcessItemsIntoGroups(): void
+    {
+        if (! isset($this->groups)) {
+            foreach ($this->items as $item) {
+                $implements = class_implements($item);
+                $parents = class_parents($item);
+                foreach (array_merge([get_class($item)], $implements, $parents) as $parent) {
+                    $this->groups[$parent][] = $item;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param class-string $attributeClass
+     */
+    public function hasAttribute(string $attributeClass): bool
+    {
+        $this->maybeProcessItemsIntoGroups();
+
+        return ! empty($this->groups[$attributeClass]);
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $attributeClass
+     *
+     * @return Collection<T>
+     */
+    public function getAttributes(string $attributeClass): Collection
+    {
+        $this->maybeProcessItemsIntoGroups();
+
+        return collect($this->groups[$attributeClass] ?? []);
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $attributeClass
+     *
+     * @return ?T
+     */
+    public function getAttribute(string $attributeClass): ?object
+    {
+        $this->maybeProcessItemsIntoGroups();
+
+        return current($this->groups[$attributeClass] ?? []) ?: null;
+    }
+}

--- a/src/Support/DataClass.php
+++ b/src/Support/DataClass.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Collection;
  * @property  class-string $name
  * @property  Collection<string, DataProperty> $properties
  * @property  Collection<string, DataMethod> $methods
- * @property  Collection<string, object> $attributes
+ * @property  AttributeCollection<string, object> $attributes
  * @property  array<string, \Spatie\LaravelData\Support\Annotations\DataIterableAnnotation> $dataCollectablePropertyAnnotations
  */
 class DataClass
@@ -27,7 +27,7 @@ class DataClass
         public readonly bool $validateable,
         public readonly bool $wrappable,
         public readonly bool $emptyData,
-        public readonly Collection $attributes,
+        public readonly AttributeCollection $attributes,
         public readonly array $dataIterablePropertyAnnotations,
         public DataStructureProperty $allowedRequestIncludes,
         public DataStructureProperty $allowedRequestExcludes,

--- a/src/Support/DataProperty.php
+++ b/src/Support/DataProperty.php
@@ -2,13 +2,12 @@
 
 namespace Spatie\LaravelData\Support;
 
-use Illuminate\Support\Collection;
 use Spatie\LaravelData\Attributes\AutoLazy;
 use Spatie\LaravelData\Casts\Cast;
 use Spatie\LaravelData\Transformers\Transformer;
 
 /**
- * @property Collection<string, object> $attributes
+ * @property AttributeCollection<string, object> $attributes
  */
 class DataProperty
 {
@@ -28,7 +27,7 @@ class DataProperty
         public readonly ?Transformer $transformer,
         public readonly ?string $inputMappedName,
         public readonly ?string $outputMappedName,
-        public readonly Collection $attributes,
+        public readonly AttributeCollection $attributes,
     ) {
     }
 }

--- a/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
+++ b/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
@@ -53,9 +53,7 @@ class DataTypeScriptTransformer extends DtoTransformer
     ): string {
         $dataClass = app(DataConfig::class)->getDataClass($class->getName());
 
-        $isOptional = $dataClass->attributes->contains(
-            fn (object $attribute) => $attribute instanceof TypeScriptOptional
-        );
+        $isOptional = $dataClass->attributes->hasAttribute(TypeScriptOptional::class);
 
         return array_reduce(
             $this->resolveProperties($class),
@@ -76,9 +74,7 @@ class DataTypeScriptTransformer extends DtoTransformer
                 }
 
                 $isOptional = $isOptional
-                    || $dataProperty->attributes->contains(
-                        fn (object $attribute) => $attribute instanceof TypeScriptOptional
-                    )
+                    || $dataProperty->attributes->hasAttribute(TypeScriptOptional::class)
                     || ($dataProperty->type->lazyType && $dataProperty->type->lazyType !== ClosureLazy::class)
                     || $dataProperty->type->isOptional
                     || ($dataProperty->type->isNullable && $this->config->shouldConsiderNullAsOptional());

--- a/tests/Fakes/FakeModelData.php
+++ b/tests/Fakes/FakeModelData.php
@@ -4,10 +4,8 @@ namespace Spatie\LaravelData\Tests\Fakes;
 
 use Carbon\CarbonImmutable;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
-use Spatie\LaravelData\Attributes\MapInputName;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\DataCollection;
-use Spatie\LaravelData\Mappers\CamelCaseMapper;
 use Spatie\LaravelData\Optional;
 
 class FakeModelData extends Data
@@ -16,7 +14,7 @@ class FakeModelData extends Data
         public string $string,
         public ?string $nullable,
         public CarbonImmutable $date,
-        #[DataCollectionOf(FakeNestedModelData::class), MapInputName(CamelCaseMapper::class)]
+        #[DataCollectionOf(FakeNestedModelData::class)]
         public Optional|null|DataCollection $fake_nested_models,
         public string $accessor,
         public string $old_accessor,

--- a/tests/Fakes/FakeModelData.php
+++ b/tests/Fakes/FakeModelData.php
@@ -4,8 +4,10 @@ namespace Spatie\LaravelData\Tests\Fakes;
 
 use Carbon\CarbonImmutable;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Attributes\MapInputName;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\DataCollection;
+use Spatie\LaravelData\Mappers\CamelCaseMapper;
 use Spatie\LaravelData\Optional;
 
 class FakeModelData extends Data
@@ -14,7 +16,7 @@ class FakeModelData extends Data
         public string $string,
         public ?string $nullable,
         public CarbonImmutable $date,
-        #[DataCollectionOf(FakeNestedModelData::class)]
+        #[DataCollectionOf(FakeNestedModelData::class), MapInputName(CamelCaseMapper::class)]
         public Optional|null|DataCollection $fake_nested_models,
         public string $accessor,
         public string $old_accessor,

--- a/tests/Normalizers/ModelNormalizerTest.php
+++ b/tests/Normalizers/ModelNormalizerTest.php
@@ -72,7 +72,7 @@ it('can get a data object from model with accessors', function () {
         ->old_accessor->toEqual($data->old_accessor);
 });
 
-it('it will only call model accessors when required', function () {
+it('will only call model accessors when required', function () {
     $dataClass = new class () extends Data {
         public string $accessor;
 
@@ -118,7 +118,7 @@ it('can load relations on a model when required and the LoadRelation attribute i
 
     $dataClass = new class () extends Data {
         #[LoadRelation, DataCollectionOf(FakeNestedModelData::class)]
-        public array $fakeNestedModels;
+        public array $fake_nested_models;
 
         #[LoadRelation, DataCollectionOf(FakeNestedModelData::class)]
         public array $fake_nested_models_snake_cased;
@@ -131,7 +131,7 @@ it('can load relations on a model when required and the LoadRelation attribute i
 
     $queryLog = DB::getQueryLog();
 
-    expect($data->fakeNestedModels)
+    expect($data->fake_nested_models)
         ->toHaveCount(2)
         ->each->toBeInstanceOf(FakeNestedModelData::class);
 
@@ -183,9 +183,7 @@ it('can use mappers to map the names', function () {
 
     $dataClass = new class () extends Data {
         #[DataCollectionOf(FakeNestedModelData::class), MapInputName(SnakeCaseMapper::class)]
-        public array $fakeNestedModels;
-        #[DataCollectionOf(FakeNestedModelData::class), MapInputName(SnakeCaseMapper::class), LoadRelation]
-        public array|Optional $fakeNestedModelsSnakeCased;
+        public array|Optional $fakeNestedModels;
 
         #[MapInputName(SnakeCaseMapper::class)]
         public string $oldAccessor;
@@ -193,8 +191,7 @@ it('can use mappers to map the names', function () {
 
     $data = $dataClass::from($model->load('fakeNestedModels'));
 
-    expect(isset($data->fakeNestedModels))->toBeFalse();
-    expect($data->fakeNestedModelsSnakeCased)
+    expect($data->fakeNestedModels)
         ->toHaveCount(2)
         ->each()
         ->toBeInstanceOf(FakeNestedModelData::class);

--- a/tests/Normalizers/ModelNormalizerTest.php
+++ b/tests/Normalizers/ModelNormalizerTest.php
@@ -118,7 +118,7 @@ it('can load relations on a model when required and the LoadRelation attribute i
 
     $dataClass = new class () extends Data {
         #[LoadRelation, DataCollectionOf(FakeNestedModelData::class)]
-        public array $fake_nested_models;
+        public array $fakeNestedModels;
 
         #[LoadRelation, DataCollectionOf(FakeNestedModelData::class)]
         public array $fake_nested_models_snake_cased;
@@ -131,7 +131,7 @@ it('can load relations on a model when required and the LoadRelation attribute i
 
     $queryLog = DB::getQueryLog();
 
-    expect($data->fake_nested_models)
+    expect($data->fakeNestedModels)
         ->toHaveCount(2)
         ->each->toBeInstanceOf(FakeNestedModelData::class);
 
@@ -183,7 +183,9 @@ it('can use mappers to map the names', function () {
 
     $dataClass = new class () extends Data {
         #[DataCollectionOf(FakeNestedModelData::class), MapInputName(SnakeCaseMapper::class)]
-        public array|Optional $fakeNestedModels;
+        public array $fakeNestedModels;
+        #[DataCollectionOf(FakeNestedModelData::class), MapInputName(SnakeCaseMapper::class), LoadRelation]
+        public array|Optional $fakeNestedModelsSnakeCased;
 
         #[MapInputName(SnakeCaseMapper::class)]
         public string $oldAccessor;
@@ -191,7 +193,8 @@ it('can use mappers to map the names', function () {
 
     $data = $dataClass::from($model->load('fakeNestedModels'));
 
-    expect($data->fakeNestedModels)
+    expect(isset($data->fakeNestedModels))->toBeFalse();
+    expect($data->fakeNestedModelsSnakeCased)
         ->toHaveCount(2)
         ->each()
         ->toBeInstanceOf(FakeNestedModelData::class);

--- a/tests/Resolvers/NameMappersResolverTest.php
+++ b/tests/Resolvers/NameMappersResolverTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Collection;
 use Spatie\LaravelData\Attributes\MapInputName;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\MapOutputName;
@@ -9,11 +8,11 @@ use Spatie\LaravelData\Mappers\ProvidedNameMapper;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 use Spatie\LaravelData\Mappers\StudlyCaseMapper;
 use Spatie\LaravelData\Resolvers\NameMappersResolver;
+use Spatie\LaravelData\Support\AttributeCollection;
 
-function getAttributes(object $class): Collection
+function getAttributes(object $class): AttributeCollection
 {
-    return collect((new ReflectionProperty($class, 'property'))->getAttributes())
-        ->map(fn (ReflectionAttribute $attribute) => $attribute->newInstance());
+    return AttributeCollection::makeFromReflectionAttributes((new ReflectionProperty($class, 'property'))->getAttributes());
 }
 
 beforeEach(function () {

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -291,7 +291,7 @@ it('is possible to have multiple required rules', function () {
     ]);
 })->skip('Add a new ruleinferrer to rule them all and make these cases better');
 
-it('it will take care of mapping', function () {
+it('will take care of mapping', function () {
     DataValidationAsserter::for(new class () extends Data {
         #[MapInputName('some_property')]
         public string $property;


### PR DESCRIPTION
As seen in #870 the move to `getAttributeValue` bypasses the overriden method https://github.com/Astrotomic/laravel-translatable/edit/main/src/Translatable/Translatable.php#L143

This PR goes back to using `getAttribute` but after already checking if it's a relation (because getAttribute loads the relation otherwise, which we don't want), like this both spatie/translatable and astrotomic/translatable will work with this package