### PR TITLE
Add ability to set responseStatusCode on Response objects

### DIFF
--- a/src/Concerns/ResponsableData.php
+++ b/src/Concerns/ResponsableData.php
@@ -12,6 +12,8 @@ use Spatie\LaravelData\Support\Wrapping\WrapExecutionType;
 
 trait ResponsableData
 {
+    protected int $responseStatusCode;
+
     public function toResponse($request)
     {
         $contextFactory = TransformationContextFactory::create()
@@ -63,8 +65,20 @@ trait ResponsableData
         );
     }
 
+    public function setResponseStatusCode(int $responseStatusCode): self
+    {
+        $this->responseStatusCode = $responseStatusCode;
+
+        return $this;
+    }
+
     protected function calculateResponseStatus(Request $request): int
     {
+        $responseStatusCode = $this->responseStatusCode ?? null;
+        if ($responseStatusCode !== null) {
+            return $responseStatusCode;
+        }
+
         return $request->isMethod(Request::METHOD_POST) ? Response::HTTP_CREATED : Response::HTTP_OK;
     }
 

--- a/src/Concerns/ResponsableData.php
+++ b/src/Concerns/ResponsableData.php
@@ -12,7 +12,7 @@ use Spatie\LaravelData\Support\Wrapping\WrapExecutionType;
 
 trait ResponsableData
 {
-    protected int $responseStatusCode;
+    protected int $_responseStatusCode;
 
     public function toResponse($request)
     {
@@ -67,14 +67,14 @@ trait ResponsableData
 
     public function setResponseStatusCode(int $responseStatusCode): self
     {
-        $this->responseStatusCode = $responseStatusCode;
+        $this->_responseStatusCode = $responseStatusCode;
 
         return $this;
     }
 
     protected function calculateResponseStatus(Request $request): int
     {
-        $responseStatusCode = $this->responseStatusCode ?? null;
+        $responseStatusCode = $this->_responseStatusCode ?? null;
         if ($responseStatusCode !== null) {
             return $responseStatusCode;
         }

--- a/tests/PartialsTest.php
+++ b/tests/PartialsTest.php
@@ -1647,3 +1647,16 @@ it('handles circular dependencies', function () {
     ]);
     // Not really a test with expectation, we just want to check we don't end up in an infinite loop
 });
+
+it('sets response code', function () {
+    // Given
+    $data = new SimpleData("roxanne");
+    // And
+    $data->setResponseStatusCode(404);
+
+    // When
+    $jsonResponse = $data->toResponse(request());
+
+    // Then
+    expect($jsonResponse->status())->toBe(404);
+});


### PR DESCRIPTION
## Goal
Provide the ability to set a specific status code on responses.

## Background
I'm using the package for error response messages (rather than throwing exceptions). For instance, we have a custom NotAuthorizedResponse that will have a payload like this:
```json
{
    "code": "not_authorized",
    "uuid": "abcd-e4gab2-ffff-a324-0001",
    "message": "You are not authorized to view this post"
}
```

And an object like this:

```php
class NotAuthorizedResponse extends Response
{
    public ErrorResponseEnum $code = ErrorResponseEnum::NOT_AUTHORIZED;

    public function __construct(
        public ?string $uuid,
        public string $message = "We could not find this resource"
    ) {}
}
```

We can get away with overriding the `calculateResponseStatus` method in a `BaseResponse` class, but I thought that this functionality would be helpful for others as well.

## Usage
```php
public function show(Request $request): PostResponse|NotAuthorizedResponse
{
    if (! $request->user()->isAdmin()) {
        return (new NotAuthorizedResponse($request->uuid, "You are not authorized to view this post"))
            ->setResponseStatusCode(403);
    }
   // ... happy path
}
```