### PR TITLE
Implement enum json serialization

### DIFF
--- a/src/Enums/CustomCreationMethodType.php
+++ b/src/Enums/CustomCreationMethodType.php
@@ -2,9 +2,9 @@
 
 namespace Spatie\LaravelData\Enums;
 
-enum CustomCreationMethodType
+enum CustomCreationMethodType: string
 {
-    case None;
-    case Object;
-    case Collection;
+    case None = 'None';
+    case Object = 'Object';
+    case Collection = 'Collection';
 }

--- a/src/Enums/DataCollectableType.php
+++ b/src/Enums/DataCollectableType.php
@@ -2,11 +2,11 @@
 
 namespace Spatie\LaravelData\Enums;
 
-enum DataCollectableType
+enum DataCollectableType: string
 {
-    case Default;
-    case Array;
-    case Collection;
-    case Paginated;
-    case CursorPaginated;
+    case Default = 'Default';
+    case Array = 'Array';
+    case Collection = 'Collection';
+    case Paginated = 'Paginated';
+    case CursorPaginated = 'CursorPaginated';
 }

--- a/src/Enums/DataTypeKind.php
+++ b/src/Enums/DataTypeKind.php
@@ -4,21 +4,21 @@ namespace Spatie\LaravelData\Enums;
 
 use Exception;
 
-enum DataTypeKind
+enum DataTypeKind: string
 {
-    case Default;
-    case Array;
-    case Enumerable;
-    case Paginator;
-    case CursorPaginator;
-    case DataObject;
-    case DataCollection;
-    case DataPaginatedCollection;
-    case DataCursorPaginatedCollection;
-    case DataArray;
-    case DataEnumerable;
-    case DataPaginator;
-    case DataCursorPaginator;
+    case Default = 'Default';
+    case Array = 'Array';
+    case Enumerable = 'Enumerable';
+    case Paginator = 'Paginator';
+    case CursorPaginator = 'CursorPaginator';
+    case DataObject = 'DataObject';
+    case DataCollection = 'DataCollection';
+    case DataPaginatedCollection = 'DataPaginatedCollection';
+    case DataCursorPaginatedCollection = 'DataCursorPaginatedCollection';
+    case DataArray = 'DataArray';
+    case DataEnumerable = 'DataEnumerable';
+    case DataPaginator = 'DataPaginator';
+    case DataCursorPaginator = 'DataCursorPaginator';
 
     public function isDataObject(): bool
     {

--- a/tests/ExceptionTraceArgumentsJsonSerializationTest.php
+++ b/tests/ExceptionTraceArgumentsJsonSerializationTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Exceptions\CannotCreateData;
+use Spatie\LaravelData\Tests\Fakes\NotExtendedDataClass;
+use Spatie\LaravelData\Tests\Fakes\SimpleData;
+
+// enable args in exception trace
+beforeEach(function () {
+    ini_set('zend.exception_ignore_args', 'Off');
+});
+
+it('can json_encode exception trace with args when not all required properties passed', function () {
+    try {
+        SimpleData::from([]);
+    } catch (CannotCreateData $e) {
+        $trace = $e->getTrace();
+        $encodedJson = json_encode($trace, JSON_THROW_ON_ERROR);
+
+        expect($encodedJson)->toBeJson();
+    }
+});
+
+it('can json_encode exception trace with args when nested property not extends Data or Dto class', function () {
+    $dataClass = new class ('', new NotExtendedDataClass('')) extends Data {
+        public function __construct(
+            public string $string,
+            public NotExtendedDataClass $nested
+        ) {
+        }
+    };
+
+    try {
+        $dataClass::from(['string' => '', 'nested' => ['name' => '']]);
+    } catch (TypeError $e) {
+        $trace = $e->getTrace();
+        $encodedJson = json_encode($trace, JSON_THROW_ON_ERROR);
+
+        expect($encodedJson)->toBeJson();
+    }
+});

--- a/tests/Fakes/NotExtendedDataClass.php
+++ b/tests/Fakes/NotExtendedDataClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+class NotExtendedDataClass
+{
+    public function __construct(
+        public string $name
+    ) {
+    }
+}


### PR DESCRIPTION
Hi team, this is a small PR fixing enum serialization.

## Prerequisites

[zend.exception_ignore_args](https://www.php.net/manual/en/ini.core.php) must be disabled.

## Description

PHP doesn't support Pure Enum json serialization: https://www.php.net/manual/en/language.enumerations.serialization.php

> If a Pure Enum is serialized to JSON, an error will be thrown.


We will get an serialization error, for example, if we want to write json serialized error trace with arguments into log, because some package classes/methods use enum in arguments.


There are two possible solutions:
1. Using Backed Enum
2. Implement `JsonSerializable` interface. I chose this option because the package uses Pure Enums.


