### PR TITLE
Casting DateTimeInterface: Truncate nanoseconds to microseconds (first 6 digits) / with Tests

### DIFF
--- a/src/Casts/DateTimeInterfaceCast.php
+++ b/src/Casts/DateTimeInterfaceCast.php
@@ -38,6 +38,11 @@ class DateTimeInterfaceCast implements Cast, IterableItemCast
             return Uncastable::create();
         }
 
+        // Truncate nanoseconds to microseconds (first 6 digits)
+        // Input: 2024-12-02T16:20:15.969827247Z
+        $value = preg_replace('/\.(\d{6})\d*Z$/', '.$1Z', $value);
+        // Output: 2024-12-02T16:20:15.969827Z
+
         /** @var DateTimeInterface|null $datetime */
         $datetime = $formats
             ->map(fn (string $format) => rescue(fn () => $type::createFromFormat(

--- a/tests/Casts/DateTimeInterfaceCastTest.php
+++ b/tests/Casts/DateTimeInterfaceCastTest.php
@@ -209,3 +209,64 @@ it('can define multiple date formats to be used', function () {
         ->and($data::from(['date' => '2022-05-16 17:00:00']))->toArray()
         ->toMatchArray(['date' => '2022-05-16T17:00:00+00:00']);
 });
+
+
+it('can cast date times with nanosecond precision by truncating nanoseconds to microseconds', function () {
+    $caster = new DateTimeInterfaceCast("Y-m-d\TH:i:s.u\Z");
+
+    $class = new class () {
+        public Carbon $carbon;
+
+        public CarbonImmutable $carbonImmutable;
+
+        public DateTime $dateTime;
+
+        public DateTimeImmutable $dateTimeImmutable;
+    };
+
+
+    expect(
+        $caster->cast(
+            FakeDataStructureFactory::property($class, 'carbon'),
+            '2024-12-02T16:20:15.969827247Z',
+            [],
+            CreationContextFactory::createFromConfig($class::class)->get()
+        )
+    )->toEqual(new Carbon('2024-12-02T16:20:15.969827247Z'));
+
+    expect(
+        $caster->cast(
+            FakeDataStructureFactory::property($class, 'carbonImmutable'),
+            '2024-12-02T16:20:15.969827247Z',
+            [],
+            CreationContextFactory::createFromConfig($class::class)->get()
+        )
+    )->toEqual(new CarbonImmutable('2024-12-02T16:20:15.969827247Z'));
+
+    expect(
+        $caster->cast(
+            FakeDataStructureFactory::property($class, 'dateTime'),
+            '2024-12-02T16:20:15.969827247Z',
+            [],
+            CreationContextFactory::createFromConfig($class::class)->get()
+        )
+    )->toEqual(new DateTime('2024-12-02T16:20:15.969827247Z'));
+
+    expect(
+        $caster->cast(
+            FakeDataStructureFactory::property($class, 'dateTimeImmutable'),
+            '2024-12-02T16:20:15.969827247Z',
+            [],
+            CreationContextFactory::createFromConfig($class::class)->get()
+        )
+    )->toEqual(new DateTimeImmutable('2024-12-02T16:20:15.969827247Z'));
+
+    expect(
+        $caster->cast(
+            FakeDataStructureFactory::property($class, 'dateTimeImmutable'),
+            '2024-12-02T16:20:15.969827247Z',
+            [],
+            CreationContextFactory::createFromConfig($class::class)->get()
+        )
+    )->toEqual(new DateTimeImmutable('2024-12-02T16:20:15.969827247Z'));
+});


### PR DESCRIPTION
So I'm basically just making this pull request to fix a very specific issue I'm having.

a Third Party API i'm using is returning dates in ISO 8601 Format with Nanoseconds precision, but sadly PHP does not support nanoseconds (they only support up-to microseconds)

Example:
A provided datetime 2024-12-03T10:33:18.924711041Z is in ISO 8601 format with a nanosecond precision and a timezone indicator (Z for UTC). However, PHP's DateTime and the provided formats DATE_ATOM or Y-m-d\TH:i:s.u\Z do not handle nanoseconds (fractions of a second) by default, which is causing the error.