### PR TITLE
Use container to call `Data::authorize()` to allow for dependencies

### DIFF
--- a/src/DataPipes/AuthorizedDataPipe.php
+++ b/src/DataPipes/AuthorizedDataPipe.php
@@ -27,7 +27,7 @@ class AuthorizedDataPipe implements DataPipe
     protected function ensureRequestIsAuthorized(string $class): void
     {
         /** @psalm-suppress UndefinedMethod */
-        if (method_exists($class, 'authorize') && $class::authorize() === false) {
+        if (method_exists($class, 'authorize') && app()->call([$class, 'authorize']) === false) {
             throw new AuthorizationException();
         }
     }


### PR DESCRIPTION
I want to build a request object that leverages Laravel's new contextual attributes. For instance:

```php
class CreatePodcast extends Data
{
    public function __construct(
        public string $name,
        public bool $premium
    ) {
    }

    public static function authorize(
        #[CurrentUser] User $user,
        #[RouteParameter('org')] Organization $org
    ): bool
    {
        return $user->can('createPodcastFor', $org);
    }
}
```

While it's possible to add a custom DataPipe to `pipelines()`, this seems like it would be a pretty common use-case for folks.