### PR TITLE
Failing annotation tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": "^8.1",
         "illuminate/contracts": "^10.0|^11.0",
         "phpdocumentor/reflection": "^6.0",
+        "phpdocumentor/reflection-docblock": "^5.5",
         "spatie/laravel-package-tools": "^1.9.0",
         "spatie/php-structure-discoverer": "^2.0"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,11 +121,6 @@ parameters:
 			path: src/Support/DataConfig.php
 
 		-
-			message: "#^Call to method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),string\\|null\\>\\:\\:isEmpty\\(\\) will always evaluate to false\\.$#"
-			count: 1
-			path: src/Support/Validation/RuleDenormalizer.php
-
-		-
 			message: "#^Call to an undefined method DateTimeInterface\\:\\:setTimezone\\(\\)\\.$#"
 			count: 1
 			path: src/Transformers/DateTimeInterfaceTransformer.php

--- a/tests/CollectionAttributeWithAnotationsTest.php
+++ b/tests/CollectionAttributeWithAnotationsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Spatie\LaravelData\Tests\Fakes\Collections\SimpleDataCollectionWithAnotations;
+use Spatie\LaravelData\Tests\Fakes\Collections\SimpleDataCollectionWithAnnotations;
 use Spatie\LaravelData\Tests\Fakes\DataWithSimpleDataCollectionWithAnotations;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
 use Spatie\LaravelData\Tests\TestSupport\DataValidationAsserter;
@@ -20,7 +20,7 @@ it('can create a data object with a collection attribute from array and back', f
     $data = DataWithSimpleDataCollectionWithAnotations::from($this->payload);
 
     expect($data)->toEqual(new DataWithSimpleDataCollectionWithAnotations(
-        collection: new SimpleDataCollectionWithAnotations([
+        collection: new SimpleDataCollectionWithAnnotations([
             new SimpleData(string: 'string1'),
             new SimpleData(string: 'string2'),
             new SimpleData(string: 'string3'),

--- a/tests/Fakes/Collections/SimpleDataCollectionWithAnnotations.php
+++ b/tests/Fakes/Collections/SimpleDataCollectionWithAnnotations.php
@@ -10,6 +10,6 @@ use Illuminate\Support\Collection;
  *
  * @extends \Illuminate\Support\Collection<TKey, TData>
  */
-class SimpleDataCollectionWithAnotations extends Collection
+class SimpleDataCollectionWithAnnotations extends Collection
 {
 }

--- a/tests/Fakes/DataWithSimpleDataCollectionWithAnotations.php
+++ b/tests/Fakes/DataWithSimpleDataCollectionWithAnotations.php
@@ -3,12 +3,12 @@
 namespace Spatie\LaravelData\Tests\Fakes;
 
 use Spatie\LaravelData\Data;
-use Spatie\LaravelData\Tests\Fakes\Collections\SimpleDataCollectionWithAnotations;
+use Spatie\LaravelData\Tests\Fakes\Collections\SimpleDataCollectionWithAnnotations;
 
 class DataWithSimpleDataCollectionWithAnotations extends Data
 {
     public function __construct(
-        public SimpleDataCollectionWithAnotations $collection
+        public SimpleDataCollectionWithAnnotations $collection
     ) {
     }
 }

--- a/tests/Support/DataPropertyTypeTest.php
+++ b/tests/Support/DataPropertyTypeTest.php
@@ -35,7 +35,7 @@ use Spatie\LaravelData\Support\Types\IntersectionType;
 use Spatie\LaravelData\Support\Types\NamedType;
 use Spatie\LaravelData\Support\Types\UnionType;
 use Spatie\LaravelData\Tests\Factories\FakeDataStructureFactory;
-use Spatie\LaravelData\Tests\Fakes\Collections\SimpleDataCollectionWithAnotations;
+use Spatie\LaravelData\Tests\Fakes\Collections\SimpleDataCollectionWithAnnotations;
 use Spatie\LaravelData\Tests\Fakes\ComplicatedData;
 use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
@@ -575,7 +575,7 @@ it('can deduce an enumerable data collection union type', function () {
 
 it('can deduce an enumerable data collection type from collection', function () {
     $type = resolveDataType(new class () {
-        public SimpleDataCollectionWithAnotations $property;
+        public SimpleDataCollectionWithAnnotations $property;
     });
 
     expect($type)
@@ -585,21 +585,21 @@ it('can deduce an enumerable data collection type from collection', function () 
         ->lazyType->toBeNull()
         ->kind->toBe(DataTypeKind::DataEnumerable)
         ->dataClass->toBe(SimpleData::class)
-        ->iterableClass->toBe(SimpleDataCollectionWithAnotations::class)
-        ->getAcceptedTypes()->toHaveKeys([SimpleDataCollectionWithAnotations::class]);
+        ->iterableClass->toBe(SimpleDataCollectionWithAnnotations::class)
+        ->getAcceptedTypes()->toHaveKeys([SimpleDataCollectionWithAnnotations::class]);
 
     expect($type->type)
         ->toBeInstanceOf(NamedType::class)
-        ->name->toBe(SimpleDataCollectionWithAnotations::class)
+        ->name->toBe(SimpleDataCollectionWithAnnotations::class)
         ->builtIn->toBeFalse()
         ->kind->toBe(DataTypeKind::DataEnumerable)
         ->dataClass->toBe(SimpleData::class)
-        ->iterableClass->toBe(SimpleDataCollectionWithAnotations::class);
+        ->iterableClass->toBe(SimpleDataCollectionWithAnnotations::class);
 });
 
 it('can deduce an enumerable data collection union type from collection', function () {
     $type = resolveDataType(new class () {
-        public SimpleDataCollectionWithAnotations|Lazy $property;
+        public SimpleDataCollectionWithAnnotations|Lazy $property;
     });
 
     expect($type)
@@ -609,16 +609,16 @@ it('can deduce an enumerable data collection union type from collection', functi
         ->lazyType->toBe(Lazy::class)
         ->kind->toBe(DataTypeKind::DataEnumerable)
         ->dataClass->toBe(SimpleData::class)
-        ->iterableClass->toBe(SimpleDataCollectionWithAnotations::class)
-        ->getAcceptedTypes()->toHaveKeys([SimpleDataCollectionWithAnotations::class]);
+        ->iterableClass->toBe(SimpleDataCollectionWithAnnotations::class)
+        ->getAcceptedTypes()->toHaveKeys([SimpleDataCollectionWithAnnotations::class]);
 
     expect($type->type)
         ->toBeInstanceOf(NamedType::class)
-        ->name->toBe(SimpleDataCollectionWithAnotations::class)
+        ->name->toBe(SimpleDataCollectionWithAnnotations::class)
         ->builtIn->toBeFalse()
         ->kind->toBe(DataTypeKind::DataEnumerable)
         ->dataClass->toBe(SimpleData::class)
-        ->iterableClass->toBe(SimpleDataCollectionWithAnotations::class);
+        ->iterableClass->toBe(SimpleDataCollectionWithAnnotations::class);
 });
 
 it('can deduce a paginator data collection type', function () {


### PR DESCRIPTION
Tests were failing for me locally and on some branch builds. E.g. for the same commit:
- This one passed: https://github.com/spatie/laravel-data/actions/runs/12477953676/job/34824836963
- This one failed: https://github.com/spatie/laravel-data/actions/runs/12477953676/job/34824836512

I believe this is happening because of an update to `phpdocumentor/reflection-docblock` that added support for more specific docblock types: https://github.com/phpDocumentor/ReflectionDocBlock/releases/tag/5.5.0

This means that the returned tag classes for the `@extends` and `@template` are new specific classes instead of the "Generic" class they previously were.

Unfortunately this dependency is loaded indirectly via  `phpdocumentor/reflection` and their requirement for `phpdocumentor/reflection-docblock` is just `^5`. So I've added `^5.5` to ensure we have the required classes and to make the check more consistent.
