### PR TITLE
New mappers added: `LowerCaseMapper` and `UpperCaseMapper`

### DIFF
--- a/docs/advanced-usage/available-mappers.md
+++ b/docs/advanced-usage/available-mappers.md
@@ -1,0 +1,41 @@
+---
+title: Available mappers
+weight: 19
+---
+
+Sometimes the property names in the array from which you're creating a data object might be different.
+You can use mappers for property names when it is created from an array using attributes:
+
+```php
+class ContractData extends Data
+{
+    public function __construct(
+        #[MapName(CamelCaseMapper::class)]
+        public string $name,
+        #[MapName(SnakeCaseMapper::class)]
+        public string $recordCompany,
+        #[MapName(new ProvidedNameMapper('country field'))]
+        public string $country,
+        #[MapName(StudlyCaseMapper::class)]
+        public string $cityName,
+        #[MapName(LowerCaseMapper::class)]
+        public string $addressLine1,
+        #[MapName(UpperCaseMapper::class)]
+        public string $addressLine2,
+    ) {
+    }
+}
+```
+
+Creating the data object can now be done as such:
+
+```php
+ContractData::from([
+    'name' => 'Rick Astley',
+    'record_company' => 'RCA Records',
+    'country field' => 'Belgium',
+    'CityName' => 'Antwerp',
+    'addressline1' => 'some address line 1',
+    'ADDRESSLINE2' => 'some address line 2',
+]);
+```

--- a/docs/as-a-data-transfer-object/mapping-property-names.md
+++ b/docs/as-a-data-transfer-object/mapping-property-names.md
@@ -91,3 +91,4 @@ SongData::from([
 ]);
 ```
 
+You can also use other mappers to input and output property name mapping (see [available mappers](/docs/laravel-data/v4/advanced-usage/available-mappers)).

--- a/docs/as-a-resource/mapping-property-names.md
+++ b/docs/as-a-resource/mapping-property-names.md
@@ -80,3 +80,36 @@ And a transformed version of the data object will look like this:
     'record_company' => 'RCA Records',
 ]
 ```
+
+### Available mappers:
+
+```php
+class ContractData extends Data
+{
+    public function __construct(
+        #[MapName(CamelCaseMapper::class)]
+        public string $name,
+        #[MapName(SnakeCaseMapper::class)]
+        public string $recordCompany,
+        #[MapName(new ProvidedNameMapper('country field'))]
+        public string $country,
+        #[MapName(StudlyCaseMapper::class)]
+        public string $cityName,
+        #[MapName(LowerCaseMapper::class)]
+        public string $addressLine1,
+        #[MapName(UpperCaseMapper::class)]
+        public string $addressLine2,
+    ) {
+    }
+}
+```
+```php
+[
+    'name' => 'Rick Astley',
+    'record_company' => 'RCA Records',
+    'country field' => 'Belgium',
+    'CityName' => 'Antwerp',
+    'addressline1' => 'some address line 1',
+    'ADDRESSLINE2' => 'some address line 2',
+]
+```

--- a/docs/as-a-resource/mapping-property-names.md
+++ b/docs/as-a-resource/mapping-property-names.md
@@ -81,35 +81,4 @@ And a transformed version of the data object will look like this:
 ]
 ```
 
-### Available mappers:
-
-```php
-class ContractData extends Data
-{
-    public function __construct(
-        #[MapName(CamelCaseMapper::class)]
-        public string $name,
-        #[MapName(SnakeCaseMapper::class)]
-        public string $recordCompany,
-        #[MapName(new ProvidedNameMapper('country field'))]
-        public string $country,
-        #[MapName(StudlyCaseMapper::class)]
-        public string $cityName,
-        #[MapName(LowerCaseMapper::class)]
-        public string $addressLine1,
-        #[MapName(UpperCaseMapper::class)]
-        public string $addressLine2,
-    ) {
-    }
-}
-```
-```php
-[
-    'name' => 'Rick Astley',
-    'record_company' => 'RCA Records',
-    'country field' => 'Belgium',
-    'CityName' => 'Antwerp',
-    'addressline1' => 'some address line 1',
-    'ADDRESSLINE2' => 'some address line 2',
-]
-```
+You can also use other mappers to input and output property name mapping (see [available mappers](/docs/laravel-data/v4/advanced-usage/available-mappers)).

--- a/src/Mappers/LowerCaseMapper.php
+++ b/src/Mappers/LowerCaseMapper.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\LaravelData\Mappers;
+
+use Illuminate\Support\Str;
+
+class LowerCaseMapper implements NameMapper
+{
+    public function map(int|string $name): string|int
+    {
+        return Str::lower($name);
+    }
+}

--- a/src/Mappers/LowerCaseMapper.php
+++ b/src/Mappers/LowerCaseMapper.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Spatie\LaravelData\Mappers;
 
 use Illuminate\Support\Str;

--- a/src/Mappers/UpperCaseMapper.php
+++ b/src/Mappers/UpperCaseMapper.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Spatie\LaravelData\Mappers;
 
 use Illuminate\Support\Str;

--- a/src/Mappers/UpperCaseMapper.php
+++ b/src/Mappers/UpperCaseMapper.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\LaravelData\Mappers;
+
+use Illuminate\Support\Str;
+
+class UpperCaseMapper implements NameMapper
+{
+    public function map(int|string $name): string|int
+    {
+        return Str::upper($name);
+    }
+}

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -6,9 +6,11 @@ use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\MapOutputName;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\CamelCaseMapper;
+use Spatie\LaravelData\Mappers\LowerCaseMapper;
 use Spatie\LaravelData\Mappers\ProvidedNameMapper;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 use Spatie\LaravelData\Mappers\StudlyCaseMapper;
+use Spatie\LaravelData\Mappers\UpperCaseMapper;
 use Spatie\LaravelData\Support\Transformation\TransformationContextFactory;
 use Spatie\LaravelData\Tests\Fakes\DataWithMapper;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
@@ -328,6 +330,12 @@ it('has a mappers built in', function () {
         #[MapName(StudlyCaseMapper::class)]
         public string $studly_case = 'StudlyCase';
 
+        #[MapName(LowerCaseMapper::class)]
+        public string $lowercase = 'lowercase';
+
+        #[MapName(UpperCaseMapper::class)]
+        public string $uppercase = 'UPPERCASE';
+
         #[MapName(new ProvidedNameMapper('i_provided'))]
         public string $provided = 'provided';
     };
@@ -336,6 +344,8 @@ it('has a mappers built in', function () {
         'camelCase' => 'camelCase',
         'snake_case' => 'snake_case',
         'StudlyCase' => 'StudlyCase',
+        'lowercase' => 'lowercase',
+        'UPPERCASE' => 'UPPERCASE',
         'i_provided' => 'provided',
     ]);
 
@@ -343,10 +353,14 @@ it('has a mappers built in', function () {
         'camelCase' => 'camelCase',
         'snake_case' => 'snake_case',
         'StudlyCase' => 'StudlyCase',
+        'lowercase' => 'lowercase',
+        'UPPERCASE' => 'UPPERCASE',
         'i_provided' => 'provided',
     ]))
         ->camel_case->toBe('camelCase')
         ->snakeCase->toBe('snake_case')
         ->studly_case->toBe('StudlyCase')
+        ->lowercase->toBe('lowercase')
+        ->uppercase->toBe('UPPERCASE')
         ->provided->toBe('provided');
 });


### PR DESCRIPTION
In some projects there was a need to use such mappers and I created them in the application. Then I thought that they could be added to the package. Hope this helps :)

I also added information about available mappers with usage examples to the [documentation](https://spatie.be/docs/laravel-data/v4/as-a-data-transfer-object/mapping-property-names) page.

> ![image](https://github.com/user-attachments/assets/9ae3b74c-8a74-40e3-95f7-b400626bf786)
