### PR TITLE
Add phpdoc to `TransformableData.php`

### DIFF
--- a/src/Concerns/TransformableData.php
+++ b/src/Concerns/TransformableData.php
@@ -7,13 +7,18 @@ use Spatie\LaravelData\Contracts\BaseData as BaseDataContract;
 use Spatie\LaravelData\Contracts\BaseDataCollectable as BaseDataCollectableContract;
 use Spatie\LaravelData\Contracts\ContextableData as ContextableDataContract;
 use Spatie\LaravelData\Contracts\IncludeableData as IncludeableDataContract;
+use Spatie\LaravelData\Exceptions\MaxTransformationDepthReached;
 use Spatie\LaravelData\Support\DataContainer;
 use Spatie\LaravelData\Support\EloquentCasts\DataEloquentCast;
 use Spatie\LaravelData\Support\Transformation\TransformationContext;
 use Spatie\LaravelData\Support\Transformation\TransformationContextFactory;
+use TypeError;
 
 trait TransformableData
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function transform(
         null|TransformationContextFactory|TransformationContext $transformationContext = null,
     ): array {
@@ -39,11 +44,17 @@ trait TransformableData
         return $resolver->execute($this, $transformationContext);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function all(): array
     {
         return $this->transform(TransformationContextFactory::create()->withValueTransformation(false));
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         return $this->transform();
@@ -54,6 +65,9 @@ trait TransformableData
         return json_encode($this->transform(), $options);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return $this->transform();

--- a/src/Concerns/TransformableData.php
+++ b/src/Concerns/TransformableData.php
@@ -17,7 +17,7 @@ use TypeError;
 trait TransformableData
 {
     /**
-     * @return array<string, mixed>
+     * @return array<array-key, mixed>
      */
     public function transform(
         null|TransformationContextFactory|TransformationContext $transformationContext = null,
@@ -45,17 +45,14 @@ trait TransformableData
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<array-key, mixed>
      */
     public function all(): array
     {
         return $this->transform(TransformationContextFactory::create()->withValueTransformation(false));
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function toArray(): array
+    public function toArray()
     {
         return $this->transform();
     }
@@ -66,7 +63,7 @@ trait TransformableData
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<array-key, mixed>
      */
     public function jsonSerialize(): array
     {

--- a/src/Contracts/TransformableData.php
+++ b/src/Contracts/TransformableData.php
@@ -11,16 +11,28 @@ use Spatie\LaravelData\Support\Transformation\TransformationContextFactory;
 
 interface TransformableData extends JsonSerializable, Jsonable, Arrayable, EloquentCastable
 {
+    /**
+     * @return array<array-key, mixed>
+     */
     public function transform(
         null|TransformationContextFactory|TransformationContext $transformationContext = null,
     ): array;
 
+    /**
+     * @return array<array-key, mixed>
+     */
     public function all(): array;
 
+    /**
+     * @return array<array-key, mixed>
+     */
     public function toArray(): array;
 
     public function toJson($options = 0): string;
 
+    /**
+     * @return array<array-key, mixed>
+     */
     public function jsonSerialize(): array;
 
     public static function castUsing(array $arguments);


### PR DESCRIPTION
I was running into an issue with phpstan on level 10, when I try to create an object using the `toArray()` method.

The code I have looks like this: 
```
Model::create($data->toArray())
```

This results in the following error:

```
Model>>::create() expects array<string, mixed>, array<mixed> given.
```

Adding phpdoc to the definition of the class should fix this issue. 
Since I was already touching this concern, I decided to add the phpdoc to the other methods returning arrays as well.