### PR TITLE
Clear up confusion

### DIFF
--- a/docs/advanced-usage/creating-a-cast.md
+++ b/docs/advanced-usage/creating-a-cast.md
@@ -74,7 +74,7 @@ use Spatie\LaravelData\Casts\Castable;
 use Spatie\LaravelData\Support\Creation\CreationContext;
 use Spatie\LaravelData\Support\DataProperty;
 
-class Email implements Castable
+class Email extends Data implements Castable
 {
   public function __construct(public string $email) {
 


### PR DESCRIPTION
I was reading through the docs on [Castables](https://spatie.be/docs/laravel-data/v4/advanced-usage/creating-a-cast#content-castables) and didn't quite grasp the concept and use case until @edalzell explained that it's an interface that can be used on a DTO to have the castable logic all in one place. This would have been clear to me if the example was extending the `Data` class. Thus, this small PR to clear up any confusion.