### PR TITLE
Introduce FromHeaderParameter Attribute: Map Header to DTO Prop

### DIFF
--- a/src/Attributes/FromHeaderParameter.php
+++ b/src/Attributes/FromHeaderParameter.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Spatie\LaravelData\Attributes;
+
+use Attribute;
+use Spatie\LaravelData\Attributes\InjectsPropertyValue;
+use Illuminate\Http\Request;
+use Spatie\LaravelData\Support\Creation\CreationContext;
+use Spatie\LaravelData\Support\DataProperty;
+use Spatie\LaravelData\Support\Skipped;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class FromHeaderParameter implements InjectsPropertyValue
+{
+    public function __construct(
+        public string $headerParameter,
+        public bool $replaceWhenPresentInPayload = true,
+        /** @deprecated  */
+        public bool $replaceWhenPresentInBody = true
+    ) {
+    }
+
+    public function resolve(
+        DataProperty $dataProperty,
+        mixed $payload,
+        array $properties,
+        CreationContext $creationContext
+    ): mixed {
+        if (! $payload instanceof Request) {
+            return Skipped::create();
+        }
+
+        $parameter = $payload->header($this->headerParameter);
+
+        if ($parameter === null) {
+            return Skipped::create();
+        }
+
+        return $parameter;
+    }
+
+    public function shouldBeReplacedWhenPresentInPayload(): bool
+    {
+        return $this->replaceWhenPresentInPayload && $this->replaceWhenPresentInBody;
+    }
+}

--- a/src/Attributes/FromHeaderParameterProperty.php
+++ b/src/Attributes/FromHeaderParameterProperty.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spatie\LaravelData\Attributes;
+
+use Attribute;
+use Spatie\LaravelData\Attributes\Concerns\ResolvesPropertyForInjectedValue;
+use Spatie\LaravelData\Support\Creation\CreationContext;
+use Spatie\LaravelData\Support\DataProperty;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class FromHeaderParameterProperty extends FromHeaderParameter
+{
+    use ResolvesPropertyForInjectedValue;
+
+    public function __construct(
+        string $headerParameter,
+        public ?string $property = null,
+        bool $replaceWhenPresentInPayload = true,
+        /** @deprecated  */
+        bool $replaceWhenPresentInBody = true
+    ) {
+        parent::__construct($headerParameter, $replaceWhenPresentInPayload, $replaceWhenPresentInBody);
+    }
+
+    public function resolve(
+        DataProperty $dataProperty,
+        mixed $payload,
+        array $properties,
+        CreationContext $creationContext
+    ): mixed {
+        return $this->resolvePropertyForInjectedValue(
+            $dataProperty,
+            $payload,
+            $properties,
+            $creationContext
+        );
+    }
+
+    protected function getPropertyKey(): string|null
+    {
+        return $this->property;
+    }
+}


### PR DESCRIPTION
Map header input to data prop for some scenarios like: 
- send Binary Files using `HEAD` HTTP Method so other info should be sent via Headers
- map user insenstive headers like Language to DTO prop