### PR TITLE
[Documentation] Add missing commas in example constructor parameter

### DIFF
--- a/docs/advanced-usage/eloquent-casting.md
+++ b/docs/advanced-usage/eloquent-casting.md
@@ -55,7 +55,7 @@ abstract class RecordConfig extends Data
 class CdRecordConfig extends RecordConfig
 {
     public function __construct(
-        int $tracks
+        int $tracks,
         public int $bytes,
     ) {
         parent::__construct($tracks);
@@ -65,7 +65,7 @@ class CdRecordConfig extends RecordConfig
 class VinylRecordConfig extends RecordConfig
 {
     public function __construct(
-        int $tracks
+        int $tracks,
         public int $rpm,
     ) {
         parent::__construct($tracks);


### PR DESCRIPTION
Documentation about the Abstract data objects was missing a comma in the example snippets, so this PR adds them.