### PR TITLE
Fix data stub spacing

### DIFF
--- a/stubs/data.stub
+++ b/stubs/data.stub
@@ -7,6 +7,6 @@ use Spatie\LaravelData\Data;
 class DummyClass extends Data
 {
     public function __construct(
-      //
+        //
     ) {}
 }


### PR DESCRIPTION
This PR updates the default spacing in data.stub from 2 to 4 spaces to match the spacing used in other stub files. This is used when generating new data objects with the artisan command make:data.