### PR TITLE
Fix a display error in the docs

### DIFF
--- a/docs/validation/manual-rules.md
+++ b/docs/validation/manual-rules.md
@@ -56,9 +56,9 @@ class SongData extends Data
 
 As a rule of thumb always follow these rules:
 
-> Always use the array syntax for defining rules and not a single string which spits the rules by | characters.
-> This is needed when using regexes those | can be seen as part of the regex
- 
+Always use the array syntax for defining rules and not a single string which spits the rules by | characters.
+This is needed when using regexes those | can be seen as part of the regex
+
 ## Merging manual rules
 
 Writing manual rules doesn't mean that you can't use the automatic rules inferring anymore. By adding the `MergeValidationRules` attribute to your data class, the rules will be merged:


### PR DESCRIPTION

* Removed the > character as it doesn't seem to be used anywhere else either

Noticed an gapping issue in the docs, it displayed fine in PHPStorms markdown simulator, so maybe an underlying issue with the docs engine.

I think just removing the > character should fix it.

![Screenshot 2025-02-18 at 19 47 14](https://github.com/user-attachments/assets/289e1b88-6709-4b75-b356-d9137918322c)
