### PR TITLE
Add EmptyString support for Formik compatibility

### DIFF
--- a/src/Concerns/EmptyStringData.php
+++ b/src/Concerns/EmptyStringData.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\LaravelData\Concerns;
+
+use Spatie\LaravelData\Resolvers\EmptyDataResolver;
+
+trait EmptyStringData
+{
+    use EmptyData;
+    public static function emptyString(array $extra = []): array
+    {
+        return app(EmptyDataResolver::class)->execute(static::class, $extra, '');
+    }
+}

--- a/src/Contracts/EmptyStringData.php
+++ b/src/Contracts/EmptyStringData.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\LaravelData\Contracts;
+
+interface EmptyStringData
+{
+    public static function empty(array $extra = []): array;
+}

--- a/src/Data.php
+++ b/src/Data.php
@@ -7,6 +7,7 @@ use Spatie\LaravelData\Concerns\AppendableData;
 use Spatie\LaravelData\Concerns\BaseData;
 use Spatie\LaravelData\Concerns\ContextableData;
 use Spatie\LaravelData\Concerns\EmptyData;
+use Spatie\LaravelData\Concerns\EmptyStringData;
 use Spatie\LaravelData\Concerns\IncludeableData;
 use Spatie\LaravelData\Concerns\ResponsableData;
 use Spatie\LaravelData\Concerns\TransformableData;
@@ -16,13 +17,14 @@ use Spatie\LaravelData\Contracts\AppendableData as AppendableDataContract;
 use Spatie\LaravelData\Contracts\BaseData as BaseDataContract;
 use Spatie\LaravelData\Contracts\ContextableData as ContextableDataContract;
 use Spatie\LaravelData\Contracts\EmptyData as EmptyDataContract;
+use Spatie\LaravelData\Contracts\EmptyStringData as EmptyStringDataContract;
 use Spatie\LaravelData\Contracts\IncludeableData as IncludeableDataContract;
 use Spatie\LaravelData\Contracts\ResponsableData as ResponsableDataContract;
 use Spatie\LaravelData\Contracts\TransformableData as TransformableDataContract;
 use Spatie\LaravelData\Contracts\ValidateableData as ValidateableDataContract;
 use Spatie\LaravelData\Contracts\WrappableData as WrappableDataContract;
 
-abstract class Data implements Responsable, AppendableDataContract, BaseDataContract, TransformableDataContract, ContextableDataContract, IncludeableDataContract, ResponsableDataContract, ValidateableDataContract, WrappableDataContract, EmptyDataContract
+abstract class Data implements Responsable, AppendableDataContract, BaseDataContract, TransformableDataContract, ContextableDataContract, IncludeableDataContract, ResponsableDataContract, ValidateableDataContract, WrappableDataContract, EmptyDataContract, EmptyStringDataContract
 {
     use ResponsableData;
     use IncludeableData;
@@ -32,5 +34,6 @@ abstract class Data implements Responsable, AppendableDataContract, BaseDataCont
     use TransformableData;
     use BaseData;
     use EmptyData;
+    use EmptyStringData;
     use ContextableData;
 }

--- a/src/Resolvers/EmptyDataResolver.php
+++ b/src/Resolvers/EmptyDataResolver.php
@@ -15,7 +15,7 @@ class EmptyDataResolver
     {
     }
 
-    public function execute(string $class, array $extra = []): array
+    public function execute(string $class, array $extra = [], string|null $defaultValue = null): array
     {
         $dataClass = $this->dataConfig->getDataClass($class);
 
@@ -27,19 +27,19 @@ class EmptyDataResolver
             if ($property->hasDefaultValue) {
                 $payload[$name] = $property->defaultValue;
             } else {
-                $payload[$name] = $extra[$property->name] ?? $this->getValueForProperty($property);
+                $payload[$name] = $extra[$property->name] ?? $this->getValueForProperty($property, $defaultValue);
             }
         }
 
         return $payload;
     }
 
-    protected function getValueForProperty(DataProperty $property): ?array
+    protected function getValueForProperty(DataProperty $property, string|null $defaultValue = null): null|array|string
     {
         $propertyType = $property->type;
 
         if ($propertyType->isMixed) {
-            return null;
+            return $defaultValue;
         }
 
         if ($propertyType->type instanceof CombinationType && count($propertyType->type->types) > 1) {
@@ -67,6 +67,6 @@ class EmptyDataResolver
             return [];
         }
 
-        return null;
+        return $defaultValue;
     }
 }


### PR DESCRIPTION
# Add EmptyString support for Formik compatibility

## Description

Added support for generating Data Transfer Objects (DTOs) with empty string values instead of null values. This enhancement is particularly useful when working with Formik and Inertia.js in Laravel applications.

## Features
- New `EmptyStringData` trait and interface
- Extended `EmptyDataResolver` with empty string support
- Static method `emptyString()` that returns DTO with empty strings as default values

## Use Case
When working with Formik forms in React + Inertia.js + Laravel applications, you often need to provide initial values for form fields. Using null values with Formik can cause errors as Formik expects string values for its form fields. Previously, you would need to:

```php
// Before
UserStoreData::empty([
    'name' => '',
    'email' => '',
    'address' => '',
    // ... many more fields
]);
```
Now you can simply use:
```php
// After
UserStoreData::emptyString();
```
This is particularly beneficial for large DTOs where manually defining empty values for each field would be tedious and error-prone.
Example with [formik](https://formik.org/), [spatie/laravel-typescript-transformer](https://github.com/spatie/laravel-typescript-transformer) and inertia.js:

Controller:
```php
public function create(): Response
{
    return Inertia::render('Users/UserStorePage', [
        'user' => UserStoreData::form(),
    ]);
}
```

```tsx
const UserStorePage: React.FC<{user: UserStoreData}> = ({ user }) => {
    const handleUserStore = (values: UserStoreData, actions: FormikHelpers<UserStoreData>) => {
        /* store method content */
    };

    return <Formik initialValues={user} onSubmit={handleUserStore}>

    </Formik>
};

export default UserStorePage;
```
## Changes 
- Added `EmptyStringData` trait and interface
- Extended `EmptyDataResolver` with `defaultValue` parameter
- Updated base `Data` class to implement `EmptyStringData`

## Breaking Changes
None. This is a backwards-compatible enhancement.