### PR TITLE
Fix Data Class Discovery for Data Classes

### DIFF
--- a/src/Support/Caching/DataClassFinder.php
+++ b/src/Support/Caching/DataClassFinder.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\LaravelData\Support\Caching;
 
-use Spatie\LaravelData\Contracts\BaseData;
+use Spatie\LaravelData\Data;
 use Spatie\StructureDiscoverer\Discover;
 
 class DataClassFinder
@@ -31,7 +31,7 @@ class DataClassFinder
     public function classes(): array
     {
         $discoverer = Discover::in(...$this->directories)
-            ->implementing(BaseData::class);
+            ->extending(Data::class);            
 
         if ($this->useReflection) {
             $discoverer->useReflection($this->reflectionBasePath, $this->reflectionRootNamespace);


### PR DESCRIPTION
This PR addresses the issue described in [#962](https://github.com/spatie/laravel-data/issues/962) where Data classes from external packages were not being discovered when added to the caching directories.

## Summary of Changes

- **Discovery Logic Update:**  
  Changed the discovery logic in `DataClassFinder.php` to check for classes extending the `Data` class instead of verifying an implementation of the `BaseData` interface.  
  This update ensures that both local and package Data classes are correctly identified and cached when `reflection_discovery` is disabled.

Fixes [#962](https://github.com/spatie/laravel-data/issues/962).