### PR TITLE
add support for variadic parameter

### DIFF
--- a/tests/CreationTest.php
+++ b/tests/CreationTest.php
@@ -1452,3 +1452,21 @@ it('can use auto lazy to construct a when loaded lazy with a manual defined rela
         ->toHaveCount(2)
         ->each()->toBeInstanceOf(FakeNestedModelData::class);
 });
+
+it('can be created using variadic argument', function () {
+    class ExtendedData extends SimpleData
+    {
+        public function __construct(public string $name, ...$variadic)
+        {
+            parent::__construct(...$variadic);
+        }
+    }
+
+    $extendedData = ExtendedData::from([
+        'name' => 'Wrapper name',
+        'string' => 'SimpleData string',
+    ]);
+
+    expect($extendedData)->name->toEqual("Wrapper name")
+        ->string->toEqual("SimpleData string");
+});


### PR DESCRIPTION
Dear Reviewers,

I found a particular use case where I had a Data class with many parameters and two child classes extending it by adding more detailed parameters. Using the variadic parameter would have made it much easier to pass parameters to the parent constructor without replicating them in the child constructors. I believe this functionality was available in older versions (when reflection read the class properties instead of the constructor), and I looked for related issues but found nothing.
Let me know what you think and whether you believe it could be useful to include in the package.

**Current status**
```
class SimpleData extends Data 
    {
        public function __construct(public string $string)
        {
            parent::__construct(...$variadic);
        }
    }
class ExtendedData extends SimpleData
    {
        public function __construct(public string $name, ...$variadic)
        {
            parent::__construct(...$variadic);
        }
    }

$obj = ExtendedData::from([
        'name' => 'Wrapper name',
        'string' => 'SimpleData string',
    ]);
```

Currently raises this error:
```
the constructor requires 2 parameters, 1 given. Parameters given: name. Parameters missing: variadic
```

**Applying this fix**
```
$obj->name === 'Wrappr name';
$obj->string === 'SimpleData string'
```
as expected.

**Why support variadic parameters?**
It allows for easier extension of Data objects and passing parameters to the parent without specifying them again in the child constructor. Additionally, it enables the use of a standard PHP feature, avoiding the need to throw an exception.