### PR TITLE
Add dataClass to normalize exception message

### DIFF
--- a/src/Resolvers/DataCollectableFromSomethingResolver.php
+++ b/src/Resolvers/DataCollectableFromSomethingResolver.php
@@ -155,7 +155,7 @@ class DataCollectableFromSomethingResolver
             return [];
         }
 
-        throw new Exception('Unable to normalize items');
+        throw new Exception("Unable to normalize items in {$dataClass}");
     }
 
     protected function normalizeToArray(


### PR DESCRIPTION
I ran into an issue when using this package when trying to convert a large nested object. It presented the exception message 'Unable to normalize items', but it didn't specify where the issue was occurring, making it difficult to debug the issue and find where the error was in my code. 

This change adds the `$dataClass` string that is passed into the normalizeItems() method to the exception message to make it easier to debug and find the effected class. 