### PR TITLE
Update ide.json

### DIFF
--- a/ide.json
+++ b/ide.json
@@ -16,18 +16,31 @@
                     "place": "arrayKey"
                 },
                 {
-                    "methodNames": ["collection"],
+                    "methodNames": ["empty"],
+                    "classFqn": ["\\Spatie\\LaravelData\\Concerns\\EmptyData"],
+                    "place": "arrayKey"
+                },
+                {
+                    "methodNames": ["collect"],
                     "classFqn": ["\\Spatie\\LaravelData\\Concerns\\BaseData"],
                     "place": "arrayInArrayKey"
                 },
                 {
-                    "methodNames": ["include", "exclude", "only", "except"],
-                    "classFqn": ["\\Spatie\\LaravelData\\Concerns\\IncludeableData"],
+                    "methodNames": ["collection"],
+                    "classFqn": ["\\Spatie\\LaravelData\\Concerns\\WithDeprecatedCollectionMethod"],
+                    "place": "arrayInArrayKey"
+                },
+                {
+                    "methodNames": [
+                        "include", "exclude", "only", "except",
+                        "includePermanently", "excludePermanently", "onlyPermanently", "exceptPermanently"
+                    ],
+                    "classParentFqn": ["\\Spatie\\LaravelData\\Concerns\\IncludeableData"],
                     "place": "parameter"
                 },
                 {
                     "methodNames": ["includeWhen", "excludeWhen", "onlyWhen", "exceptWhen"],
-                    "classFqn": ["\\Spatie\\LaravelData\\Concerns\\IncludeableData"],
+                    "classParentFqn": ["\\Spatie\\LaravelData\\Concerns\\IncludeableData"],
                     "place": "parameter",
                     "parameters": [1]
                 }


### PR DESCRIPTION
This is a configuration file for the Laravel Idea Plugin (for PHPStorm). With the correct configuration, it can automatically suggest properties defined in the Data when using certain methods.

The previous ide.json used classFqn, which seems not to work well with the latest version of Laravel Idea in PHPStorm. Upon reviewing the Laravel Idea schema, I found that classParentFqn exists and appears to be effective in my case.

Note that, according to the Laravel Idea plugin's [documentation](https://laravel-idea.com/docs/ide_json/completion#methods), classParentFqn may add some overhead.

Previously, it seems that only from/optional worked correctly, but now I've added several new methods, such as empty and some Permanently methods.

---

When using WithDeprecatedCollectionMethod, some new properties are added due to annotations. Using own here can be a good solution, but this will break #307, so I still plan to use all.

all:
![image](https://github.com/user-attachments/assets/2be1372b-7e91-4079-98e8-ff3c5de84973)

own:

![image](https://github.com/user-attachments/assets/d5120952-d726-49b8-a615-7877468760a7)

---

Here are some practical examples of usage:

![image](https://github.com/user-attachments/assets/a645595e-44bd-4a9e-bf83-904112459819)

![image](https://github.com/user-attachments/assets/751591f0-e4f8-4d47-87bf-7316db1871d2)

![image](https://github.com/user-attachments/assets/e3ca1b9f-8be4-43ff-9c04-ba3002d05a92)

![image](https://github.com/user-attachments/assets/27de12c5-0e58-4109-9550-0cfa7a1eb5c3)
