### PR TITLE
Add ComparableData trait with equalTo() method for value comparison

### DIFF
--- a/docs/advanced-usage/comparing-data-objects.md
+++ b/docs/advanced-usage/comparing-data-objects.md
@@ -1,6 +1,6 @@
 ---
 title: Comparing data objects
-weight: 20
+weight: 15
 ---
 
 ## Comparing data objects

--- a/docs/advanced-usage/comparing-data-objects.md
+++ b/docs/advanced-usage/comparing-data-objects.md
@@ -1,0 +1,23 @@
+---
+title: Comparing data objects
+weight: 20
+---
+
+## Comparing data objects
+
+The package provides a way to compare data objects with each other using the `ComparableData` trait and interface. This is helpful when you need to determine if two data objects have the same values, regardless of whether they are the same instance.
+
+The `equalTo` method compares two data objects by comparing their array representations. This means that two data objects are considered equal if their `toArray()` method returns the same array.
+
+Both the `Spatie\LaravelData\Data` and `Spatie\LaravelData\Resource` classes implement the `ComparableData` interface and use the `ComparableData` trait.
+
+### Basic usage
+
+You can use the `equalTo` method to compare two data objects:
+
+```php
+$data1 = new UserData(name: 'John', email: 'john@example.com');
+$data2 = new UserData(name: 'John', email: 'john@example.com');
+
+$data1->equalTo($data2); // true
+```

--- a/docs/advanced-usage/comparing-data-objects.md
+++ b/docs/advanced-usage/comparing-data-objects.md
@@ -16,8 +16,20 @@ Both the `Spatie\LaravelData\Data` and `Spatie\LaravelData\Resource` classes imp
 You can use the `equalTo` method to compare two data objects:
 
 ```php
-$data1 = new UserData(name: 'John', email: 'john@example.com');
-$data2 = new UserData(name: 'John', email: 'john@example.com');
+class UserData extends Data
+{
+    public function __construct(
+        public int $id,
+        public string|Optional $name = new Optional,
+    ) {}
+}
 
+$data1 = new UserData(id: 10);
+$data2 = UserData::from($data1);
+
+// Default PHP comparison
+$data1 == $data2; // false
+
+// New value comparison
 $data1->equalTo($data2); // true
 ```

--- a/docs/advanced-usage/internal-structures.md
+++ b/docs/advanced-usage/internal-structures.md
@@ -23,6 +23,7 @@ The DataClass represents the structure of a data object and has the following pr
 - `validatable` is the class implementing `ValidatableData`
 - `wrappable` is the class implementing `WrappableData`
 - `emptyData` the the class implementing `EmptyData`
+- `comparableData` the the class implementing `ComparableData`
 - `attributes` a collection of resolved attributes assigned to the class
 - `dataCollectablePropertyAnnotations` the property annotations of the class used to infer the data collection type
 - `allowedRequestIncludes` the allowed request includes of the class

--- a/docs/advanced-usage/traits-and-interfaces.md
+++ b/docs/advanced-usage/traits-and-interfaces.md
@@ -18,16 +18,19 @@ use Spatie\LaravelData\Concerns\ResponsableData;
 use Spatie\LaravelData\Concerns\TransformableData;
 use Spatie\LaravelData\Concerns\ValidateableData;
 use Spatie\LaravelData\Concerns\WrappableData;
+use Spatie\LaravelData\Concerns\ComparableData;
 use Spatie\LaravelData\Contracts\AppendableData as AppendableDataContract;
 use Spatie\LaravelData\Contracts\BaseData as BaseDataContract;
+use Spatie\LaravelData\Contracts\ContextableData as ContextableDataContract;
 use Spatie\LaravelData\Contracts\EmptyData as EmptyDataContract;
 use Spatie\LaravelData\Contracts\IncludeableData as IncludeableDataContract;
 use Spatie\LaravelData\Contracts\ResponsableData as ResponsableDataContract;
 use Spatie\LaravelData\Contracts\TransformableData as TransformableDataContract;
 use Spatie\LaravelData\Contracts\ValidateableData as ValidateableDataContract;
 use Spatie\LaravelData\Contracts\WrappableData as WrappableDataContract;
+use Spatie\LaravelData\Contracts\ComparableData as ComparableDataContract;
 
-abstract class Data implements Responsable, AppendableDataContract, BaseDataContract, TransformableDataContract, IncludeableDataContract, ResponsableDataContract, ValidateableDataContract, WrappableDataContract, EmptyDataContract
+abstract class Data implements Responsable, AppendableDataContract, BaseDataContract, TransformableDataContract, ContextableDataContract, IncludeableDataContract, ResponsableDataContract, ValidateableDataContract, WrappableDataContract, EmptyDataContract, ComparableDataContract
 {
     use ResponsableData;
     use IncludeableData;
@@ -38,6 +41,7 @@ abstract class Data implements Responsable, AppendableDataContract, BaseDataCont
     use BaseData;
     use EmptyData;
     use ContextableData;
+    use ComparableData;
 }
 ```
 
@@ -56,5 +60,6 @@ Each interface (and corresponding trait) provides a piece of functionality:
 - **WrappableData** provides the functionality to wrap the transformed data object/collectable
 - **AppendableData** provides the functionality to append data to the transformed data payload
 - **EmptyData** provides the functionality to get an empty version of the data object
+- **ComparableData** provides the functionality to compare data objects using the `equalTo` method, which checks if two data objects are equal by comparing their array representations
 - **ValidateableData** provides the functionality to validate the data object
 - **DeprecatableData** provides the functionality to add deprecated functionality to the data object

--- a/src/Concerns/ComparableData.php
+++ b/src/Concerns/ComparableData.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\LaravelData\Concerns;
+
+use Spatie\LaravelData\Contracts\TransformableData as TransformableDataContract;
+
+trait ComparableData
+{
+    public function equalTo(TransformableDataContract $other): bool
+    {
+        return $this->toArray() === $other->toArray();
+    }
+}

--- a/src/Contracts/ComparableData.php
+++ b/src/Contracts/ComparableData.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\LaravelData\Contracts;
+
+interface ComparableData
+{
+    public function equalTo(TransformableData $other): bool;
+}

--- a/src/Data.php
+++ b/src/Data.php
@@ -12,6 +12,7 @@ use Spatie\LaravelData\Concerns\ResponsableData;
 use Spatie\LaravelData\Concerns\TransformableData;
 use Spatie\LaravelData\Concerns\ValidateableData;
 use Spatie\LaravelData\Concerns\WrappableData;
+use Spatie\LaravelData\Concerns\ComparableData;
 use Spatie\LaravelData\Contracts\AppendableData as AppendableDataContract;
 use Spatie\LaravelData\Contracts\BaseData as BaseDataContract;
 use Spatie\LaravelData\Contracts\ContextableData as ContextableDataContract;
@@ -21,8 +22,9 @@ use Spatie\LaravelData\Contracts\ResponsableData as ResponsableDataContract;
 use Spatie\LaravelData\Contracts\TransformableData as TransformableDataContract;
 use Spatie\LaravelData\Contracts\ValidateableData as ValidateableDataContract;
 use Spatie\LaravelData\Contracts\WrappableData as WrappableDataContract;
+use Spatie\LaravelData\Contracts\ComparableData as ComparableDataContract;
 
-abstract class Data implements Responsable, AppendableDataContract, BaseDataContract, TransformableDataContract, ContextableDataContract, IncludeableDataContract, ResponsableDataContract, ValidateableDataContract, WrappableDataContract, EmptyDataContract
+abstract class Data implements Responsable, AppendableDataContract, BaseDataContract, TransformableDataContract, ContextableDataContract, IncludeableDataContract, ResponsableDataContract, ValidateableDataContract, WrappableDataContract, EmptyDataContract, ComparableDataContract
 {
     use ResponsableData;
     use IncludeableData;
@@ -33,4 +35,5 @@ abstract class Data implements Responsable, AppendableDataContract, BaseDataCont
     use BaseData;
     use EmptyData;
     use ContextableData;
+    use ComparableData;
 }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -10,6 +10,7 @@ use Spatie\LaravelData\Concerns\IncludeableData;
 use Spatie\LaravelData\Concerns\ResponsableData;
 use Spatie\LaravelData\Concerns\TransformableData;
 use Spatie\LaravelData\Concerns\WrappableData;
+use Spatie\LaravelData\Concerns\ComparableData;
 use Spatie\LaravelData\Contracts\AppendableData as AppendableDataContract;
 use Spatie\LaravelData\Contracts\BaseData as BaseDataContract;
 use Spatie\LaravelData\Contracts\ContextableData as ContextableDataContract;
@@ -18,13 +19,14 @@ use Spatie\LaravelData\Contracts\IncludeableData as IncludeableDataContract;
 use Spatie\LaravelData\Contracts\ResponsableData as ResponsableDataContract;
 use Spatie\LaravelData\Contracts\TransformableData as TransformableDataContract;
 use Spatie\LaravelData\Contracts\WrappableData as WrappableDataContract;
+use Spatie\LaravelData\Contracts\ComparableData as ComparableDataContract;
 use Spatie\LaravelData\DataPipes\CastPropertiesDataPipe;
 use Spatie\LaravelData\DataPipes\DefaultValuesDataPipe;
 use Spatie\LaravelData\DataPipes\FillRouteParameterPropertiesDataPipe;
 use Spatie\LaravelData\DataPipes\InjectPropertyValuesPipe;
 use Spatie\LaravelData\DataPipes\MapPropertiesDataPipe;
 
-class Resource implements BaseDataContract, AppendableDataContract, IncludeableDataContract, TransformableDataContract, ResponsableDataContract, WrappableDataContract, EmptyDataContract, ContextableDataContract
+class Resource implements BaseDataContract, AppendableDataContract, IncludeableDataContract, TransformableDataContract, ResponsableDataContract, WrappableDataContract, EmptyDataContract, ContextableDataContract, ComparableDataContract
 {
     use BaseData;
     use AppendableData;
@@ -34,6 +36,7 @@ class Resource implements BaseDataContract, AppendableDataContract, IncludeableD
     use WrappableData;
     use EmptyData;
     use ContextableData;
+    use ComparableData;
 
     public static function pipeline(): DataPipeline
     {

--- a/tests/ComparableTest.php
+++ b/tests/ComparableTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Optional;
+use Spatie\LaravelData\Resource;
+
+it('can compare data objects with equal property values', function (string $dataClass1, string $dataClass2) {
+    // Basic comparison with scalar properties
+    $data1 = new $dataClass1(id: 10);
+    $data2 = $dataClass2::from($data1);
+
+    // Default PHP object comparison (checks reference equality)
+    expect($data1 == $data2)->toBeFalse();
+
+    // Custom equalTo comparator (checks property value equality)
+    expect($data1->equalTo($data2))->toBeTrue();
+    expect($data2->equalTo($data1))->toBeTrue();
+
+    // Verifies that equalTo returns false when values differ
+    $data2->name = 'a name 2';
+    expect($data1->equalTo($data2))->toBeFalse();
+    expect($data2->equalTo($data1))->toBeFalse();
+})->with([
+    'from same class' => [DataWithOptionalAttribute::class, DataWithOptionalAttribute::class],
+    'from different classes' => [DataWithOptionalAttribute::class, ResourceWithOptionalAttribute::class],
+    'from different classes (reversed)' => [ResourceWithOptionalAttribute::class, DataWithOptionalAttribute::class],
+    'from same class (reversed)' => [ResourceWithOptionalAttribute::class, ResourceWithOptionalAttribute::class],
+]);
+
+class DataWithOptionalAttribute extends Data
+{
+    public function __construct(
+        public int $id,
+        public string|Optional $name = new Optional,
+    ) {}
+}
+
+class ResourceWithOptionalAttribute extends Resource
+{
+    public function __construct(
+        public int $id,
+        public string|Optional $name = new Optional,
+    ) {}
+}

--- a/tests/Support/DataPropertyTypeTest.php
+++ b/tests/Support/DataPropertyTypeTest.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Collection;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Contracts\AppendableData;
 use Spatie\LaravelData\Contracts\BaseData;
+use Spatie\LaravelData\Contracts\ComparableData;
 use Spatie\LaravelData\Contracts\ContextableData;
 use Spatie\LaravelData\Contracts\EmptyData;
 use Spatie\LaravelData\Contracts\IncludeableData;
@@ -801,6 +802,7 @@ it(
                  ValidateableData::class,
                  WrappableData::class,
                  EmptyData::class,
+                 ComparableData::class,
              ],
          ], // expected
     ];


### PR DESCRIPTION
This PR adds a new ComparableData trait and interface that provides an equalTo() method to compare data objects by their values rather than their instances.

# Why?
PHP's default object comparison operator `==` only checks if two objects are the same instance. This limitation becomes particularly problematic when data objects contain special properties like `Optional` attributes.

This new `equalTo()` method allows comparing data objects based on their values by comparing the result of their `toArray()` methods, which correctly handles nested objects, collections, and special types like `Optional`.

# Usage Example

```php
class UserData extends Data
{
    public function __construct(
        public int $id,
        public string|Optional $name = new Optional,
    ) {}
}

$data1 = new UserData(id: 10);
$data2 = UserData::from($data1);

// Default PHP comparison (checks object instance)
$data1 == $data2; // false (different instances)

// New value comparison (checks actual values)
$data1->equalTo($data2); // true (same values)

// When values differ
$data2->name = 'John';
$data1->equalTo($data2); // false (different values)
```
This method is especially useful in testing scenarios or when comparing objects from different sources, including comparing objects with nested data structures or optional properties.