### PR TITLE
Add return type annotations to TransformableData trait

### DIFF
--- a/src/Concerns/TransformableData.php
+++ b/src/Concerns/TransformableData.php
@@ -14,6 +14,12 @@ use Spatie\LaravelData\Support\Transformation\TransformationContextFactory;
 
 trait TransformableData
 {
+    /**
+     * Transform the data object into an array.
+     *
+     * @param null|TransformationContextFactory|TransformationContext $transformationContext
+     * @return array<string, mixed>
+     */
     public function transform(
         null|TransformationContextFactory|TransformationContext $transformationContext = null,
     ): array {
@@ -39,11 +45,21 @@ trait TransformableData
         return $resolver->execute($this, $transformationContext);
     }
 
+    /**
+     * Get all data as an array without transforming values.
+     *
+     * @return array<string, mixed>
+     */
     public function all(): array
     {
         return $this->transform(TransformationContextFactory::create()->withValueTransformation(false));
     }
 
+    /**
+     * Get the data object as an array.
+     *
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         return $this->transform();
@@ -54,6 +70,11 @@ trait TransformableData
         return json_encode($this->transform(), $options);
     }
 
+    /**
+     * Get the data object as an array for JSON serialization.
+     *
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return $this->transform();


### PR DESCRIPTION
This PR adds proper PHPDoc type annotations to the methods in the TransformableData trait to improve static analysis with PHPStan. Specifically:

- Added `@return array<string, mixed>` to `transform()`, `toArray()`, `all()`, and `jsonSerialize()` methods
- These annotations accurately reflect that these methods return associative arrays with string keys and mixed values
- Improves type safety and IDE autocompletion support
- Helps PHPStan better understand the return types for static analysis

The changes are purely documentation improvements with no functional impact.