### PR TITLE
Fix dynamic properties for PHP 8.2

### DIFF
--- a/src/Normalizers/Normalized/NormalizedModel.php
+++ b/src/Normalizers/Normalized/NormalizedModel.php
@@ -13,6 +13,10 @@ class NormalizedModel implements Normalized
 {
     protected array $properties = [];
 
+    protected ReflectionProperty $attributesProperty;
+
+    protected ReflectionProperty $castsProperty;
+
     public function __construct(
         protected Model $model,
     ) {


### PR DESCRIPTION
Hey Spatie, thanks for the great package! 

We're currently upgrading our application and hitting a [deprecation error](https://php.watch/versions/8.2/dynamic-properties-deprecated) due to the use of dynamic properties in Laravel Data. This PR simply adds types for 2 properties, nothing special — let me know if there's any questions! 