### PR TITLE
Add missing payload renormalization for morphDataClass

### DIFF
--- a/src/Resolvers/DataFromSomethingResolver.php
+++ b/src/Resolvers/DataFromSomethingResolver.php
@@ -48,6 +48,9 @@ class DataFromSomethingResolver
 
         if ($morphDataClass = $this->dataMorphClassResolver->execute($dataClass, $normalizedPayloads)) {
             $pipeline = $this->dataConfig->getResolvedDataPipeline($morphDataClass);
+            foreach ($payloads as $i => $payload) {
+                $normalizedPayloads[$i] = $pipeline->normalize($payload ?? []);
+            }
 
             $creationContext->dataClass = $morphDataClass;
             $class = $morphDataClass;


### PR DESCRIPTION
Hey, so I am using abstract data with PropertyMorphableData contract implemented, but when correct data class is resolved, it only contains properties that are defined in that abstract class. This PR fixes that issue by renormalizing payload for correct morphDataClass. It is also a shame that this feature is not documented at all.