### PR TITLE
Ensure toJson and toResponse call jsonSerialize

### DIFF
--- a/src/Concerns/ResponsableData.php
+++ b/src/Concerns/ResponsableData.php
@@ -58,7 +58,7 @@ trait ResponsableData
         }
 
         return new JsonResponse(
-            data: $this->transform($contextFactory),
+            data: $this->jsonSerializeWithTransformationContext($contextFactory),
             status: $this->calculateResponseStatus($request),
         );
     }

--- a/src/Concerns/TransformableData.php
+++ b/src/Concerns/TransformableData.php
@@ -14,6 +14,8 @@ use Spatie\LaravelData\Support\Transformation\TransformationContextFactory;
 
 trait TransformableData
 {
+    protected null|TransformationContextFactory|TransformationContext $_jsonSerializeContextOnce = null;
+
     public function transform(
         null|TransformationContextFactory|TransformationContext $transformationContext = null,
     ): array {
@@ -51,12 +53,25 @@ trait TransformableData
 
     public function toJson($options = 0): string
     {
-        return json_encode($this->transform(), $options);
+        return json_encode($this->jsonSerialize(), $options);
     }
 
     public function jsonSerialize(): array
     {
-        return $this->transform();
+        $transformationContext = $this->_jsonSerializeContextOnce;
+
+        if ($this->_jsonSerializeContextOnce) {
+            $this->_jsonSerializeContextOnce = null;
+        }
+
+        return $this->transform($transformationContext);
+    }
+
+    public function jsonSerializeWithTransformationContext(null|TransformationContextFactory|TransformationContext $transformationContext): array
+    {
+        $this->_jsonSerializeContextOnce = $transformationContext;
+
+        return $this->jsonSerialize();
     }
 
     public static function castUsing(array $arguments)

--- a/src/Contracts/TransformableData.php
+++ b/src/Contracts/TransformableData.php
@@ -23,5 +23,7 @@ interface TransformableData extends JsonSerializable, Jsonable, Arrayable, Eloqu
 
     public function jsonSerialize(): array;
 
+    public function jsonSerializeWithTransformationContext(null|TransformationContextFactory|TransformationContext $transformationContext): array;
+
     public static function castUsing(array $arguments);
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Spatie\LaravelData\Data;
+
+it('calls jsonSerialize when toResponse is invoked', function () {
+
+    $data = new class extends Data
+    {
+        public function jsonSerialize(): array
+        {
+            return [
+                'string' => 'Hello from serialize',
+            ];
+        }
+    };
+
+    expect($data->toResponse(request())->getContent())->toBe('{"string":"Hello from serialize"}');
+});

--- a/tests/TransformationTest.php
+++ b/tests/TransformationTest.php
@@ -133,6 +133,21 @@ it('can transform to JSON', function () {
         ->toEqual(json_encode(SimpleData::from('Hello')));
 });
 
+it('calls jsonSerialize when toJson is invoked', function () {
+
+    $data = new class extends Data
+    {
+        public function jsonSerialize(): array
+        {
+            return [
+                'string' => 'Hello from serialize',
+            ];
+        }
+    };
+
+    expect($data->toJson())->toBe('{"string":"Hello from serialize"}');
+});
+
 it('can use a custom transformer for a data object and/or data collectable', function () {
     $nestedData = new class (42, 'Hello World') extends Data {
         public function __construct(


### PR DESCRIPTION
## Description

I noticed that the `toJson()` and `toResponse()` methods do not use the `jsonSerialize()` method.

This can be problematic in certain use cases. For example, you might override `jsonSerialize()` to transform an empty array into an object to ensure consistent data structures on the frontend.

With this PR, the package will be [more aligned with Laravel's behavior](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Database/Eloquent/Model.php#L1745), which respects the `jsonSerialize()` method in similar scenarios.

### Example

```php
$data = new class extends Data
{
    public function __construct(
        public array $customFields = [],
    ) {}

    public function jsonSerialize(): array
    {
        $array = parent::jsonSerialize();

        // Ensure customFields is always an object
        $array['customFields'] = (object) $array['customFields'];

        return $array;
    }
};

// Current behavior:
json_encode($data);           // {"customFields":{}}
$data->toJson();              // {"customFields":[]}
$data->toResponse(request()); // {"customFields":[]}

// With this PR:
json_encode($data);           // {"customFields":{}}
$data->toJson();              // {"customFields":{}}
$data->toResponse(request()); // {"customFields":{}}
```

As shown, `json_encode($data)` and `$data->toJson()` currently produce inconsistent results. This PR fixes that.

### Implementation Note

To make `toResponse()` respect `jsonSerialize()`, I introduced a new method: `jsonSerializeWithTransformationContext()`. This method may also be useful in other parts of the package, such as:

- [Livewire integration](https://github.com/spatie/laravel-data/blob/main/src/Support/Livewire/LivewireDataSynth.php#L52)
- Possibly other areas as well?