### PR TITLE
Add support for default values on properties for morph

### DIFF
--- a/src/Resolvers/DataMorphClassResolver.php
+++ b/src/Resolvers/DataMorphClassResolver.php
@@ -58,6 +58,15 @@ class DataMorphClassResolver
                 }
             }
 
+            if ($dataProperty->hasDefaultValue) {
+                $morphProperties[$dataProperty->name] = $this->normalizeValue(
+                    $dataProperty,
+                    $dataProperty->defaultValue,
+                );
+
+                continue;
+            }
+
             if ($found === false) {
                 return null;
             }

--- a/tests/CreationTest.php
+++ b/tests/CreationTest.php
@@ -1638,4 +1638,42 @@ describe('property-morphable creation tests', function () {
             ->variant->toEqual(TestPropertyMorphableEnum::B)
             ->b->toEqual('bar');
     });
+
+    it('will allow property-morphable data to be created from a default', function () {
+        abstract class TestAbstractPropertyMorphableDefaultData extends Data implements PropertyMorphableData
+        {
+            public function __construct(
+                #[\Spatie\LaravelData\Attributes\PropertyForMorph]
+                public TestPropertyMorphableEnum $variant = TestPropertyMorphableEnum::A,
+            ) {
+            }
+
+            public static function morph(array $properties): ?string
+            {
+                return match ($properties['variant'] ?? null) {
+                    TestPropertyMorphableEnum::A => TestPropertyMorphableDefaultDataA::class,
+                    default => null,
+                };
+            }
+        }
+
+        class TestPropertyMorphableDefaultDataA extends TestAbstractPropertyMorphableDefaultData
+        {
+            public function __construct(public string $a, public DummyBackedEnum $enum)
+            {
+                parent::__construct(TestPropertyMorphableEnum::A);
+            }
+        }
+
+        $dataA = TestAbstractPropertyMorphableDefaultData::from([
+            'a' => 'foo',
+            'enum' => 'foo',
+        ]);
+
+        expect($dataA)
+            ->toBeInstanceOf(TestPropertyMorphableDefaultDataA::class)
+            ->variant->toEqual(TestPropertyMorphableEnum::A)
+            ->a->toEqual('foo')
+            ->enum->toEqual(DummyBackedEnum::FOO);
+    });
 });

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -2761,6 +2761,10 @@ describe('property-morphable validation tests', function () {
                 'enum' => ['The enum field is required.'],
             ])
             ->assertOk([
+                'a' => 'foo',
+                'enum' => 'foo',
+            ])
+            ->assertOk([
                 'variant' => 'a',
                 'a' => 'foo',
                 'enum' => 'foo',

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -2731,4 +2731,39 @@ describe('property-morphable validation tests', function () {
                 'nestedCollection' => [['variant' => 'a', 'a' => 'foo', 'enum' => 'foo'], ['variant' => 'b', 'b' => 'bar']],
             ]);
     });
+
+    it('can validate property-morphable data with a default', function () {
+        abstract class TestValidationAbstractPropertyMorphableDefaultData extends Data implements PropertyMorphableData
+        {
+            #[\Spatie\LaravelData\Attributes\PropertyForMorph]
+            public TestValidationPropertyMorphableEnum $variant = TestValidationPropertyMorphableEnum::A;
+
+            public static function morph(array $properties): ?string
+            {
+                return match ($properties['variant'] ?? null) {
+                    TestValidationPropertyMorphableEnum::A => TestValidationPropertyMorphableDefaultDataA::class,
+                    default => null,
+                };
+            }
+        }
+
+        class TestValidationPropertyMorphableDefaultDataA extends TestValidationAbstractPropertyMorphableDefaultData
+        {
+            public function __construct(public string $a, public DummyBackedEnum $enum)
+            {
+                $this->variant = TestValidationPropertyMorphableEnum::A;
+            }
+        }
+
+        DataValidationAsserter::for(TestValidationAbstractPropertyMorphableDefaultData::class)
+            ->assertErrors([], [
+                'a' => ['The a field is required.'],
+                'enum' => ['The enum field is required.'],
+            ])
+            ->assertOk([
+                'variant' => 'a',
+                'a' => 'foo',
+                'enum' => 'foo',
+            ]);
+    });
 });


### PR DESCRIPTION
At the moment it isn't possible to add defaults to properties that are used to determine the morph for an abstract class.

While this might not be best practice, this limitation isn't mentioned in the documentation, and it feels like it _should_ work.
It turns out it's pretty easy to add so I think it might be worth including support for!