### PR TITLE
Add null to the list of returnable types in DateTimeInterfaceCast::cast and castIterableItem

### DIFF
--- a/src/Casts/DateTimeInterfaceCast.php
+++ b/src/Casts/DateTimeInterfaceCast.php
@@ -18,12 +18,12 @@ class DateTimeInterfaceCast implements Cast, IterableItemCast
     ) {
     }
 
-    public function cast(DataProperty $property, mixed $value, array $properties, CreationContext $context): DateTimeInterface|Uncastable
+    public function cast(DataProperty $property, mixed $value, array $properties, CreationContext $context): DateTimeInterface|Uncastable|null
     {
         return $this->castValue($this->type ?? $property->type->type->findAcceptedTypeForBaseType(DateTimeInterface::class), $value);
     }
 
-    public function castIterableItem(DataProperty $property, mixed $value, array $properties, CreationContext $context): DateTimeInterface|Uncastable
+    public function castIterableItem(DataProperty $property, mixed $value, array $properties, CreationContext $context): DateTimeInterface|Uncastable|null
     {
         return $this->castValue($property->type->iterableItemType, $value);
     }


### PR DESCRIPTION
I've added null to the list of return types so that it matches the return types from `DateTimeInterfaceCast::castValue`. This enables subclasses to be able to do this https://github.com/spatie/laravel-data/discussions/205#discussioncomment-11942763 in v4