### PR TITLE
Add the possibibilty to expcet key for empty data generation

### DIFF
--- a/src/Concerns/EmptyData.php
+++ b/src/Concerns/EmptyData.php
@@ -6,8 +6,13 @@ use Spatie\LaravelData\Resolvers\EmptyDataResolver;
 
 trait EmptyData
 {
-    public static function empty(array $extra = [], mixed $replaceNullValuesWith = null): array
+    public static function empty(array $extra = [], mixed $replaceNullValuesWith = null, array $except = []): array
     {
-        return app(EmptyDataResolver::class)->execute(static::class, $extra, $replaceNullValuesWith);
+        $emptyData = app(EmptyDataResolver::class)->execute(static::class, $extra, $replaceNullValuesWith);
+        if(count($except) === 0) {
+            return $emptyData;
+        }
+
+        return array_diff_key($emptyData, array_flip($except));
     }
 }

--- a/tests/EmptyTest.php
+++ b/tests/EmptyTest.php
@@ -5,6 +5,7 @@ use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\DataCollection;
 use Spatie\LaravelData\Lazy;
+use Spatie\LaravelData\Tests\Fakes\MultiData;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
 
 it('can get the empty version of a data object', function () {
@@ -51,4 +52,17 @@ it('can overwrite properties in an empty version of a data object', function () 
     expect(SimpleData::empty(['string' => 'Ruben']))->toMatchArray([
         'string' => 'Ruben',
     ]);
+});
+
+it('can remove properties in an empty version of a data object', function () {
+    expect(MultiData::empty(except: ['second']))
+        ->toHaveKey('first')
+    ->not->toHaveKey('second');
+
+    expect(MultiData::empty(extra: ['second' => 'Ruben'], except:['first']))
+        ->toHaveKey('second')
+        ->not->toHaveKey('first')
+        ->toMatchArray([
+            'second' => 'Ruben',
+        ]);
 });


### PR DESCRIPTION
In a scenario where you use sole properties to generate complex data you can come across a situation where you want to use `::empty()` to have a blueprint for your UI but cannot pass a value from the frontend.

For example:

```php
class TenantData extends Data
{
    public string|Optional $database;

    public function __construct(
        public string $name = 'Rick Astley',
    ) {
        $this->database =  Str::random(8);
    }
}

```

For the UI you want to use the `TenantData::empty()` to provide a blueprint.
With the current implementation this results in:
```php
$emptyData = [
    'database' => null,
    'name' => null,
];
```

With this PR you can pass an array with keys to except from the emptyData array like:
```php
$emptyData = TenantData::empty(except: ['database']);

$emptyData === [ 'name' => null ];
```