### PR TITLE
Enhance CannotCastEnum exception message to include property name

### DIFF
--- a/src/Exceptions/CannotCastEnum.php
+++ b/src/Exceptions/CannotCastEnum.php
@@ -6,8 +6,8 @@ use Exception;
 
 class CannotCastEnum extends Exception
 {
-    public static function create(string $type, mixed $value): self
+    public static function create(string $type, mixed $value, string $propertyName): self
     {
-        return new self("Could not cast enum: `{$value}` into a `{$type}`");
+        return new self("Could not cast enum (`{$propertyName}`): `{$value}` into a `{$type}`");
     }
 }


### PR DESCRIPTION
When casting Enums, specially in nested objects, it quickly becomes cumbersome to figure out which parameter needs to be adjusted.
Currently it generates messages like:
`Could not cast enum: `` into a `EnumClass`.
Afetr merging this PR, it will include the property name too.