### PR TITLE
Improve validation performance - add cache (PoC - needs feedback)

### DIFF
--- a/src/Support/DataClass.php
+++ b/src/Support/DataClass.php
@@ -27,6 +27,7 @@ class DataClass
         public readonly bool $validateable,
         public readonly bool $wrappable,
         public readonly bool $emptyData,
+        public readonly bool $hasDynamicValidationRules,
         public readonly DataAttributesCollection $attributes,
         public readonly array $dataIterablePropertyAnnotations,
         public DataStructureProperty $allowedRequestIncludes,

--- a/src/Support/Factories/DataClassFactory.php
+++ b/src/Support/Factories/DataClassFactory.php
@@ -93,6 +93,7 @@ class DataClassFactory
             validateable: $reflectionClass->implementsInterface(ValidateableData::class),
             wrappable: $reflectionClass->implementsInterface(WrappableData::class),
             emptyData: $reflectionClass->implementsInterface(EmptyData::class),
+            hasDynamicValidationRules: method_exists($reflectionClass->name, 'rules'),
             attributes: $attributes,
             dataIterablePropertyAnnotations: $dataIterablePropertyAnnotations,
             allowedRequestIncludes: new LazyDataStructureProperty(fn (): ?array => $responsable ? $name::allowedRequestIncludes() : null),


### PR DESCRIPTION
Here is the additional PoC for adding a simple cache for static rules as extended logic to PR #1043 

Please share feedback as it's potentially a bit "hardcoded" with a list of unsafe rules to cache, maybe there is some better approach. 

But the positive thing is that using the same benchmark as in PR #1043 it saves additionally 20% (around 200ms in time instead of about 258ms.