### PR TITLE
Add support for expanding dot notation in Data objects and TypeScript transformer

### DIFF
--- a/config/data.php
+++ b/config/data.php
@@ -29,6 +29,12 @@ return [
          * ignore the value being passed into the computed property and recalculate it.
          */
         'ignore_exception_when_trying_to_set_computed_property_value' => false,
+
+        /*
+         * When enabled, the package will expand attributes that use dot notation
+         * to access nested array values (e.g., 'user.name' will access $array['user']['name']).
+         */
+        'expand_dot_notation' => false,
     ],
 
     /*

--- a/config/data.php
+++ b/config/data.php
@@ -29,12 +29,6 @@ return [
          * ignore the value being passed into the computed property and recalculate it.
          */
         'ignore_exception_when_trying_to_set_computed_property_value' => false,
-
-        /*
-         * When enabled, the package will expand attributes that use dot notation
-         * to access nested array values (e.g., 'user.name' will access $array['user']['name']).
-         */
-        'expand_dot_notation' => false,
     ],
 
     /*

--- a/docs/advanced-usage/typescript.md
+++ b/docs/advanced-usage/typescript.md
@@ -128,3 +128,53 @@ class DataObject extends Data
     }
 }
 ```
+
+### Dotted Notation Expansion
+
+When using the `MapOutputName` or `MapName` attributes with dot notation (e.g., 'user.name'), the TypeScript transformer will respect the `expand_dot_notation` configuration setting:
+
+```php
+class UserData extends Data
+{
+    public function __construct(
+        #[MapOutputName('user.name')]
+        public string $name,
+        #[MapOutputName('user.profile.bio')]
+        public string $userBio,
+    ) {
+    }
+}
+```
+
+With `expand_dot_notation` disabled (default), this will generate:
+
+```tsx
+{
+    'user.name': string;
+    'user.profile.bio': string;
+}
+```
+
+When you enable `expand_dot_notation` in your `config/data.php` file:
+
+```php
+'features' => [
+    // Other features...
+    'expand_dot_notation' => true,
+],
+```
+
+The same data object will generate a nested TypeScript interface:
+
+```tsx
+{
+    user: {
+        name: string;
+        profile: {
+            bio: string;
+        };
+    };
+}
+```
+
+This ensures that your TypeScript interfaces match the structure of your JSON output when using dotted notation expansion.

--- a/docs/advanced-usage/typescript.md
+++ b/docs/advanced-usage/typescript.md
@@ -131,50 +131,45 @@ class DataObject extends Data
 
 ### Dotted Notation Expansion
 
-When using the `MapOutputName` or `MapName` attributes with dot notation (e.g., 'user.name'), the TypeScript transformer will respect the `expand_dot_notation` configuration setting:
+By default, dotted notation in property names is kept as-is in TypeScript. You can expand it into nested interfaces using the same **four approaches** as in data transformation:
 
 ```php
 class UserData extends Data
 {
     public function __construct(
-        #[MapOutputName('user.name')]
+        // 1. MapDotExpandedOutputName - output only
+        #[MapDotExpandedOutputName('user.profile.name')]
         public string $name,
-        #[MapOutputName('user.profile.bio')]
-        public string $userBio,
+        
+        // 2. MapDotExpandedName - input & output
+        #[MapDotExpandedName('user.profile.email')]
+        public string $email,
+        
+        // 3. MapOutputName with parameter - output only
+        #[MapOutputName('user.settings.theme', expandDotNotation: true)]
+        public string $theme,
+        
+        // 4. MapName with parameter - input & output
+        #[MapName('user.settings.language', expandDotNotation: true)]
+        public string $language,
     ) {
     }
 }
 ```
 
-With `expand_dot_notation` disabled (default), this will generate:
-
-```tsx
-{
-    'user.name': string;
-    'user.profile.bio': string;
-}
-```
-
-When you enable `expand_dot_notation` in your `config/data.php` file:
-
-```php
-'features' => [
-    // Other features...
-    'expand_dot_notation' => true,
-],
-```
-
-The same data object will generate a nested TypeScript interface:
+This generates nested TypeScript interfaces:
 
 ```tsx
 {
     user: {
-        name: string;
         profile: {
-            bio: string;
+            name: string;
+            email: string;
+        };
+        settings: {
+            theme: string;
+            language: string;
         };
     };
 }
 ```
-
-This ensures that your TypeScript interfaces match the structure of your JSON output when using dotted notation expansion.

--- a/docs/as-a-data-transfer-object/mapping-property-names.md
+++ b/docs/as-a-data-transfer-object/mapping-property-names.md
@@ -92,3 +92,5 @@ SongData::from([
 ```
 
 The package has a set of default mappers available, you can find them [here](/docs/laravel-data/v4/advanced-usage/available-property-mappers).
+
+When transforming data objects with properties that use dotted notation, you can enable the expansion of these properties into nested arrays. See [Expanding Dotted Notation](/docs/laravel-data/v4/as-a-resource/mapping-property-names#expanding-dotted-notation) for more details.

--- a/docs/as-a-resource/mapping-property-names.md
+++ b/docs/as-a-resource/mapping-property-names.md
@@ -85,89 +85,50 @@ The package has a set of default mappers available, you can find them [here](/do
 
 ## Expanding Dotted Notation
 
-When using `MapOutputName` or `MapName` with dot notation (e.g., 'user.name'), by default the package will keep the dotted notation as-is in the output:
+By default, dotted notation in property names (e.g., 'user.name') is kept as-is in the output. You can enable expansion to create nested arrays using **four different approaches**:
 
 ```php
 class UserData extends Data
 {
     public function __construct(
-        #[MapOutputName('user.name')]
+        // 1. MapDotExpandedOutputName - output only, cleaner syntax
+        #[MapDotExpandedOutputName('user.profile.name')]
         public string $name,
+        
+        // 2. MapDotExpandedName - input & output, cleaner syntax
+        #[MapDotExpandedName('user.profile.email')]
+        public string $email,
+        
+        // 3. MapOutputName with parameter - output only, explicit
+        #[MapOutputName('user.settings.theme', expandDotNotation: true)]
+        public string $theme,
+        
+        // 4. MapName with parameter - input & output, explicit
+        #[MapName('user.settings.language', expandDotNotation: true)]
+        public string $language,
     ) {
     }
 }
 ```
 
-When transformed, this will result in:
-
-```php
-[
-    'user.name' => 'John Doe',
-]
-```
-
-However, you can enable the expansion of dotted notation to create nested arrays by setting the `expand_dot_notation` feature flag to `true` in your `config/data.php` file:
-
-```php
-'features' => [
-    // Other features...
-    'expand_dot_notation' => true,
-],
-```
-
-With this feature enabled, the same data object will transform to:
+All four approaches transform to nested arrays:
 
 ```php
 [
     'user' => [
-        'name' => 'John Doe',
-    ],
-]
-```
-
-This feature is particularly useful when you need to generate nested JSON structures from flat data objects or when integrating with APIs that expect nested data.
-
-### Example with Nested Data
-
-Consider a more complex example:
-
-```php
-class OrderData extends Data
-{
-    public function __construct(
-        #[MapOutputName('order.id')]
-        public int $id,
-        #[MapOutputName('order.customer.name')]
-        public string $customerName,
-        #[MapOutputName('order.items')]
-        public array $items,
-    ) {
-    }
-}
-```
-
-With `expand_dot_notation` disabled (default):
-
-```php
-[
-    'order.id' => 1234,
-    'order.customer.name' => 'Jane Smith',
-    'order.items' => ['item1', 'item2'],
-]
-```
-
-With `expand_dot_notation` enabled:
-
-```php
-[
-    'order' => [
-        'id' => 1234,
-        'customer' => [
-            'name' => 'Jane Smith',
+        'profile' => [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
         ],
-        'items' => ['item1', 'item2'],
+        'settings' => [
+            'theme' => 'dark',
+            'language' => 'en',
+        ],
     ],
 ]
 ```
 
-This feature uses Laravel's `Arr::set()` method internally to expand the dotted notation into nested arrays.
+**Choosing the right attribute:**
+- Use `MapDotExpandedOutputName` or `MapOutputName(..., expandDotNotation: true)` for output-only transformation
+- Use `MapDotExpandedName` or `MapName(..., expandDotNotation: true)` for both input mapping and output transformation
+- Dedicated attributes provide cleaner syntax; parameter-based approach offers more flexibility

--- a/docs/as-a-resource/mapping-property-names.md
+++ b/docs/as-a-resource/mapping-property-names.md
@@ -82,3 +82,92 @@ And a transformed version of the data object will look like this:
 ```
 
 The package has a set of default mappers available, you can find them [here](/docs/laravel-data/v4/advanced-usage/available-property-mappers).
+
+## Expanding Dotted Notation
+
+When using `MapOutputName` or `MapName` with dot notation (e.g., 'user.name'), by default the package will keep the dotted notation as-is in the output:
+
+```php
+class UserData extends Data
+{
+    public function __construct(
+        #[MapOutputName('user.name')]
+        public string $name,
+    ) {
+    }
+}
+```
+
+When transformed, this will result in:
+
+```php
+[
+    'user.name' => 'John Doe',
+]
+```
+
+However, you can enable the expansion of dotted notation to create nested arrays by setting the `expand_dot_notation` feature flag to `true` in your `config/data.php` file:
+
+```php
+'features' => [
+    // Other features...
+    'expand_dot_notation' => true,
+],
+```
+
+With this feature enabled, the same data object will transform to:
+
+```php
+[
+    'user' => [
+        'name' => 'John Doe',
+    ],
+]
+```
+
+This feature is particularly useful when you need to generate nested JSON structures from flat data objects or when integrating with APIs that expect nested data.
+
+### Example with Nested Data
+
+Consider a more complex example:
+
+```php
+class OrderData extends Data
+{
+    public function __construct(
+        #[MapOutputName('order.id')]
+        public int $id,
+        #[MapOutputName('order.customer.name')]
+        public string $customerName,
+        #[MapOutputName('order.items')]
+        public array $items,
+    ) {
+    }
+}
+```
+
+With `expand_dot_notation` disabled (default):
+
+```php
+[
+    'order.id' => 1234,
+    'order.customer.name' => 'Jane Smith',
+    'order.items' => ['item1', 'item2'],
+]
+```
+
+With `expand_dot_notation` enabled:
+
+```php
+[
+    'order' => [
+        'id' => 1234,
+        'customer' => [
+            'name' => 'Jane Smith',
+        ],
+        'items' => ['item1', 'item2'],
+    ],
+]
+```
+
+This feature uses Laravel's `Arr::set()` method internally to expand the dotted notation into nested arrays.

--- a/src/Attributes/MapDotExpandedName.php
+++ b/src/Attributes/MapDotExpandedName.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\LaravelData\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
+class MapDotExpandedName extends MapName
+{
+    public function __construct(string|int $input, string|int|null $output = null)
+    {
+        parent::__construct($input, $output, expandDotNotation: true);
+    }
+}

--- a/src/Attributes/MapDotExpandedOutputName.php
+++ b/src/Attributes/MapDotExpandedOutputName.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\LaravelData\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
+class MapDotExpandedOutputName extends MapOutputName
+{
+    public function __construct(string|int $output)
+    {
+        parent::__construct($output, expandDotNotation: true);
+    }
+}

--- a/src/Attributes/MapName.php
+++ b/src/Attributes/MapName.php
@@ -8,8 +8,11 @@ use Spatie\LaravelData\Mappers\NameMapper;
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
 class MapName
 {
-    public function __construct(public string|int|NameMapper $input, public string|int|NameMapper|null $output = null)
-    {
+    public function __construct(
+        public string|int|NameMapper $input,
+        public string|int|NameMapper|null $output = null,
+        public bool $expandDotNotation = false,
+    ) {
         $this->output ??= $this->input;
     }
 }

--- a/src/Attributes/MapOutputName.php
+++ b/src/Attributes/MapOutputName.php
@@ -7,7 +7,9 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
 class MapOutputName
 {
-    public function __construct(public string|int $output)
-    {
+    public function __construct(
+        public string|int $output,
+        public bool $expandDotNotation = false,
+    ) {
     }
 }

--- a/src/Resolvers/EmptyDataResolver.php
+++ b/src/Resolvers/EmptyDataResolver.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelData\Resolvers;
 
+use Illuminate\Support\Arr;
 use Spatie\LaravelData\Concerns\EmptyData;
 use Spatie\LaravelData\Exceptions\DataPropertyCanOnlyHaveOneType;
 use Spatie\LaravelData\Support\DataConfig;
@@ -24,10 +25,14 @@ class EmptyDataResolver
         foreach ($dataClass->properties as $property) {
             $name = $property->outputMappedName ?? $property->name;
 
-            if ($property->hasDefaultValue) {
-                $payload[$name] = $property->defaultValue;
+            $value = $property->hasDefaultValue
+                ? $property->defaultValue
+                : ($extra[$property->name] ?? $this->getValueForProperty($property, $defaultReturnValue));
+
+            if ($property->expandDotNotation) {
+                Arr::set($payload, $name, $value);
             } else {
-                $payload[$name] = $extra[$property->name] ?? $this->getValueForProperty($property, $defaultReturnValue);
+                $payload[$name] = $value;
             }
         }
 

--- a/src/Resolvers/NameMappersResolver.php
+++ b/src/Resolvers/NameMappersResolver.php
@@ -26,6 +26,7 @@ class NameMappersResolver
         return [
             'inputNameMapper' => $this->resolveInputNameMapper($attributes),
             'outputNameMapper' => $this->resolveOutputNameMapper($attributes),
+            'expandDotNotation' => $this->resolveExpandDotNotation($attributes),
         ];
     }
 
@@ -93,5 +94,14 @@ class NameMappersResolver
         }
 
         return $this->resolveMapperClass($value);
+    }
+
+    protected function resolveExpandDotNotation(
+        DataAttributesCollection $attributes
+    ): bool {
+        $mapper = $attributes->first(MapOutputName::class)
+            ?? $attributes->first(MapName::class);
+
+        return $mapper->expandDotNotation ?? false;
     }
 }

--- a/src/Resolvers/TransformedDataResolver.php
+++ b/src/Resolvers/TransformedDataResolver.php
@@ -83,7 +83,7 @@ class TransformedDataResolver
                 $name = $property->outputMappedName;
             }
 
-            if (config('data.features.expand_dot_notation')) {
+            if ($property->expandDotNotation) {
                 Arr::set($payload, $name, $value);
             }
             else {

--- a/src/Resolvers/TransformedDataResolver.php
+++ b/src/Resolvers/TransformedDataResolver.php
@@ -83,7 +83,12 @@ class TransformedDataResolver
                 $name = $property->outputMappedName;
             }
 
-            $payload[$name] = $value;
+            if (config('data.features.expand_dot_notation')) {
+                Arr::set($payload, $name, $value);
+            }
+            else {
+                $payload[$name] = $value;
+            }
         }
 
         return $payload;

--- a/src/Support/DataProperty.php
+++ b/src/Support/DataProperty.php
@@ -25,6 +25,7 @@ class DataProperty
         public readonly ?Transformer $transformer,
         public readonly ?string $inputMappedName,
         public readonly ?string $outputMappedName,
+        public readonly bool $expandDotNotation,
         public readonly DataAttributesCollection $attributes,
     ) {
     }

--- a/src/Support/Factories/DataPropertyFactory.php
+++ b/src/Support/Factories/DataPropertyFactory.php
@@ -59,6 +59,8 @@ class DataPropertyFactory
             default => null,
         };
 
+        $expandDotNotation = $mappers['expandDotNotation'];
+
         if (! $reflectionProperty->isPromoted()) {
             $hasDefaultValue = $reflectionProperty->hasDefaultValue();
             $defaultValue = $hasDefaultValue ? $reflectionProperty->getDefaultValue() : null;
@@ -94,6 +96,7 @@ class DataPropertyFactory
             transformer: ($attributes->first(WithTransformer::class) ?? $attributes->first(WithCastAndTransformer::class))?->get(),
             inputMappedName: $inputMappedName,
             outputMappedName: $outputMappedName,
+            expandDotNotation: $expandDotNotation,
             attributes: $attributes,
         );
     }

--- a/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
+++ b/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
@@ -89,7 +89,7 @@ class DataTypeScriptTransformer extends DtoTransformer
 
                 $propertyName = $dataProperty->outputMappedName ?? $dataProperty->name;
 
-                if (config('data.features.expand_dot_notation') && str_contains($propertyName, '.')) {
+                if ($dataProperty->expandDotNotation && str_contains($propertyName, '.')) {
                     Arr::set(
                         $carry,
                         $propertyName,

--- a/tests/DottedMappingTest.php
+++ b/tests/DottedMappingTest.php
@@ -1,12 +1,15 @@
 <?php
 
 use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Attributes\MapDotExpandedName;
+use Spatie\LaravelData\Attributes\MapDotExpandedOutputName;
+use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\MapOutputName;
 use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Tests\Fakes\SimpleDataWithExpandedDottedProperty;
 use Spatie\LaravelData\Tests\Fakes\SimpleDataWithMappedDottedProperty;
 
-it('can map dotted property names when transforming without undot', function () {
-    config()->set('data.features.expand_dot_notation', false);
+it('can map dotted property names when transforming without expand', function () {
     $data = new SimpleDataWithMappedDottedProperty('hello');
     $dataCollection = SimpleDataWithMappedDottedProperty::collect([
         ['dotted.description' => 'never'],
@@ -59,10 +62,9 @@ it('can map dotted property names when transforming without undot', function () 
     ]);
 });
 
-it('can map dotted property names when transforming with undot', function () {
-    config()->set('data.features.expand_dot_notation', true);
-    $data = new SimpleDataWithMappedDottedProperty('hello');
-    $dataCollection = SimpleDataWithMappedDottedProperty::collect([
+it('can map dotted property names when transforming with expand', function () {
+    $data = new SimpleDataWithExpandedDottedProperty('hello');
+    $dataCollection = SimpleDataWithExpandedDottedProperty::collect([
         ['dotted.description' => 'never'],
         ['dotted.description' => 'gonna'],
         ['dotted.description' => 'give'],
@@ -72,16 +74,16 @@ it('can map dotted property names when transforming with undot', function () {
 
     $dataClass = new class ('hello', $data, $data, $dataCollection, $dataCollection) extends Data {
         public function __construct(
-            #[MapOutputName('dotted.property')]
+            #[MapDotExpandedOutputName('dotted.property')]
             public string $string,
-            public SimpleDataWithMappedDottedProperty $nested,
-            #[MapOutputName('dotted.nested_other')]
-            public SimpleDataWithMappedDottedProperty $nested_renamed,
-            #[DataCollectionOf(SimpleDataWithMappedDottedProperty::class)]
+            public SimpleDataWithExpandedDottedProperty $nested,
+            #[MapDotExpandedOutputName('dotted.nested_other')]
+            public SimpleDataWithExpandedDottedProperty $nested_renamed,
+            #[DataCollectionOf(SimpleDataWithExpandedDottedProperty::class)]
             public array $nested_collection,
             #[
-                MapOutputName('dotted.nested_other_collection'),
-                DataCollectionOf(SimpleDataWithMappedDottedProperty::class)
+                MapDotExpandedOutputName('dotted.nested_other_collection'),
+                DataCollectionOf(SimpleDataWithExpandedDottedProperty::class)
             ]
             public array $nested_renamed_collection,
         ) {
@@ -111,4 +113,60 @@ it('can map dotted property names when transforming with undot', function () {
             ['dotted' => ['description' => 'up']],
         ],
     ]);
+});
+
+it('can use all four attribute combinations for dot notation expansion', function () {
+    // Test all four combinations for OUTPUT transformation
+    $dataClass = new class ('value1', 'value2', 'value3', 'value4') extends Data {
+        public function __construct(
+            #[MapDotExpandedOutputName('user.profile.name')]
+            public string $property1,
+            #[MapDotExpandedName('user.profile.email')]
+            public string $property2,
+            #[MapOutputName('user.settings.theme', expandDotNotation: true)]
+            public string $property3,
+            #[MapName('user.settings.language', expandDotNotation: true)]
+            public string $property4,
+        ) {
+        }
+    };
+
+    // Test output transformation - all four should expand dot notation
+    expect($dataClass->toArray())->toMatchArray([
+        'user' => [
+            'profile' => [
+                'name' => 'value1',
+                'email' => 'value2',
+            ],
+            'settings' => [
+                'theme' => 'value3',
+                'language' => 'value4',
+            ],
+        ],
+    ]);
+
+    // Test INPUT mapping with MapDotExpandedName and MapName (both handle input)
+    $inputTestClass = new class ('default1', 'default2') extends Data {
+        public function __construct(
+            #[MapDotExpandedName('user.profile.email')]
+            public string $email,
+            #[MapName('user.settings.language', expandDotNotation: true)]
+            public string $language,
+        ) {
+        }
+    };
+
+    $fromArray = $inputTestClass::from([
+        'user' => [
+            'profile' => [
+                'email' => 'test@example.com',
+            ],
+            'settings' => [
+                'language' => 'fr',
+            ],
+        ],
+    ]);
+
+    expect($fromArray->email)->toBe('test@example.com');
+    expect($fromArray->language)->toBe('fr');
 });

--- a/tests/DottedMappingTest.php
+++ b/tests/DottedMappingTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Attributes\MapOutputName;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Tests\Fakes\SimpleDataWithMappedDottedProperty;
+
+it('can map dotted property names when transforming without undot', function () {
+    config()->set('data.features.expand_dot_notation', false);
+    $data = new SimpleDataWithMappedDottedProperty('hello');
+    $dataCollection = SimpleDataWithMappedDottedProperty::collect([
+        ['dotted.description' => 'never'],
+        ['dotted.description' => 'gonna'],
+        ['dotted.description' => 'give'],
+        ['dotted.description' => 'you'],
+        ['dotted' => ['description' => 'up']],
+    ]);
+
+    $dataClass = new class ('hello', $data, $data, $dataCollection, $dataCollection) extends Data {
+        public function __construct(
+            #[MapOutputName('dotted.property')]
+            public string $string,
+            public SimpleDataWithMappedDottedProperty $nested,
+            #[MapOutputName('dotted.nested_other')]
+            public SimpleDataWithMappedDottedProperty $nested_renamed,
+            #[DataCollectionOf(SimpleDataWithMappedDottedProperty::class)]
+            public array $nested_collection,
+            #[
+                MapOutputName('dotted.nested_other_collection'),
+                DataCollectionOf(SimpleDataWithMappedDottedProperty::class)
+            ]
+            public array $nested_renamed_collection,
+        ) {
+        }
+    };
+
+    expect($dataClass->toArray())->toMatchArray([
+        'dotted.property' => 'hello',
+        'nested' => [
+            'dotted.description' => 'hello',
+        ],
+        'dotted.nested_other' => [
+            'dotted.description' => 'hello',
+        ],
+        'nested_collection' => [
+            ['dotted.description' => 'never'],
+            ['dotted.description' => 'gonna'],
+            ['dotted.description' => 'give'],
+            ['dotted.description' => 'you'],
+            ['dotted.description' => 'up'],
+        ],
+        'dotted.nested_other_collection' => [
+            ['dotted.description' => 'never'],
+            ['dotted.description' => 'gonna'],
+            ['dotted.description' => 'give'],
+            ['dotted.description' => 'you'],
+            ['dotted.description' => 'up'],
+        ],
+    ]);
+});
+
+it('can map dotted property names when transforming with undot', function () {
+    config()->set('data.features.expand_dot_notation', true);
+    $data = new SimpleDataWithMappedDottedProperty('hello');
+    $dataCollection = SimpleDataWithMappedDottedProperty::collect([
+        ['dotted.description' => 'never'],
+        ['dotted.description' => 'gonna'],
+        ['dotted.description' => 'give'],
+        ['dotted.description' => 'you'],
+        ['dotted' => ['description' => 'up']],
+    ]);
+
+    $dataClass = new class ('hello', $data, $data, $dataCollection, $dataCollection) extends Data {
+        public function __construct(
+            #[MapOutputName('dotted.property')]
+            public string $string,
+            public SimpleDataWithMappedDottedProperty $nested,
+            #[MapOutputName('dotted.nested_other')]
+            public SimpleDataWithMappedDottedProperty $nested_renamed,
+            #[DataCollectionOf(SimpleDataWithMappedDottedProperty::class)]
+            public array $nested_collection,
+            #[
+                MapOutputName('dotted.nested_other_collection'),
+                DataCollectionOf(SimpleDataWithMappedDottedProperty::class)
+            ]
+            public array $nested_renamed_collection,
+        ) {
+        }
+    };
+
+    expect($dataClass->toArray())->toMatchArray([
+        'dotted' => [
+            'property' => 'hello',
+            'nested_other' => ['dotted' => ['description' => 'hello']],
+            'nested_other_collection' => [
+                ['dotted' => ['description' => 'never']],
+                ['dotted' => ['description' => 'gonna']],
+                ['dotted' => ['description' => 'give']],
+                ['dotted' => ['description' => 'you']],
+                ['dotted' => ['description' => 'up']],
+            ],
+        ],
+        'nested' => [
+            'dotted' => ['description' => 'hello'],
+        ],
+        'nested_collection' => [
+            ['dotted' => ['description' => 'never']],
+            ['dotted' => ['description' => 'gonna']],
+            ['dotted' => ['description' => 'give']],
+            ['dotted' => ['description' => 'you']],
+            ['dotted' => ['description' => 'up']],
+        ],
+    ]);
+});

--- a/tests/Fakes/SimpleDataWithExpandedDottedProperty.php
+++ b/tests/Fakes/SimpleDataWithExpandedDottedProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data;
+
+class SimpleDataWithExpandedDottedProperty extends Data
+{
+    public function __construct(
+        #[MapName('dotted.description', expandDotNotation: true)]
+        public string $string
+    ) {
+    }
+}

--- a/tests/Fakes/SimpleDataWithMappedDottedProperty.php
+++ b/tests/Fakes/SimpleDataWithMappedDottedProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data;
+
+class SimpleDataWithMappedDottedProperty extends Data
+{
+    public function __construct(
+        #[MapName('dotted.description', 'dotted.description')]
+        public string $string
+    ) {
+    }
+}

--- a/tests/Support/TypeScriptTransformer/DataTypeScriptTransformerTest.php
+++ b/tests/Support/TypeScriptTransformer/DataTypeScriptTransformerTest.php
@@ -3,6 +3,8 @@
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Attributes\MapDotExpandedOutputName;
+use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\MapOutputName;
 use Spatie\LaravelData\CursorPaginatedDataCollection;
 use Spatie\LaravelData\Data;
@@ -341,9 +343,8 @@ it('supports converting nullable types to optional properties', function () {
     assertMatchesSnapshot($transformer->transform($reflection, 'DataObject')->transformed);
 });
 
-it('handles dotted property names with expand_dot_notation disabled', function () {
+it('handles dotted property names without expand', function () {
     $config = TypeScriptTransformerConfig::create();
-    config()->set('data.features.expand_dot_notation', false);
 
     $data = new class ('hello', 'world') extends Data {
         public function __construct(
@@ -370,16 +371,17 @@ it('handles dotted property names with expand_dot_notation disabled', function (
     );
 });
 
-it('handles dotted property names with expand_dot_notation enabled', function () {
+it('handles dotted property names with expand', function () {
     $config = TypeScriptTransformerConfig::create();
-    config()->set('data.features.expand_dot_notation', true);
 
-    $data = new class ('hello', 'world') extends Data {
+    $data = new class ('hello', 'world', 'description') extends Data {
         public function __construct(
-            #[MapOutputName('user.name')]
+            #[MapDotExpandedOutputName('user.name')]
             public string $userName,
-            #[MapOutputName('user.profile.bio')]
+            #[MapName('user.profile.bio', expandDotNotation: true)]
             public string $userBio,
+            #[MapOutputName('user.profile.description', expandDotNotation: true)]
+            public string $userDescription,
         ) {
         }
     };
@@ -395,6 +397,7 @@ it('handles dotted property names with expand_dot_notation enabled', function ()
         name: string;
         profile: {
         bio: string;
+        description: string;
         };
         };
         }


### PR DESCRIPTION
## Description
This PR adds a new feature that allows dot notation in property names to be expanded into nested objects when using Data objects as resources and in TypeScript definitions. This is particularly useful when working with APIs that require or return nested JSON structures.

When using the `MapOutputName` or `MapName` attributes with dot notation (e.g., 'user.name'), the package can now generate nested arrays in the JSON output and nested TypeScript interfaces that match the structure of your JSON.

## Configuration
The feature is controlled by a new configuration option in `config/data.php`:

```php
'features' => [
    // Other features...
    'expand_dot_notation' => true, // Defaults to false if not specified
],
```

## Benefits
- Creates nested JSON structures from flat data objects when using Data objects as resources
- Generates more intuitive TypeScript interfaces that match nested JSON structures
- Improves readability and maintainability of both JSON output and TypeScript definitions
- Makes it easier to work with APIs that expect nested data structures

## Examples

### Basic Example
```php
class UserData extends Data
{
    public function __construct(
        #[MapOutputName('user.name')]
        public string $name,
        #[MapOutputName('user.profile.bio')]
        public string $userBio,
    ) {
    }
}
```

With `expand_dot_notation` enabled, this generates the following JSON:
```json
{
    "user": {
        "name": "John Doe",
        "profile": {
            "bio": "Software developer"
        }
    }
}
```

Instead of the flat structure:
```json
{
    "user.name": "John Doe",
    "user.profile.bio": "Software developer"
}
```

### JSON:API Specification Example
When working with JSON:API specification, you often have relationships and attributes in a specific structure:

```php
class ArticleData extends Data
{
    public function __construct(
        public int $id,
        #[MapOutputName('attributes.title')]
        public string $title,
        #[MapOutputName('attributes.content')]
        public string $content,
        #[MapOutputName('attributes.published_at')]
        public Carbon $publishedAt,
        #[MapOutputName('relationships.author.data')]
        public UserData $author,
        #[MapOutputName('relationships.comments.data')]
        public DataCollection $comments,
    ) {
    }
}
```

With `expand_dot_notation` enabled, this generates a JSON structure that perfectly matches the JSON:API specification:

```json
{
    "id": 1,
    "attributes": {
        "title": "My First Article",
        "content": "This is the content of my article",
        "published_at": "2023-01-15T10:00:00Z"
    },
    "relationships": {
        "author": {
            "data": {
                "id": 1,
                "attributes": {
                  "name": "John Doe"
                }
            }
        },
        "comments": {
            "data": [
                {
                    "id": 1,
                    "attributes": {
                      "body": "Great article!"
                    }
                }
            ]
        }
    }
}
```
