### PR TITLE
can get the data class for a data collection by annotation with unicode characters

### DIFF
--- a/src/Support/Annotations/DataIterableAnnotationReader.php
+++ b/src/Support/Annotations/DataIterableAnnotationReader.php
@@ -50,19 +50,19 @@ class DataIterableAnnotationReader
         $comment = str_replace('?', '', $comment);
 
         $kindPattern = '(?:@property|@var|@param)\s*';
-        $fqsenPattern = '[\\\\a-z0-9_\|]+';
-        $typesPattern = '[\\\\a-z0-9_\\|\\[\\]]+';
+        $fqsenPattern = '[\\\\\\p{L}0-9_\|]+';
+        $typesPattern = '[\\\\\\p{L}0-9_\\|\\[\\]]+';
         $keyPattern = '(?<key>int|string|int\|string|string\|int|array-key)';
-        $parameterPattern = '\s*\$?(?<parameter>[a-z0-9_]+)?';
+        $parameterPattern = '\s*\$?(?<parameter>[\\p{L}0-9_]+)?';
 
         preg_match_all(
-            "/{$kindPattern}(?<types>{$typesPattern}){$parameterPattern}/i",
+            "/{$kindPattern}(?<types>{$typesPattern}){$parameterPattern}/ui",
             $comment,
             $arrayMatches,
         );
 
         preg_match_all(
-            "/{$kindPattern}(?<collectionClass>{$fqsenPattern})<(?:{$keyPattern}\s*?,\s*?)?(?<dataClass>{$fqsenPattern})>(?:{$typesPattern})*{$parameterPattern}/i",
+            "/{$kindPattern}(?<collectionClass>{$fqsenPattern})<(?:{$keyPattern}\s*?,\s*?)?(?<dataClass>{$fqsenPattern})>(?:{$typesPattern})*{$parameterPattern}/ui",
             $comment,
             $collectionMatches,
         );

--- a/tests/Fakes/CollectionDataAnnotationsData.php
+++ b/tests/Fakes/CollectionDataAnnotationsData.php
@@ -15,6 +15,7 @@ use Spatie\LaravelData\DataCollection;
  * @property \Spatie\LaravelData\Tests\Fakes\SimpleData[] $propertyR
  * @property array<SimpleData> $propertyS
  * @property \Illuminate\Support\Collection<\Spatie\LaravelData\Tests\Fakes\SimpleData>|null $propertyT
+ * @property \Illuminate\Support\Collection<\Spatie\LaravelData\Tests\Fakes\SimpleDataWithUnicodeCharséÄöü>|null $propertyW
  */
 class CollectionDataAnnotationsData
 {
@@ -73,6 +74,11 @@ class CollectionDataAnnotationsData
     /** @var \Illuminate\Support\Collection<\Spatie\LaravelData\Tests\Fakes\SimpleData>|null */
     public ?array $propertyU;
 
+    /** @var \Illuminate\Support\Collection<\Spatie\LaravelData\Tests\Fakes\SimpleDataWithUnicodeCharséÄöü>|null */
+    public ?array $propertyV;
+
+    public ?array $propertyW;
+
     /**
      * @param \Spatie\LaravelData\Tests\Fakes\SimpleData[]|null $paramA
      * @param null|\Spatie\LaravelData\Tests\Fakes\SimpleData[] $paramB
@@ -85,6 +91,10 @@ class CollectionDataAnnotationsData
      * @param array<int,SimpleData> $paramJ
      * @param array<int, SimpleData> $paramI
      * @param \Spatie\LaravelData\DataCollection<\Spatie\LaravelData\Tests\Fakes\SimpleData>|null $paramK
+     * @param \Spatie\LaravelData\DataCollection<\Spatie\LaravelData\Tests\Fakes\SimpleDataWithUnicodeCharséÄöü>|null $paramL
+     * @param Collection<\Spatie\LaravelData\Tests\Fakes\SimpleDataWithUnicodeCharséÄöü>|null $paramM
+     * @param array<\Spatie\LaravelData\Tests\Fakes\SimpleDataWithUnicodeCharséÄöü>|null $paramN
+     * @param \Spatie\LaravelData\Tests\Fakes\SimpleDataWithUnicodeCharséÄöü[]|null $paramO
      */
     public function method(
         array $paramA,
@@ -97,6 +107,10 @@ class CollectionDataAnnotationsData
         array $paramJ,
         array $paramI,
         ?array $paramK,
+        ?DataCollection $paramL,
+        ?Collection $paramM,
+        ?array $paramN,
+        ?array $paramO
     ) {
 
     }

--- a/tests/Fakes/SimpleDataWithUnicodeCharséÄöü.php
+++ b/tests/Fakes/SimpleDataWithUnicodeCharséÄöü.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Fakes;
+
+use Spatie\LaravelData\Data;
+
+class SimpleDataWithUnicodeCharséÄöü extends Data
+{
+    public function __construct(
+        public string $string
+    ) {
+    }
+
+    public static function fromString(string $string): self
+    {
+        return new self($string);
+    }
+
+    public function toUserDefinedToArray(): array
+    {
+        return [
+            'string' => $this->string,
+        ];
+    }
+}

--- a/tests/Support/Annotations/DataIterableAnnotationReaderTest.php
+++ b/tests/Support/Annotations/DataIterableAnnotationReaderTest.php
@@ -8,6 +8,7 @@ use Spatie\LaravelData\Tests\Fakes\CollectionNonDataAnnotationsData;
 use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
 use Spatie\LaravelData\Tests\Fakes\Error;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
+use Spatie\LaravelData\Tests\Fakes\SimpleDataWithUnicodeCharséÄöü;
 
 it(
     'can get the data class for a data collection by annotation',
@@ -34,6 +35,11 @@ it(
 
     yield 'propertyD' => [
         'propertyD', // property
+        new DataIterableAnnotation(SimpleData::class, isData: true), // expected
+    ];
+
+    yield 'propertyE' => [
+        'propertyE', // property
         new DataIterableAnnotation(SimpleData::class, isData: true), // expected
     ];
 
@@ -86,6 +92,11 @@ it(
         'propertyU', // property
         new DataIterableAnnotation(SimpleData::class, isData: true), // expected
     ];
+
+    yield 'propertyV' => [
+        'propertyV', // property
+        new DataIterableAnnotation(SimpleDataWithUnicodeCharséÄöü::class, isData: true), // expected
+    ];
 });
 
 it('can get the data class for a data collection by class annotation', function () {
@@ -99,6 +110,7 @@ it('can get the data class for a data collection by class annotation', function 
         'propertyR' => new DataIterableAnnotation(SimpleData::class, isData: true, property: 'propertyR'),
         'propertyS' => new DataIterableAnnotation(SimpleData::class, isData: true, property: 'propertyS'),
         'propertyT' => new DataIterableAnnotation(SimpleData::class, isData: true, property: 'propertyT'),
+        'propertyW' => new DataIterableAnnotation(SimpleDataWithUnicodeCharséÄöü::class, isData: true, property: 'propertyW'),
     ]);
 });
 
@@ -117,6 +129,10 @@ it('can get data class for a data collection by method annotation', function () 
         'paramJ' => new DataIterableAnnotation(SimpleData::class, isData: true, keyType: 'int', property: 'paramJ'),
         'paramI' => new DataIterableAnnotation(SimpleData::class, isData: true, keyType: 'int', property: 'paramI'),
         'paramK' => new DataIterableAnnotation(SimpleData::class, isData: true, property: 'paramK'),
+        'paramL' => new DataIterableAnnotation(SimpleDataWithUnicodeCharséÄöü::class, isData: true, property: 'paramL'),
+        'paramM' => new DataIterableAnnotation(SimpleDataWithUnicodeCharséÄöü::class, isData: true, property: 'paramM'),
+        'paramN' => new DataIterableAnnotation(SimpleDataWithUnicodeCharséÄöü::class, isData: true, property: 'paramN'),
+        'paramO' => new DataIterableAnnotation(SimpleDataWithUnicodeCharséÄöü::class, isData: true, property: 'paramO'),
     ]);
 });
 


### PR DESCRIPTION
When using data classes with unicode characters, the annotation resolving doesn't work properly, because the regex does not capture unicode chars. 