### PR TITLE
Allow re-encrypting attributes when app uses previous keys

### DIFF
--- a/src/Support/EloquentCasts/DataCollectionEloquentCast.php
+++ b/src/Support/EloquentCasts/DataCollectionEloquentCast.php
@@ -107,6 +107,10 @@ class DataCollectionEloquentCast implements CastsAttributes
 
     public function compare($model, string $key, $firstValue, $secondValue): bool
     {
+        if (in_array('encrypted', $this->arguments) && ! empty(Crypt::getPreviousKeys())) {
+            return false;
+        }
+
         return $this->get($model, $key, $firstValue, [])->toArray() === $this->get($model, $key, $secondValue, [])->toArray();
     }
 

--- a/src/Support/EloquentCasts/DataEloquentCast.php
+++ b/src/Support/EloquentCasts/DataEloquentCast.php
@@ -84,6 +84,10 @@ class DataEloquentCast implements CastsAttributes
 
     public function compare($model, string $key, $firstValue, $secondValue): bool
     {
+        if (in_array('encrypted', $this->arguments) && ! empty(Crypt::getPreviousKeys())) {
+            return false;
+        }
+
         return $this->get($model, $key, $firstValue, [])?->toArray() === $this->get($model, $key, $secondValue, [])?->toArray();
     }
 

--- a/tests/Support/EloquentCasts/DataCollectionEloquentCastTest.php
+++ b/tests/Support/EloquentCasts/DataCollectionEloquentCastTest.php
@@ -15,6 +15,7 @@ use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
 use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithCasts;
 use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithCustomCollectionCasts;
 use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithDefaultCasts;
+use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithEncryptedCasts;
 use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithJson;
 use Spatie\LaravelData\Tests\Fakes\MultiData;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
@@ -263,5 +264,35 @@ it('can correctly detect if the attribute is dirty', function () {
 
     expect($model->getRawOriginal('data_collection'))->toBe('[{"second": "Second", "first": "First"}, {"first": "Third", "second": "Fourth"}]')
         ->and($model->getAttributes()['data_collection'])->toBe('[{"first":"First","second":"Second"},{"first":"Third","second":"Fourth"}]')
+        ->and($model->isDirty('data_collection'))->toBeFalse();
+})->skip(fn () => version_compare(app()->version(), '12.18.0', '<'));
+
+it('flags the attribute as dirty when it is encrypted and there are previous encryption keys', function () {
+    config()->set('app.previous_keys', ['base64:'.base64_encode(random_bytes(32))]);
+
+    $model = new DummyModelWithEncryptedCasts();
+    $model->data_collection = [
+        new SimpleData('First'),
+        new SimpleData('Second'),
+    ];
+    $model->save();
+
+    $model->data_collection = $model->data_collection;
+
+    expect($model->getRawOriginal('data_collection'))->not->toBe($model->getAttributes()['data_collection'])
+        ->and($model->isDirty('data_collection'))->toBeTrue();
+})->skip(fn () => version_compare(app()->version(), '12.18.0', '<'));
+
+it('does not flag the attribute as dirty when it is encrypted and there are no previous encryption keys', function () {
+    $model = new DummyModelWithEncryptedCasts();
+    $model->data_collection = [
+        new SimpleData('First'),
+        new SimpleData('Second'),
+    ];
+    $model->save();
+
+    $model->data_collection = $model->data_collection;
+
+    expect($model->getRawOriginal('data_collection'))->not->toBe($model->getAttributes()['data_collection'])
         ->and($model->isDirty('data_collection'))->toBeFalse();
 })->skip(fn () => version_compare(app()->version(), '12.18.0', '<'));

--- a/tests/Support/EloquentCasts/DataEloquentCastTest.php
+++ b/tests/Support/EloquentCasts/DataEloquentCastTest.php
@@ -270,6 +270,30 @@ it('can correctly detect if the attribute is dirty with null values', function (
         ->and($model->isDirty('data'))->toBeTrue();
 })->skip(fn () => version_compare(app()->version(), '12.18.0', '<'));
 
+it('flags the attribute as dirty when it is encrypted and there are previous encryption keys', function () {
+    config()->set('app.previous_keys', ['base64:'.base64_encode(random_bytes(32))]);
+
+    $model = new DummyModelWithEncryptedCasts();
+    $model->data = new SimpleData('First');
+    $model->save();
+
+    $model->data = $model->data;
+
+    expect($model->getRawOriginal('data'))->not->toBe($model->getAttributes()['data'])
+        ->and($model->isDirty('data'))->toBeTrue();
+})->skip(fn () => version_compare(app()->version(), '12.18.0', '<'));
+
+it('does not flag the attribute as dirty when it is encrypted and there are no previous encryption keys', function () {
+    $model = new DummyModelWithEncryptedCasts();
+    $model->data = new SimpleData('First');
+    $model->save();
+
+    $model->data = $model->data;
+
+    expect($model->getRawOriginal('data'))->not->toBe($model->getAttributes()['data'])
+        ->and($model->isDirty('data'))->toBeFalse();
+})->skip(fn () => version_compare(app()->version(), '12.18.0', '<'));
+
 it('can update a model where the cast is initially null', function () {
     $model = DummyModelWithCasts::create([
         'data' => null,


### PR DESCRIPTION
In #1033 the compare method is introduced, which is really nice! However, as Laravel now thinks the value is equal, it's impossible to "re-encrypt" the attributes without changing the actual value.

### Issue
Say you have a model that uses one of the casts provided by this package and have set it up to encrypt that data. Afterwards, you rotate the app key and set the app previous keys. Laravel handles decrypting the value using your new or old key, whichever works. Now you want to get rid of the previous key, maybe it's leaked, and have all data encrypted using your new key. With the "native" encrypted casts provided by Laravel, the value is re-encrypted using the new key and marked as dirty on update (see https://github.com/laravel/framework/blob/959fac8/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L2284-L2285 for details). So if you want to re-encrypt all data, you can just loop over all models, set the attribute to trigger a re-encrypt, and save them. However, since version #1033 introduced the compare function, Laravel thinks the values are equal and it doesn't mark the attribute as dirty and doesn't save the re-encrypted value.

### Solution
By implementing the same logic as Laravel, i.e. marking the attribute as dirty when there are previous encryption keys, we restore the ability to re-encrypt all data.