### PR TITLE
Add support for external validation attribute references

### DIFF
--- a/docs/advanced-usage/validation-attributes.md
+++ b/docs/advanced-usage/validation-attributes.md
@@ -979,6 +979,12 @@ public string $closure;
 
 #[Unique('users', ignore: 5)]
 public string $closure;
+
+#[Unique('users', ignore: new AuthenticatedUserReference())]
+public string $closure;
+
+#[Unique('posts', ignore: new RouteParameterReference('post'))]
+public string $closure;
 ```
 
 ## Uppercase

--- a/docs/validation/using-validation-attributes.md
+++ b/docs/validation/using-validation-attributes.md
@@ -20,7 +20,8 @@ class SongData extends Data
 
 These rules will be merged together with the rules that are inferred from the data object.
 
-So it is not required to add the `required` and `string` rule, these will be added automatically. The rules for the above data object will look like this:
+So it is not required to add the `required` and `string` rule, these will be added automatically. The rules for the
+above data object will look like this:
 
 ```php
 [
@@ -29,11 +30,12 @@ So it is not required to add the `required` and `string` rule, these will be add
 ]
 ```
 
-For each Laravel validation rule we've got a matching validation attribute, you can find a list of them [here](/docs/laravel-data/v4/advanced-usage/validation-attributes).
+For each Laravel validation rule we've got a matching validation attribute, you can find a list of
+them [here](/docs/laravel-data/v4/advanced-usage/validation-attributes).
 
 ## Referencing route parameters
 
-Sometimes you need a value within your validation attribute which is a route parameter. 
+Sometimes you need a value within your validation attribute which is a route parameter.
 Like the example below where the id should be unique ignoring the current id:
 
 ```php
@@ -61,6 +63,99 @@ class SongData extends Data
     }
 }
 ```
+
+## Referencing the current authenticated user
+
+If you need to reference the current authenticated user in your validation attributes, you can use the
+`AuthenticatedUserReference`:
+
+```php
+use Spatie\LaravelData\Support\Validation\References\AuthenticatedUserReference;
+
+class UserData extends Data
+{
+    public function __construct(
+        public string $name,
+        #[Unique('users', 'email', ignore: new AuthenticatedUserReference())]
+        public string $email,
+    ) {   
+    }
+}
+```
+
+When you need to reference a specific property of the authenticated user, you can do so like this:
+
+```php
+class SongData extends Data
+{
+    public function __construct(
+        #[Max(new AuthenticatedUserReference('max_song_title_length'))]
+        public string $title,
+    ) {
+    }
+}
+```
+
+Using a different guard than the default one can be done by passing the guard name to the constructor:
+
+```php
+class UserData extends Data
+{
+    public function __construct(
+        public string $name,
+        #[Unique('users', 'email', ignore: new AuthenticatedUserReference(guard: 'api'))]
+        public string $email,
+    ) {   
+    }
+}
+```
+
+## Referencing container dependencies
+
+If you need to reference a container dependency in your validation attributes, you can use the `ContainerReference`:
+
+```php
+use Spatie\LaravelData\Support\Validation\References\ContainerReference;
+
+class SongData extends Data
+{
+    public function __construct(
+        public string $title,
+        #[Max(new ContainerReference('max_song_title_length'))]
+        public string $artist,
+    ) {
+    }
+}
+```
+
+It might be more useful to use a property of the container dependency, which can be done like this:
+
+```php
+class SongData extends Data
+{
+    public function __construct(
+        public string $title,
+        #[Max(new ContainerReference(SongSettings::class, 'max_song_title_length'))]
+        public string $artist,
+    ) {
+    }
+}
+```
+
+When your dependency requires specific parameters, you can pass them along:
+
+```php
+class SongData extends Data
+{
+    public function __construct(
+        public string $title,
+        #[Max(new ContainerReference(SongSettings::class, 'max_song_title_length', parameters: ['repository' => 'redis']))]
+        public string $artist,
+    ) {
+    }
+}
+```
+
 
 ## Referencing other fields
 
@@ -148,7 +243,8 @@ public string $property
 
 ## Creating your validation attribute
 
-It is possible to create your own validation attribute by extending the `CustomValidationAttribute` class, this class has a `getRules` method that returns the rules that should be applied to the property.
+It is possible to create your own validation attribute by extending the `CustomValidationAttribute` class, this class
+has a `getRules` method that returns the rules that should be applied to the property.
 
 ```php
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
@@ -164,4 +260,5 @@ class CustomRule extends CustomValidationAttribute
 }
 ```
 
-Quick note: you can only use these rules as an attribute, not as a class rule within the static `rules` method of the data class.
+Quick note: you can only use these rules as an attribute, not as a class rule within the static `rules` method of the
+data class.

--- a/src/Attributes/Validation/AcceptedIf.php
+++ b/src/Attributes/Validation/AcceptedIf.php
@@ -4,8 +4,8 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use BackedEnum;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\References\FieldReference;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class AcceptedIf extends StringValidationAttribute
@@ -14,7 +14,7 @@ class AcceptedIf extends StringValidationAttribute
 
     public function __construct(
         string|FieldReference $field,
-        protected string|bool|int|float|BackedEnum|RouteParameterReference $value
+        protected string|bool|int|float|BackedEnum|ExternalReference $value
     ) {
         $this->field = $this->parseFieldReference($field);
     }

--- a/src/Attributes/Validation/After.php
+++ b/src/Attributes/Validation/After.php
@@ -4,13 +4,13 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use DateTimeInterface;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\References\FieldReference;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class After extends StringValidationAttribute
 {
-    public function __construct(protected string|DateTimeInterface|FieldReference|RouteParameterReference $date)
+    public function __construct(protected string|DateTimeInterface|FieldReference|ExternalReference $date)
     {
     }
 

--- a/src/Attributes/Validation/AfterOrEqual.php
+++ b/src/Attributes/Validation/AfterOrEqual.php
@@ -4,13 +4,13 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use DateTimeInterface;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\References\FieldReference;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class AfterOrEqual extends StringValidationAttribute
 {
-    public function __construct(protected string|DateTimeInterface|RouteParameterReference|FieldReference $date)
+    public function __construct(protected string|DateTimeInterface|ExternalReference|FieldReference $date)
     {
     }
 

--- a/src/Attributes/Validation/ArrayType.php
+++ b/src/Attributes/Validation/ArrayType.php
@@ -4,14 +4,14 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use Illuminate\Support\Arr;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class ArrayType extends StringValidationAttribute
 {
     protected array $keys;
 
-    public function __construct(array|string|RouteParameterReference ...$keys)
+    public function __construct(array|string|ExternalReference ...$keys)
     {
         $this->keys = Arr::flatten($keys);
     }

--- a/src/Attributes/Validation/Before.php
+++ b/src/Attributes/Validation/Before.php
@@ -4,13 +4,13 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use DateTimeInterface;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\References\FieldReference;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Before extends StringValidationAttribute
 {
-    public function __construct(protected string|DateTimeInterface|RouteParameterReference|FieldReference $date)
+    public function __construct(protected string|DateTimeInterface|ExternalReference|FieldReference $date)
     {
     }
 

--- a/src/Attributes/Validation/BeforeOrEqual.php
+++ b/src/Attributes/Validation/BeforeOrEqual.php
@@ -4,13 +4,13 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use DateTimeInterface;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\References\FieldReference;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class BeforeOrEqual extends StringValidationAttribute
 {
-    public function __construct(protected string|DateTimeInterface|RouteParameterReference|FieldReference $date)
+    public function __construct(protected string|DateTimeInterface|ExternalReference|FieldReference $date)
     {
     }
 

--- a/src/Attributes/Validation/Between.php
+++ b/src/Attributes/Validation/Between.php
@@ -3,12 +3,12 @@
 namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Between extends StringValidationAttribute
 {
-    public function __construct(protected int|float|RouteParameterReference $min, protected int|float|RouteParameterReference $max)
+    public function __construct(protected int|float|ExternalReference $min, protected int|float|ExternalReference $max)
     {
     }
 

--- a/src/Attributes/Validation/CurrentPassword.php
+++ b/src/Attributes/Validation/CurrentPassword.php
@@ -3,13 +3,13 @@
 namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class CurrentPassword extends StringValidationAttribute
 {
-    public function __construct(protected null|string|DummyBackedEnum|RouteParameterReference $guard = null)
+    public function __construct(protected null|string|DummyBackedEnum|ExternalReference $guard = null)
     {
     }
 

--- a/src/Attributes/Validation/DateEquals.php
+++ b/src/Attributes/Validation/DateEquals.php
@@ -4,12 +4,12 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use DateTimeInterface;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class DateEquals extends StringValidationAttribute
 {
-    public function __construct(protected string|DateTimeInterface|RouteParameterReference $date)
+    public function __construct(protected string|DateTimeInterface|ExternalReference $date)
     {
     }
 

--- a/src/Attributes/Validation/DateFormat.php
+++ b/src/Attributes/Validation/DateFormat.php
@@ -4,14 +4,14 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use Illuminate\Support\Arr;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class DateFormat extends StringValidationAttribute
 {
     protected string|array $format;
 
-    public function __construct(string|array|RouteParameterReference ...$format)
+    public function __construct(string|array|ExternalReference ...$format)
     {
         $this->format = Arr::flatten($format);
     }

--- a/src/Attributes/Validation/DeclinedIf.php
+++ b/src/Attributes/Validation/DeclinedIf.php
@@ -4,8 +4,8 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use BackedEnum;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\References\FieldReference;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class DeclinedIf extends StringValidationAttribute
@@ -14,7 +14,7 @@ class DeclinedIf extends StringValidationAttribute
 
     public function __construct(
         string|FieldReference $field,
-        protected string|bool|int|float|BackedEnum|RouteParameterReference $value,
+        protected string|bool|int|float|BackedEnum|ExternalReference $value,
     ) {
         $this->field = $this->parseFieldReference($field);
     }

--- a/src/Attributes/Validation/Digits.php
+++ b/src/Attributes/Validation/Digits.php
@@ -3,12 +3,12 @@
 namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Digits extends StringValidationAttribute
 {
-    public function __construct(protected int|RouteParameterReference $value)
+    public function __construct(protected int|ExternalReference $value)
     {
     }
 

--- a/src/Attributes/Validation/DigitsBetween.php
+++ b/src/Attributes/Validation/DigitsBetween.php
@@ -3,12 +3,12 @@
 namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class DigitsBetween extends StringValidationAttribute
 {
-    public function __construct(protected int|RouteParameterReference $min, protected int|RouteParameterReference $max)
+    public function __construct(protected int|ExternalReference $min, protected int|ExternalReference $max)
     {
     }
 

--- a/src/Attributes/Validation/Dimensions.php
+++ b/src/Attributes/Validation/Dimensions.php
@@ -6,20 +6,20 @@ use Attribute;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Dimensions as BaseDimensions;
 use Spatie\LaravelData\Exceptions\CannotBuildValidationRule;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\ValidationPath;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Dimensions extends ObjectValidationAttribute
 {
     public function __construct(
-        protected null|int|RouteParameterReference $minWidth = null,
-        protected null|int|RouteParameterReference $minHeight = null,
-        protected null|int|RouteParameterReference $maxWidth = null,
-        protected null|int|RouteParameterReference $maxHeight = null,
-        protected null|float|string|RouteParameterReference $ratio = null,
-        protected null|int|RouteParameterReference $width = null,
-        protected null|int|RouteParameterReference $height = null,
+        protected null|int|ExternalReference $minWidth = null,
+        protected null|int|ExternalReference $minHeight = null,
+        protected null|int|ExternalReference $maxWidth = null,
+        protected null|int|ExternalReference $maxHeight = null,
+        protected null|float|string|ExternalReference $ratio = null,
+        protected null|int|ExternalReference $width = null,
+        protected null|int|ExternalReference $height = null,
         protected null|BaseDimensions $rule = null,
     ) {
         if (
@@ -42,13 +42,13 @@ class Dimensions extends ObjectValidationAttribute
             return $this->rule;
         }
 
-        $minWidth = $this->normalizePossibleRouteReferenceParameter($this->minWidth);
-        $minHeight = $this->normalizePossibleRouteReferenceParameter($this->minHeight);
-        $maxWidth = $this->normalizePossibleRouteReferenceParameter($this->maxWidth);
-        $maxHeight = $this->normalizePossibleRouteReferenceParameter($this->maxHeight);
-        $ratio = $this->normalizePossibleRouteReferenceParameter($this->ratio);
-        $width = $this->normalizePossibleRouteReferenceParameter($this->width);
-        $height = $this->normalizePossibleRouteReferenceParameter($this->height);
+        $minWidth = $this->normalizePossibleExternalReferenceParameter($this->minWidth);
+        $minHeight = $this->normalizePossibleExternalReferenceParameter($this->minHeight);
+        $maxWidth = $this->normalizePossibleExternalReferenceParameter($this->maxWidth);
+        $maxHeight = $this->normalizePossibleExternalReferenceParameter($this->maxHeight);
+        $ratio = $this->normalizePossibleExternalReferenceParameter($this->ratio);
+        $width = $this->normalizePossibleExternalReferenceParameter($this->width);
+        $height = $this->normalizePossibleExternalReferenceParameter($this->height);
 
         $rule = new BaseDimensions();
 

--- a/src/Attributes/Validation/Distinct.php
+++ b/src/Attributes/Validation/Distinct.php
@@ -4,7 +4,7 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use Spatie\LaravelData\Exceptions\CannotBuildValidationRule;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Distinct extends StringValidationAttribute
@@ -12,7 +12,7 @@ class Distinct extends StringValidationAttribute
     public const Strict = 'strict';
     public const IgnoreCase = 'ignore_case';
 
-    public function __construct(protected null|string|RouteParameterReference $mode = null)
+    public function __construct(protected null|string|ExternalReference $mode = null)
     {
     }
 

--- a/src/Attributes/Validation/DoesntEndWith.php
+++ b/src/Attributes/Validation/DoesntEndWith.php
@@ -4,14 +4,14 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use Illuminate\Support\Arr;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class DoesntEndWith extends StringValidationAttribute
 {
     protected string|array $values;
 
-    public function __construct(string|array|RouteParameterReference ...$values)
+    public function __construct(string|array|ExternalReference ...$values)
     {
         $this->values = Arr::flatten($values);
     }

--- a/src/Attributes/Validation/DoesntStartWith.php
+++ b/src/Attributes/Validation/DoesntStartWith.php
@@ -4,14 +4,14 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use Illuminate\Support\Arr;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class DoesntStartWith extends StringValidationAttribute
 {
     protected string|array $values;
 
-    public function __construct(string|array|RouteParameterReference ...$values)
+    public function __construct(string|array|ExternalReference ...$values)
     {
         $this->values = Arr::flatten($values);
     }

--- a/src/Attributes/Validation/Email.php
+++ b/src/Attributes/Validation/Email.php
@@ -6,7 +6,7 @@ use Attribute;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Spatie\LaravelData\Exceptions\CannotBuildValidationRule;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Email extends StringValidationAttribute
@@ -19,7 +19,7 @@ class Email extends StringValidationAttribute
 
     protected array $modes;
 
-    public function __construct(array|string|RouteParameterReference ...$modes)
+    public function __construct(array|string|ExternalReference ...$modes)
     {
         $this->modes = Arr::flatten($modes);
     }

--- a/src/Attributes/Validation/EndsWith.php
+++ b/src/Attributes/Validation/EndsWith.php
@@ -4,14 +4,14 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use Illuminate\Support\Arr;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class EndsWith extends StringValidationAttribute
 {
     protected string|array $values;
 
-    public function __construct(string|array|RouteParameterReference ...$values)
+    public function __construct(string|array|ExternalReference ...$values)
     {
         $this->values = Arr::flatten($values);
     }

--- a/src/Attributes/Validation/Enum.php
+++ b/src/Attributes/Validation/Enum.php
@@ -4,14 +4,14 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use Illuminate\Validation\Rules\Enum as EnumRule;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\ValidationPath;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Enum extends ObjectValidationAttribute
 {
     public function __construct(
-        protected string|EnumRule|RouteParameterReference $enum,
+        protected string|EnumRule|ExternalReference $enum,
         protected ?EnumRule $rule = null,
         protected ?array $only = null,
         protected ?array $except = null,

--- a/src/Attributes/Validation/ExcludeIf.php
+++ b/src/Attributes/Validation/ExcludeIf.php
@@ -4,8 +4,8 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use BackedEnum;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\References\FieldReference;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class ExcludeIf extends StringValidationAttribute
@@ -13,8 +13,8 @@ class ExcludeIf extends StringValidationAttribute
     protected FieldReference $field;
 
     public function __construct(
-        string|FieldReference                                              $field,
-        protected string|int|float|bool|BackedEnum|RouteParameterReference $value
+        string|FieldReference $field,
+        protected string|int|float|bool|BackedEnum|ExternalReference $value
     ) {
         $this->field = $this->parseFieldReference($field);
     }

--- a/src/Attributes/Validation/ExcludeUnless.php
+++ b/src/Attributes/Validation/ExcludeUnless.php
@@ -4,8 +4,8 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use BackedEnum;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\References\FieldReference;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class ExcludeUnless extends StringValidationAttribute
@@ -14,7 +14,7 @@ class ExcludeUnless extends StringValidationAttribute
 
     public function __construct(
         string|FieldReference                                              $field,
-        protected string|int|float|bool|BackedEnum|RouteParameterReference $value
+        protected string|int|float|bool|BackedEnum|ExternalReference $value
     ) {
         $this->field = $this->parseFieldReference($field);
     }

--- a/src/Attributes/Validation/Exists.php
+++ b/src/Attributes/Validation/Exists.php
@@ -6,18 +6,18 @@ use Attribute;
 use Closure;
 use Exception;
 use Illuminate\Validation\Rules\Exists as BaseExists;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\ValidationPath;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Exists extends ObjectValidationAttribute
 {
     public function __construct(
-        protected null|string|RouteParameterReference $table = null,
-        protected null|string|RouteParameterReference $column = 'NULL',
-        protected null|string|RouteParameterReference $connection = null,
-        protected bool|RouteParameterReference $withoutTrashed = false,
-        protected string|RouteParameterReference $deletedAtColumn = 'deleted_at',
+        protected null|string|ExternalReference $table = null,
+        protected null|string|ExternalReference $column = 'NULL',
+        protected null|string|ExternalReference $connection = null,
+        protected bool|ExternalReference $withoutTrashed = false,
+        protected string|ExternalReference $deletedAtColumn = 'deleted_at',
         protected ?Closure $where = null,
         protected ?BaseExists $rule = null,
     ) {
@@ -32,11 +32,11 @@ class Exists extends ObjectValidationAttribute
             return $this->rule;
         }
 
-        $table = $this->normalizePossibleRouteReferenceParameter($this->table);
-        $column = $this->normalizePossibleRouteReferenceParameter($this->column);
-        $connection = $this->normalizePossibleRouteReferenceParameter($this->connection);
-        $withoutTrashed = $this->normalizePossibleRouteReferenceParameter($this->withoutTrashed);
-        $deletedAtColumn = $this->normalizePossibleRouteReferenceParameter($this->deletedAtColumn);
+        $table = $this->normalizePossibleExternalReferenceParameter($this->table);
+        $column = $this->normalizePossibleExternalReferenceParameter($this->column);
+        $connection = $this->normalizePossibleExternalReferenceParameter($this->connection);
+        $withoutTrashed = $this->normalizePossibleExternalReferenceParameter($this->withoutTrashed);
+        $deletedAtColumn = $this->normalizePossibleExternalReferenceParameter($this->deletedAtColumn);
 
         $rule = new BaseExists(
             $connection ? "{$connection}.{$table}" : $table,

--- a/src/Attributes/Validation/In.php
+++ b/src/Attributes/Validation/In.php
@@ -5,7 +5,7 @@ namespace Spatie\LaravelData\Attributes\Validation;
 use Attribute;
 use Illuminate\Support\Arr;
 use Illuminate\Validation\Rules\In as BaseIn;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\ValidationPath;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
@@ -16,7 +16,7 @@ class In extends ObjectValidationAttribute
     private array $values;
 
     public function __construct(
-        array|string|BaseIn|RouteParameterReference ...$values
+        array|string|BaseIn|ExternalReference ...$values
     ) {
         $this->values = $values;
     }
@@ -32,7 +32,7 @@ class In extends ObjectValidationAttribute
         }
 
         $this->values = array_map(
-            fn (string|RouteParameterReference $value) => $this->normalizePossibleRouteReferenceParameter($value),
+            fn (string|ExternalReference $value) => $this->normalizePossibleExternalReferenceParameter($value),
             Arr::flatten($this->values)
         );
 

--- a/src/Attributes/Validation/Max.php
+++ b/src/Attributes/Validation/Max.php
@@ -3,12 +3,12 @@
 namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Max extends StringValidationAttribute
 {
-    public function __construct(protected int|RouteParameterReference $value)
+    public function __construct(protected int|ExternalReference $value)
     {
     }
 

--- a/src/Attributes/Validation/MaxDigits.php
+++ b/src/Attributes/Validation/MaxDigits.php
@@ -3,12 +3,12 @@
 namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class MaxDigits extends StringValidationAttribute
 {
-    public function __construct(protected int|RouteParameterReference $value)
+    public function __construct(protected int|ExternalReference $value)
     {
     }
 

--- a/src/Attributes/Validation/MimeTypes.php
+++ b/src/Attributes/Validation/MimeTypes.php
@@ -4,14 +4,14 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use Illuminate\Support\Arr;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class MimeTypes extends StringValidationAttribute
 {
     protected array $mimeTypes;
 
-    public function __construct(string|array|RouteParameterReference ...$mimeTypes)
+    public function __construct(string|array|ExternalReference ...$mimeTypes)
     {
         $this->mimeTypes = Arr::flatten($mimeTypes);
     }

--- a/src/Attributes/Validation/Mimes.php
+++ b/src/Attributes/Validation/Mimes.php
@@ -4,14 +4,14 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use Illuminate\Support\Arr;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Mimes extends StringValidationAttribute
 {
     protected array $mimes;
 
-    public function __construct(string|array|RouteParameterReference ...$mimes)
+    public function __construct(string|array|ExternalReference ...$mimes)
     {
         $this->mimes = Arr::flatten($mimes);
     }

--- a/src/Attributes/Validation/Min.php
+++ b/src/Attributes/Validation/Min.php
@@ -3,12 +3,12 @@
 namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Min extends StringValidationAttribute
 {
-    public function __construct(protected int|RouteParameterReference $value)
+    public function __construct(protected int|ExternalReference $value)
     {
     }
 

--- a/src/Attributes/Validation/MinDigits.php
+++ b/src/Attributes/Validation/MinDigits.php
@@ -3,12 +3,12 @@
 namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class MinDigits extends StringValidationAttribute
 {
-    public function __construct(protected int|RouteParameterReference $value)
+    public function __construct(protected int|ExternalReference $value)
     {
     }
 

--- a/src/Attributes/Validation/MultipleOf.php
+++ b/src/Attributes/Validation/MultipleOf.php
@@ -3,12 +3,12 @@
 namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class MultipleOf extends StringValidationAttribute
 {
-    public function __construct(protected int|float|RouteParameterReference $value)
+    public function __construct(protected int|float|ExternalReference $value)
     {
     }
 

--- a/src/Attributes/Validation/NotIn.php
+++ b/src/Attributes/Validation/NotIn.php
@@ -5,7 +5,7 @@ namespace Spatie\LaravelData\Attributes\Validation;
 use Attribute;
 use Illuminate\Support\Arr;
 use Illuminate\Validation\Rules\NotIn as BaseNotIn;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\ValidationPath;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
@@ -15,7 +15,7 @@ class NotIn extends ObjectValidationAttribute
 
     protected array $values;
 
-    public function __construct(array|string|BaseNotIn|RouteParameterReference ...$values)
+    public function __construct(array|string|BaseNotIn|ExternalReference ...$values)
     {
         $this->values = $values;
     }
@@ -31,7 +31,7 @@ class NotIn extends ObjectValidationAttribute
         }
 
         $this->values = array_map(
-            fn (string|RouteParameterReference $value) => $this->normalizePossibleRouteReferenceParameter($value),
+            fn (string|ExternalReference $value) => $this->normalizePossibleExternalReferenceParameter($value),
             Arr::flatten($this->values)
         );
 

--- a/src/Attributes/Validation/NotRegex.php
+++ b/src/Attributes/Validation/NotRegex.php
@@ -3,12 +3,12 @@
 namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class NotRegex extends StringValidationAttribute
 {
-    public function __construct(protected string|RouteParameterReference $pattern)
+    public function __construct(protected string|ExternalReference $pattern)
     {
     }
 

--- a/src/Attributes/Validation/ObjectValidationAttribute.php
+++ b/src/Attributes/Validation/ObjectValidationAttribute.php
@@ -2,16 +2,16 @@
 
 namespace Spatie\LaravelData\Attributes\Validation;
 
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\ValidationPath;
 
 abstract class ObjectValidationAttribute extends ValidationAttribute
 {
     abstract public function getRule(ValidationPath $path): object|string;
 
-    protected function normalizePossibleRouteReferenceParameter(mixed $parameter): mixed
+    protected function normalizePossibleExternalReferenceParameter(mixed $parameter): mixed
     {
-        if ($parameter instanceof RouteParameterReference) {
+        if ($parameter instanceof ExternalReference) {
             return $parameter->getValue();
         }
 

--- a/src/Attributes/Validation/Password.php
+++ b/src/Attributes/Validation/Password.php
@@ -5,21 +5,21 @@ namespace Spatie\LaravelData\Attributes\Validation;
 use Attribute;
 use Exception;
 use Illuminate\Validation\Rules\Password as BasePassword;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\ValidationPath;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Password extends ObjectValidationAttribute
 {
     public function __construct(
-        protected int|RouteParameterReference $min = 12,
-        protected bool|RouteParameterReference $letters = false,
-        protected bool|RouteParameterReference $mixedCase = false,
-        protected bool|RouteParameterReference $numbers = false,
-        protected bool|RouteParameterReference $symbols = false,
-        protected bool|RouteParameterReference $uncompromised = false,
-        protected int|RouteParameterReference $uncompromisedThreshold = 0,
-        protected bool|RouteParameterReference $default = false,
+        protected int|ExternalReference $min = 12,
+        protected bool|ExternalReference $letters = false,
+        protected bool|ExternalReference $mixedCase = false,
+        protected bool|ExternalReference $numbers = false,
+        protected bool|ExternalReference $symbols = false,
+        protected bool|ExternalReference $uncompromised = false,
+        protected int|ExternalReference $uncompromisedThreshold = 0,
+        protected bool|ExternalReference $default = false,
         protected ?BasePassword $rule = null,
     ) {
 
@@ -31,14 +31,14 @@ class Password extends ObjectValidationAttribute
             return $this->rule;
         }
 
-        $min = $this->normalizePossibleRouteReferenceParameter($this->min);
-        $letters = $this->normalizePossibleRouteReferenceParameter($this->letters);
-        $mixedCase = $this->normalizePossibleRouteReferenceParameter($this->mixedCase);
-        $numbers = $this->normalizePossibleRouteReferenceParameter($this->numbers);
-        $symbols = $this->normalizePossibleRouteReferenceParameter($this->symbols);
-        $uncompromised = $this->normalizePossibleRouteReferenceParameter($this->uncompromised);
-        $uncompromisedThreshold = $this->normalizePossibleRouteReferenceParameter($this->uncompromisedThreshold);
-        $default = $this->normalizePossibleRouteReferenceParameter($this->default);
+        $min = $this->normalizePossibleExternalReferenceParameter($this->min);
+        $letters = $this->normalizePossibleExternalReferenceParameter($this->letters);
+        $mixedCase = $this->normalizePossibleExternalReferenceParameter($this->mixedCase);
+        $numbers = $this->normalizePossibleExternalReferenceParameter($this->numbers);
+        $symbols = $this->normalizePossibleExternalReferenceParameter($this->symbols);
+        $uncompromised = $this->normalizePossibleExternalReferenceParameter($this->uncompromised);
+        $uncompromisedThreshold = $this->normalizePossibleExternalReferenceParameter($this->uncompromisedThreshold);
+        $default = $this->normalizePossibleExternalReferenceParameter($this->default);
 
         if ($default && $this->rule === null) {
             return BasePassword::default();

--- a/src/Attributes/Validation/ProhibitedIf.php
+++ b/src/Attributes/Validation/ProhibitedIf.php
@@ -5,8 +5,8 @@ namespace Spatie\LaravelData\Attributes\Validation;
 use Attribute;
 use BackedEnum;
 use Illuminate\Support\Arr;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\References\FieldReference;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class ProhibitedIf extends StringValidationAttribute
@@ -17,7 +17,7 @@ class ProhibitedIf extends StringValidationAttribute
 
     public function __construct(
         string|FieldReference $field,
-        array | string | BackedEnum | RouteParameterReference ...$values
+        array|string|BackedEnum|ExternalReference ...$values
     ) {
         $this->field = $this->parseFieldReference($field);
         $this->values = Arr::flatten($values);

--- a/src/Attributes/Validation/ProhibitedUnless.php
+++ b/src/Attributes/Validation/ProhibitedUnless.php
@@ -5,8 +5,8 @@ namespace Spatie\LaravelData\Attributes\Validation;
 use Attribute;
 use BackedEnum;
 use Illuminate\Support\Arr;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\References\FieldReference;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class ProhibitedUnless extends StringValidationAttribute
@@ -17,7 +17,7 @@ class ProhibitedUnless extends StringValidationAttribute
 
     public function __construct(
         string|FieldReference                           $field,
-        array|string|BackedEnum|RouteParameterReference ...$values
+        array|string|BackedEnum|ExternalReference ...$values
     ) {
         $this->field = $this->parseFieldReference($field);
         $this->values = Arr::flatten($values);

--- a/src/Attributes/Validation/Regex.php
+++ b/src/Attributes/Validation/Regex.php
@@ -3,12 +3,12 @@
 namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Regex extends StringValidationAttribute
 {
-    public function __construct(protected string|RouteParameterReference $pattern)
+    public function __construct(protected string|ExternalReference $pattern)
     {
     }
 

--- a/src/Attributes/Validation/RequiredArrayKeys.php
+++ b/src/Attributes/Validation/RequiredArrayKeys.php
@@ -4,14 +4,14 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use Illuminate\Support\Arr;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class RequiredArrayKeys extends StringValidationAttribute
 {
     protected string|array $values;
 
-    public function __construct(string|array|RouteParameterReference ...$values)
+    public function __construct(string|array|ExternalReference ...$values)
     {
         $this->values = Arr::flatten($values);
     }

--- a/src/Attributes/Validation/RequiredIf.php
+++ b/src/Attributes/Validation/RequiredIf.php
@@ -5,8 +5,8 @@ namespace Spatie\LaravelData\Attributes\Validation;
 use Attribute;
 use BackedEnum;
 use Illuminate\Support\Arr;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\References\FieldReference;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
 use Spatie\LaravelData\Support\Validation\RequiringRule;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
@@ -17,8 +17,8 @@ class RequiredIf extends StringValidationAttribute implements RequiringRule
     protected string|array $values;
 
     public function __construct(
-        string|FieldReference                           $field,
-        array|string|BackedEnum|RouteParameterReference ...$values
+        string|FieldReference $field,
+        array|string|BackedEnum|ExternalReference ...$values
     ) {
         $this->field = $this->parseFieldReference($field);
         $this->values = Arr::flatten($values);

--- a/src/Attributes/Validation/RequiredUnless.php
+++ b/src/Attributes/Validation/RequiredUnless.php
@@ -5,8 +5,8 @@ namespace Spatie\LaravelData\Attributes\Validation;
 use Attribute;
 use BackedEnum;
 use Illuminate\Support\Arr;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\References\FieldReference;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
 use Spatie\LaravelData\Support\Validation\RequiringRule;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
@@ -18,7 +18,7 @@ class RequiredUnless extends StringValidationAttribute implements RequiringRule
 
     public function __construct(
         string|FieldReference                                $field,
-        null|array|string|BackedEnum|RouteParameterReference ...$values
+        null|array|string|BackedEnum|ExternalReference ...$values
     ) {
         $this->field = $this->parseFieldReference($field);
         $this->values = Arr::flatten($values);

--- a/src/Attributes/Validation/Size.php
+++ b/src/Attributes/Validation/Size.php
@@ -3,12 +3,12 @@
 namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Size extends StringValidationAttribute
 {
-    public function __construct(protected int|RouteParameterReference $size)
+    public function __construct(protected int|ExternalReference $size)
     {
     }
 

--- a/src/Attributes/Validation/StartsWith.php
+++ b/src/Attributes/Validation/StartsWith.php
@@ -4,14 +4,14 @@ namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
 use Illuminate\Support\Arr;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class StartsWith extends StringValidationAttribute
 {
     protected string|array $values;
 
-    public function __construct(string | array | RouteParameterReference ...$values)
+    public function __construct(string|array|ExternalReference ...$values)
     {
         $this->values = Arr::flatten($values);
     }

--- a/src/Attributes/Validation/Unique.php
+++ b/src/Attributes/Validation/Unique.php
@@ -6,22 +6,22 @@ use Attribute;
 use Closure;
 use Exception;
 use Illuminate\Validation\Rules\Unique as BaseUnique;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\ValidationPath;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Unique extends ObjectValidationAttribute
 {
     public function __construct(
-        protected null|string|RouteParameterReference $table = null,
-        protected null|string|RouteParameterReference $column = 'NULL',
-        protected null|string|RouteParameterReference $connection = null,
-        protected null|string|RouteParameterReference $ignore = null,
-        protected null|string|RouteParameterReference $ignoreColumn = null,
-        protected bool|RouteParameterReference        $withoutTrashed = false,
-        protected string|RouteParameterReference      $deletedAtColumn = 'deleted_at',
-        protected ?Closure                            $where = null,
-        protected ?BaseUnique                         $rule = null
+        protected null|string|ExternalReference $table = null,
+        protected null|string|ExternalReference $column = 'NULL',
+        protected null|string|ExternalReference $connection = null,
+        protected null|string|ExternalReference $ignore = null,
+        protected null|string|ExternalReference $ignoreColumn = null,
+        protected bool|ExternalReference $withoutTrashed = false,
+        protected string|ExternalReference $deletedAtColumn = 'deleted_at',
+        protected ?Closure $where = null,
+        protected ?BaseUnique $rule = null
     ) {
         if ($table === null && $rule === null) {
             throw new Exception('Could not create unique validation rule, either table or a rule is required');
@@ -34,13 +34,13 @@ class Unique extends ObjectValidationAttribute
             return $this->rule;
         }
 
-        $table = $this->normalizePossibleRouteReferenceParameter($this->table);
-        $column = $this->normalizePossibleRouteReferenceParameter($this->column);
-        $connection = $this->normalizePossibleRouteReferenceParameter($this->connection);
-        $ignore = $this->normalizePossibleRouteReferenceParameter($this->ignore);
-        $ignoreColumn = $this->normalizePossibleRouteReferenceParameter($this->ignoreColumn);
-        $withoutTrashed = $this->normalizePossibleRouteReferenceParameter($this->withoutTrashed);
-        $deletedAtColumn = $this->normalizePossibleRouteReferenceParameter($this->deletedAtColumn);
+        $table = $this->normalizePossibleExternalReferenceParameter($this->table);
+        $column = $this->normalizePossibleExternalReferenceParameter($this->column);
+        $connection = $this->normalizePossibleExternalReferenceParameter($this->connection);
+        $ignore = $this->normalizePossibleExternalReferenceParameter($this->ignore);
+        $ignoreColumn = $this->normalizePossibleExternalReferenceParameter($this->ignoreColumn);
+        $withoutTrashed = $this->normalizePossibleExternalReferenceParameter($this->withoutTrashed);
+        $deletedAtColumn = $this->normalizePossibleExternalReferenceParameter($this->deletedAtColumn);
 
         $rule = new BaseUnique(
             $connection ? "{$connection}.{$table}" : $table,

--- a/src/Support/Validation/References/AuthenticatedUserReference.php
+++ b/src/Support/Validation/References/AuthenticatedUserReference.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\LaravelData\Support\Validation\References;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Auth;
+
+class AuthenticatedUserReference implements ExternalReference
+{
+    public function __construct(
+        public ?string $property = null,
+        public ?string $guard = null,
+    ) {
+    }
+
+    public function getValue(): ?Authenticatable
+    {
+        $user = Auth::guard($this->guard)->user();
+
+        if (! $user instanceof Authenticatable) {
+            return null;
+        }
+
+        if ($this->property === null) {
+            return $user;
+        }
+
+        return data_get($user, $this->property);
+    }
+}

--- a/src/Support/Validation/References/ContainerReference.php
+++ b/src/Support/Validation/References/ContainerReference.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Spatie\LaravelData\Support\Validation\References;
+
+use Illuminate\Container\Container;
+use Illuminate\Container\EntryNotFoundException;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Container\CircularDependencyException;
+
+class ContainerReference implements ExternalReference
+{
+    public function __construct(
+        public string $dependency,
+        public ?string $property = null,
+        public array $parameters = [],
+    ) {
+    }
+
+    public function getValue(): mixed
+    {
+        try {
+            $dependency = Container::getInstance()->make($this->dependency, $this->parameters);
+        } catch (CircularDependencyException|EntryNotFoundException|BindingResolutionException) {
+            return null;
+        }
+
+        if ($this->property !== null) {
+            return data_get($dependency, $this->property);
+        }
+
+        return $dependency;
+    }
+}

--- a/src/Support/Validation/References/ExternalReference.php
+++ b/src/Support/Validation/References/ExternalReference.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\LaravelData\Support\Validation\References;
+
+interface ExternalReference
+{
+    public function getValue(): mixed;
+}

--- a/src/Support/Validation/References/RouteParameterReference.php
+++ b/src/Support/Validation/References/RouteParameterReference.php
@@ -3,9 +3,8 @@
 namespace Spatie\LaravelData\Support\Validation\References;
 
 use Spatie\LaravelData\Exceptions\CannotResolveRouteParameterReference;
-use Stringable;
 
-class RouteParameterReference implements Stringable
+class RouteParameterReference implements ExternalReference
 {
     public function __construct(
         public readonly string $routeParameter,
@@ -37,10 +36,5 @@ class RouteParameterReference implements Stringable
         }
 
         return $value;
-    }
-
-    public function __toString(): string
-    {
-        return $this->getValue();
     }
 }

--- a/src/Support/Validation/RuleDenormalizer.php
+++ b/src/Support/Validation/RuleDenormalizer.php
@@ -12,8 +12,8 @@ use Spatie\LaravelData\Attributes\Validation\CustomValidationAttribute;
 use Spatie\LaravelData\Attributes\Validation\ObjectValidationAttribute;
 use Spatie\LaravelData\Attributes\Validation\Rule;
 use Spatie\LaravelData\Attributes\Validation\StringValidationAttribute;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 use Spatie\LaravelData\Support\Validation\References\FieldReference;
-use Spatie\LaravelData\Support\Validation\References\RouteParameterReference;
 
 class RuleDenormalizer
 {
@@ -114,7 +114,7 @@ class RuleDenormalizer
             return $parameter->getValue($path);
         }
 
-        if ($parameter instanceof RouteParameterReference) {
+        if ($parameter instanceof ExternalReference) {
             return $this->normalizeRuleParameter($parameter->getValue(), $path);
         }
 


### PR DESCRIPTION
Adds two new methods to inject values into validation attributes:

## Docs

### Referencing the current authenticated user

If you need to reference the current authenticated user in your validation attributes, you can use the
`AuthenticatedUserReference`:

```php
use Spatie\LaravelData\Support\Validation\References\AuthenticatedUserReference;

class UserData extends Data
{
    public function __construct(
        public string $name,
        #[Unique('users', 'email', ignore: new AuthenticatedUserReference())]
        public string $email,
    ) {   
    }
}
```

When you need to reference a specific property of the authenticated user, you can do so like this:

```php
class SongData extends Data
{
    public function __construct(
        #[Max(new AuthenticatedUserReference('max_song_title_length'))]
        public string $title,
    ) {
    }
}
```

Using a different guard than the default one can be done by passing the guard name to the constructor:

```php
class UserData extends Data
{
    public function __construct(
        public string $name,
        #[Unique('users', 'email', ignore: new AuthenticatedUserReference(guard: 'api'))]
        public string $email,
    ) {   
    }
}
```

### Referencing container dependencies

If you need to reference a container dependency in your validation attributes, you can use the `ContainerReference`:

```php
use Spatie\LaravelData\Support\Validation\References\ContainerReference;

class SongData extends Data
{
    public function __construct(
        public string $title,
        #[Max(new ContainerReference('max_song_title_length'))]
        public string $artist,
    ) {
    }
}
```

It might be more useful to use a property of the container dependency, which can be done like this:

```php
class SongData extends Data
{
    public function __construct(
        public string $title,
        #[Max(new ContainerReference(SongSettings::class, 'max_song_title_length'))]
        public string $artist,
    ) {
    }
}
```

When your dependency requires specific parameters, you can pass them along:

```php
class SongData extends Data
{
    public function __construct(
        public string $title,
        #[Max(new ContainerReference(SongSettings::class, 'max_song_title_length', parameters: ['repository' => 'redis']))]
        public string $artist,
    ) {
    }
}
```

## Headsup

Some internal changes were made to make this work, while technically not exposed to the outside for anyone to use, you're technically able to do so.

- All validation attributes with `RouteParameterReference` as parameter now accept `ExternalReference` (`RouteParameterReference`  is a `ExternalReference`)
- The `normalizePossibleRouteReferenceParameter` in an ObjectValidationAttribute has been renamed to  `normalizePossibleExternalReferenceParameter`
- `RouteParameterReference` was `Stringable`, we've removed this interface since it wasn't used by the package and it makes things rather unclear where the value of a `RouteParameterReference ` is called. You can continue using the `getValue` method which does the same.