### PR TITLE
feat(validation): add protocol support to Url attribute

### DIFF
--- a/src/Attributes/Validation/Url.php
+++ b/src/Attributes/Validation/Url.php
@@ -3,10 +3,20 @@
 namespace Spatie\LaravelData\Attributes\Validation;
 
 use Attribute;
+use Illuminate\Support\Arr;
+use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Url extends StringValidationAttribute
 {
+    protected array $protocols;
+
+    public function __construct(
+        string|array|ExternalReference ...$protocols
+    ) {
+        $this->protocols = Arr::flatten($protocols);
+    }
+
     public static function keyword(): string
     {
         return 'url';
@@ -14,6 +24,6 @@ class Url extends StringValidationAttribute
 
     public function parameters(): array
     {
-        return [];
+        return $this->protocols;
     }
 }

--- a/tests/Datasets/RulesDataset.php
+++ b/tests/Datasets/RulesDataset.php
@@ -442,10 +442,7 @@ dataset('attributes', function () {
         expected: 'uppercase',
     );
 
-    yield fixature(
-        attribute: new Url(),
-        expected: 'url',
-    );
+    yield from urlAttributes();
 
     yield fixature(
         attribute: new Ulid(),
@@ -489,6 +486,29 @@ function acceptedIfAttributes(): Generator
         attribute: new AcceptedIf('value', DummyBackedEnum::FOO),
         expected: 'accepted_if:value,foo',
         expectCreatedAttribute: new AcceptedIf('value', 'foo')
+    );
+}
+
+function urlAttributes(): Generator
+{
+    yield fixature(
+        attribute: new Url(),
+        expected: 'url',
+    );
+
+    yield fixature(
+        attribute: new Url('http'),
+        expected: 'url:http',
+    );
+
+    yield fixature(
+        attribute: new Url(['http', 'https']),
+        expected: 'url:http,https',
+    );
+
+    yield fixature(
+        attribute: new Url('http', 'https'),
+        expected: 'url:http,https',
     );
 }
 


### PR DESCRIPTION
Allow to set allowed protocols to be added to the Url attribute.

`#[Url('http')]`
`#[Url(['http', 'https'])]`