### PR TITLE
Fix TransformableData docblocks

### DIFF
--- a/src/Concerns/TransformableData.php
+++ b/src/Concerns/TransformableData.php
@@ -40,13 +40,13 @@ trait TransformableData
         return $resolver->execute($this, $transformationContext);
     }
 
-    /** @return array<string, mixed> */
+    /** @return array<array-key, mixed> */
     public function all(): array
     {
         return $this->transform(TransformationContextFactory::create()->withValueTransformation(false));
     }
 
-    /** @return array<string, mixed> */
+    /** @return array<array-key, mixed> */
     public function toArray(): array
     {
         return $this->transform();
@@ -57,7 +57,7 @@ trait TransformableData
         return json_encode($this->transform(), $options);
     }
 
-    /** @return array<string, mixed> */
+    /** @return array<array-key, mixed> */
     public function jsonSerialize(): array
     {
         return $this->transform();


### PR DESCRIPTION
I was getting static analysis errors here. There's nothing that guarantees the contents of all() has a string for a key.