### PR TITLE
FIX Inconsistency between documentation and PHPDoc for rules() 

### DIFF
--- a/src/Concerns/ValidateableData.php
+++ b/src/Concerns/ValidateableData.php
@@ -11,7 +11,7 @@ use Spatie\LaravelData\Support\Validation\ValidationContext;
 use Spatie\LaravelData\Support\Validation\ValidationPath;
 
 /**
- * @method static array rules(ValidationContext $context=null)
+ * @method static array rules(?ValidationContext $context = null)
  * @method static array messages(...$args)
  * @method static array attributes(...$args)
  * @method static bool stopOnFirstFailure()


### PR DESCRIPTION
+ FIX Inconsistency between documentation and PHPDoc for rules() by making this argument optional   
+ PSR-12 4.3 There MUST be a space between type declaration and property name.

So I did:
` * @method static array rules(?ValidationContext $context = null)`

https://github.com/spatie/laravel-data/issues/1038#issuecomment-3197957066