### PR TITLE
fix DataTypeScriptTransformer cursor paginator properties

### DIFF
--- a/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
+++ b/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
@@ -183,9 +183,9 @@ class DataTypeScriptTransformer extends DtoTransformer
                 'path' => new String_(),
                 'per_page' => new Integer(),
                 'next_cursor' => new Nullable(new String_()),
-                'next_cursor_url' => new Nullable(new String_()),
+                'next_page_url' => new Nullable(new String_()),
                 'prev_cursor' => new Nullable(new String_()),
-                'prev_cursor_url' => new Nullable(new String_()),
+                'prev_page_url' => new Nullable(new String_()),
             ]),
         ]);
     }


### PR DESCRIPTION
I opened an issue on `typescript-transformer` but I found out that the code generating the type belongs to this repo..
https://github.com/spatie/typescript-transformer/issues/116

Looking at the `blame` of [CursorPaginator.php](https://github.com/laravel/framework/blame/11.x/src/Illuminate/Pagination/CursorPaginator.php#L158) there was never a `prev_cursor_url` nor a `next_cursor_url`.

The patch just renames them to `prev_page_url` and `next_page_url` respectively.