### PR TITLE
[fix] DataMorphClassResolver: skip default value applying if morph property was resolved

### DIFF
--- a/src/Resolvers/DataMorphClassResolver.php
+++ b/src/Resolvers/DataMorphClassResolver.php
@@ -61,13 +61,13 @@ class DataMorphClassResolver
                 }
             }
 
-            if ($dataProperty->hasDefaultValue) {
+            if ($found === false && $dataProperty->hasDefaultValue) {
                 $morphProperties[$dataProperty->name] = $this->normalizeValue(
                     $dataProperty,
                     $dataProperty->defaultValue,
                 );
 
-                continue;
+                $found = true;
             }
 
             if ($found === false) {

--- a/tests/Resolvers/DataMorphClassResolverTest.php
+++ b/tests/Resolvers/DataMorphClassResolverTest.php
@@ -93,3 +93,44 @@ it('can resolve morph class with backed enum type', function () {
 
     expect($morph)->toBe(DummyBackedEnum::FOO->value);
 });
+
+it('can resolve morph class with backed enum type using default value', function () {
+    abstract class TestAbstractMorphableDataWithDefaultValue extends Data implements PropertyMorphableData
+    {
+        #[PropertyForMorph]
+        public DummyBackedEnum $type = DummyBackedEnum::BOO;
+
+        public static function morph(array $properties): ?string
+        {
+            return $properties['type']->value;
+        }
+    };
+
+    $morph = app(DataMorphClassResolver::class)->execute(
+        app(DataConfig::class)->getDataClass(TestAbstractMorphableDataWithDefaultValue::class),
+        [['type' => DummyBackedEnum::BOO]]
+    );
+
+    expect($morph)->toBe(DummyBackedEnum::BOO->value);
+});
+
+
+it('can resolve morph class with backed enum type ignoring default value', function () {
+    abstract class TestAbstractMorphableDataWithNullableBackedEnum extends Data implements PropertyMorphableData
+    {
+        #[PropertyForMorph]
+        public ?DummyBackedEnum $type = null;
+
+        public static function morph(array $properties): ?string
+        {
+            return $properties['type']?->value;
+        }
+    };
+
+    $morph = app(DataMorphClassResolver::class)->execute(
+        app(DataConfig::class)->getDataClass(TestAbstractMorphableDataWithNullableBackedEnum::class),
+        [['type' => DummyBackedEnum::FOO]]
+    );
+
+    expect($morph)->toBe(DummyBackedEnum::FOO->value);
+});


### PR DESCRIPTION
issue: [Moph property of morphable class always has default value](https://github.com/spatie/laravel-data/issues/1100)
