### PR TITLE
Change type hint from 'string|ExternalReference' to 'mixed'

### DIFF
--- a/src/Attributes/Validation/In.php
+++ b/src/Attributes/Validation/In.php
@@ -32,7 +32,7 @@ class In extends ObjectValidationAttribute
         }
 
         $this->values = array_map(
-            fn (string|ExternalReference $value) => $this->normalizePossibleExternalReferenceParameter($value),
+            fn (mixed $value) => $this->normalizePossibleExternalReferenceParameter($value),
             Arr::flatten($this->values)
         );
 


### PR DESCRIPTION
The Laravel In validation accepts Enums. However, the type of this method blocks me from using this. Also the method that is being called expects mixed :) 

Laravels implementation:
```php
    public function __toString()
    {
        $values = array_map(function ($value) {
            $value = enum_value($value);

            return '"'.str_replace('"', '""', $value).'"';
        }, $this->values);

        return $this->rule.':'.implode(',', $values);
    }
```