### PR TITLE
Fix ReflectionProperty::getDefaultValue() for properties without default value is deprecated in PHP 8.5

### DIFF
--- a/src/Support/Factories/DataPropertyFactory.php
+++ b/src/Support/Factories/DataPropertyFactory.php
@@ -61,7 +61,7 @@ class DataPropertyFactory
 
         if (! $reflectionProperty->isPromoted()) {
             $hasDefaultValue = $reflectionProperty->hasDefaultValue();
-            $defaultValue = $reflectionProperty->getDefaultValue();
+            $defaultValue = $hasDefaultValue ? $reflectionProperty->getDefaultValue() : null;
         }
 
         if ($hasDefaultValue && $defaultValue instanceof Optional) {


### PR DESCRIPTION
Getting the following deprecation warning on PHP 8.5:

```
WARNING: ReflectionProperty::getDefaultValue() for a property without a default value is deprecated, use ReflectionProperty::hasDefaultValue() to check if the default value exists in vendor/spatie/laravel-data/src/Support/Factories/DataPropertyFactory.php on line 64  
```

see https://www.php.net/manual/en/migration85.deprecated.php

> Calling [ReflectionProperty::getDefaultValue()](https://www.php.net/manual/en/reflectionproperty.getdefaultvalue.php) for properties without default values has been deprecated.