### PR TITLE
[bug] add failing tests for array/collection nested data

### DIFF
--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Validator as ValidatorFacade;
 use Illuminate\Validation\Rule;
@@ -69,6 +70,11 @@ use Spatie\LaravelData\Tests\Fakes\SimpleDataWithOverwrittenRules;
 use Spatie\LaravelData\Tests\Fakes\Support\FakeInjectable;
 use Spatie\LaravelData\Tests\Fakes\ValidationAttributes\PassThroughCustomValidationAttribute;
 use Spatie\LaravelData\Tests\TestSupport\DataValidationAsserter;
+
+class TestValidationDataWithCollectionNestedDataWithFieldReference extends Data
+{
+    public DataWithReferenceFieldValidationAttribute $nested;
+}
 
 it('can validate a string', function () {
     $dataClass = new class () extends Data {
@@ -649,15 +655,75 @@ test('can use a reference to another field in a collection', function () {
         );
 });
 
-test('can use a reference to another field in a collection with nested data', function () {
-    class TestValidationDataWithCollectionNestedDataWithFieldReference extends Data
-    {
-        public DataWithReferenceFieldValidationAttribute $nested;
-    }
-
+test('can use a reference to another field in a data collection with nested data', function () {
     $dataClass = new class () extends Data {
         #[DataCollectionOf(TestValidationDataWithCollectionNestedDataWithFieldReference::class)]
         public DataCollection $collection;
+    };
+
+    DataValidationAsserter::for($dataClass)
+        ->assertOk([
+            'collection' => [
+                ['nested' => ['check_string' => '0']],
+            ],
+        ])
+        ->assertErrors([
+            'collection' => [
+                ['nested' => ['check_string' => '1']],
+            ],
+        ])
+        ->assertRules(
+            rules: [
+                'collection' => ['present', 'array'],
+                'collection.0.nested' => ['required', 'array'],
+                'collection.0.nested.check_string' => ['boolean'],
+                'collection.0.nested.string' => ['string', 'required_if:collection.0.nested.check_string,1'],
+            ],
+            payload: [
+                'collection' => [
+                    ['nested' => ['check_string' => '1']],
+                ],
+            ]
+        );
+});
+
+test('can use a reference to another field in a collection with nested data', function () {
+    $dataClass = new class () extends Data {
+        /** @var Collection<int, TestValidationDataWithCollectionNestedDataWithFieldReference> */
+        public Collection $collection;
+    };
+
+    DataValidationAsserter::for($dataClass)
+        ->assertOk([
+            'collection' => [
+                ['nested' => ['check_string' => '0']],
+            ],
+        ])
+        ->assertErrors([
+            'collection' => [
+                ['nested' => ['check_string' => '1']],
+            ],
+        ])
+        ->assertRules(
+            rules: [
+                'collection' => ['present', 'array'],
+                'collection.0.nested' => ['required', 'array'],
+                'collection.0.nested.check_string' => ['boolean'],
+                'collection.0.nested.string' => ['string', 'required_if:collection.0.nested.check_string,1'],
+            ],
+            payload: [
+                'collection' => [
+                    ['nested' => ['check_string' => '1']],
+                ],
+            ]
+        );
+});
+
+test('can use a reference to another field in an array with nested data', function () {
+
+    $dataClass = new class () extends Data {
+        /** @var array<int, TestValidationDataWithCollectionNestedDataWithFieldReference> */
+        public array $collection;
     };
 
     DataValidationAsserter::for($dataClass)


### PR DESCRIPTION
**✏️ Describe the bug**
Validation rules referencing other field within a nested data inside an array or Illuminate\Support\Collection do not work. The validation rules only work when using the deprecated `DataCollection`.

The docs mention that for nesting a collection of data, `DataCollection` is deprecated and either a simple array and phpdoc, or `Illuminate\Support\Collection` should be used, instead. 

In fact, the docs only [show an example](https://spatie.be/docs/laravel-data/v4/validation/nesting-data#content-validating-a-nested-collection-of-data-objects) of using phpdoc annotation for a collection of data objects in the validation section.

However, it appears that some validation rules simply do not work when using these preferred method. I haven't tested everything, but it seems that rules referencing other fields on the nested Data object do not work.

I'm not sure why, but my hunch is that the validation path is not correctly set when the rules are generated.

**↪️ To Reproduce**
See the failing tests in the PR.

**✅ Expected behavior**

Rules referencing other fields on a nested data object contained within an array or Collection on the parent data object work as expected.

**🖥️ Versions**

Laravel: 12
Laravel Data: 4.18.0
PHP: 8.4
