### PR TITLE
BackedEnum to scalar cast

### DIFF
--- a/src/Casts/BackedEnumToScalarCast.php
+++ b/src/Casts/BackedEnumToScalarCast.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Spatie\LaravelData\Casts;
+
+use BackedEnum;
+use InvalidArgumentException;
+use Spatie\LaravelData\Exceptions\CannotCastScalarFromEnum;
+use Spatie\LaravelData\Support\Creation\CreationContext;
+use Spatie\LaravelData\Support\DataProperty;
+
+class BackedEnumToScalarCast implements Cast
+{
+    /**
+     * @param 'name'|'value' $output determines whether to return enum value or enum name
+     */
+    public function __construct(protected string $output = 'value')
+    {
+        if (! in_array($this->output, ['value', 'name'], true)) {
+            throw new InvalidArgumentException('Output must be either "value" or "name".');
+        }
+    }
+
+    /**
+     * Cast enum to scalar (string/int) for serialization.
+     */
+    public function cast(DataProperty $property, mixed $value, array $properties, CreationContext $context): null|int|string
+    {
+        if ($value instanceof BackedEnum) {
+            return $this->output === 'value' ? $value->value : $value->name;
+        }
+
+        if (is_string($value) || is_int($value)) {
+            return $value;
+        }
+
+        throw CannotCastScalarFromEnum::create($this->output, $value);
+    }
+}

--- a/src/Exceptions/CannotCastScalarFromEnum.php
+++ b/src/Exceptions/CannotCastScalarFromEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\LaravelData\Exceptions;
+
+use Exception;
+
+class CannotCastScalarFromEnum extends Exception
+{
+    public static function create(string $output, mixed $value): self
+    {
+        $valueStr = get_debug_type($value);
+
+        return new self(
+            "Could not cast from property `{$valueStr}::{$output}` into a scalar value."
+        );
+    }
+}

--- a/tests/Casts/BackedEnumToScalarCastTest.php
+++ b/tests/Casts/BackedEnumToScalarCastTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Spatie\LaravelData\Casts\BackedEnumToScalarCast;
+use Spatie\LaravelData\Exceptions\CannotCastScalarFromEnum;
+use Spatie\LaravelData\Support\Creation\CreationContextFactory;
+use Spatie\LaravelData\Tests\Factories\FakeDataStructureFactory;
+use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
+use Spatie\LaravelData\Tests\Fakes\Enums\DummyUnitEnum;
+
+it('can cast enum to scalar', function (string $methodName) {
+    $enum = DummyBackedEnum::FOO;
+    $class = new class () {
+        public bool|int|float|string|array $value;
+    };
+
+    $caster = new BackedEnumToScalarCast($methodName);
+    expect(
+        $caster->cast(
+            FakeDataStructureFactory::property($class, 'value'),
+            $enum,
+            [],
+            CreationContextFactory::createFromConfig($class::class)->get()
+        )
+    )->toEqual($enum->$methodName);
+})->with(['name', 'value']);
+
+
+it('fails when casting an unit enum', function () {
+    $class = new class () {
+        public DummyUnitEnum $enum;
+    };
+    $value = 1.11;
+    $caster = new BackedEnumToScalarCast();
+    $caster->cast(
+        FakeDataStructureFactory::property($class, 'enum'),
+        $value,
+        [],
+        CreationContextFactory::createFromConfig($class::class)->get()
+    );
+})->throws(
+    CannotCastScalarFromEnum::class,
+);


### PR DESCRIPTION
When serializing data often the target source expects `string|int` instead of a BackedEnum.