### PR TITLE
Improve static analysis for paginator items

### DIFF
--- a/src/PaginatedDataCollection.php
+++ b/src/PaginatedDataCollection.php
@@ -85,7 +85,7 @@ class PaginatedDataCollection implements Responsable, BaseDataCollectableContrac
      */
     public function data(): array
     {
-        return $this->items->itmes();
+        return $this->items->items();
     }
 
     public static function castUsing(array $arguments)


### PR DESCRIPTION
Currently when using `PaginatedDataCollection` the `items()` method does not define the item data type.

Example:
```php
$paginatedData = ExampleData::collect($data, PaginatedDataCollection::class); 

foreach($paginatedData->items()->items() as $item)
{
  /*
   * Problem #1: $item here is mixed 😢
   * Problem #2: items() returning a Paginator isn't intuitive, I expected the actual items. 
   *   We end up needing to do ->items()->items()
   */
}
```

- I added `@return Paginator<TKey, TValue>`  to help with static analysis and address problem 1
- Added `data` method instead of changing the `items` method to address problem 2