### PR TITLE
Fix: use `findOrFail` instead of `firstOrFail`

### DIFF
--- a/docs/as-a-data-transfer-object/creating-a-data-object.md
+++ b/docs/as-a-data-transfer-object/creating-a-data-object.md
@@ -41,7 +41,7 @@ class Song extends Model
 You can create a data object from such a model like this:
 
 ```php
-SongData::from(Song::firstOrFail($id));
+SongData::from(Song::findOrFail($id));
 ```
 
 The package will find the required properties within the model and use them to construct the data object.


### PR DESCRIPTION
If we use `firstOrFail()`, it will throw this error:
```php
Illuminate\Database\QueryException: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'some-ulid-or-id' in 'field list' (Connection: mysql, SQL: select `some-ulid-or-id` from `table_name` limit 1)
```