### PR TITLE
Fix DataTypeScriptTransformer to make it respect `TypeScriptTransformableAttribute`

### DIFF
--- a/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
+++ b/src/Support/TypeScriptTransformer/DataTypeScriptTransformer.php
@@ -25,6 +25,7 @@ use Spatie\TypeScriptTransformer\Attributes\Optional as TypeScriptOptional;
 use Spatie\TypeScriptTransformer\Structures\MissingSymbolsCollection;
 use Spatie\TypeScriptTransformer\TypeProcessors\DtoCollectionTypeProcessor;
 use Spatie\TypeScriptTransformer\TypeProcessors\ReplaceDefaultsTypeProcessor;
+use Spatie\TypeScriptTransformer\TypeReflectors\TypeReflector;
 use Spatie\TypeScriptTransformer\Types\StructType;
 
 class DataTypeScriptTransformer extends DtoTransformer
@@ -111,6 +112,22 @@ class DataTypeScriptTransformer extends DtoTransformer
                 $missingSymbols,
                 ...$this->typeProcessors()
             );
+        }
+
+        if ($type = TypeReflector::new($property)->reflectionFromAttribute()) {
+            foreach ($this->typeProcessors() as $processor) {
+                $type = $processor->process(
+                    $type,
+                    $property,
+                    $missingSymbols
+                );
+                if ($type === null) {
+                    break;
+                }
+            }
+            if ($type !== null) {
+                return $type;
+            }
         }
 
         $collectionType = match ($dataProperty->type->kind) {

--- a/tests/Support/TypeScriptTransformer/DataTypeScriptTransformerTest.php
+++ b/tests/Support/TypeScriptTransformer/DataTypeScriptTransformerTest.php
@@ -16,6 +16,7 @@ use Spatie\LaravelData\Support\TypeScriptTransformer\DataTypeScriptTransformer;
 use Spatie\LaravelData\Tests\Fakes\DataWithMapper;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
 
+use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
 use function Spatie\Snapshots\assertMatchesSnapshot as baseAssertMatchesSnapshot;
 
 use Spatie\Snapshots\Driver;
@@ -317,6 +318,29 @@ it('will transform a collection with int key as an array', function () {
         <<<TXT
         {
         collection: Array<{%Spatie\LaravelData\Tests\Fakes\SimpleData%}>;
+        }
+        TXT,
+        $transformer->transform($reflection, 'DataObject')->transformed
+    );
+});
+
+it('should respect TypeScriptTransformableAttribute even with isDataCollectable', function () {
+    $config = TypeScriptTransformerConfig::create();
+
+    $data = new class () extends Data {
+        /** @var array<int, \Spatie\LaravelData\Tests\Fakes\SimpleData> */
+        #[LiteralTypeScriptType("CustomType")]
+        public array $collection;
+    };
+
+    $transformer = new DataTypeScriptTransformer($config);
+    $reflection = new ReflectionClass($data);
+
+    $this->assertTrue($transformer->canTransform($reflection));
+    $this->assertEquals(
+        <<<TXT
+        {
+        collection: CustomType;
         }
         TXT,
         $transformer->transform($reflection, 'DataObject')->transformed


### PR DESCRIPTION
Fix #1128

Fix DataTypeScriptTransformer to make it respect `TypeScriptTransformableAttribute` if possible