### PR TITLE
Fix: Deprication warning for symfony/http-foundation 7.4

### DIFF
--- a/src/Resolvers/RequestQueryStringPartialsResolver.php
+++ b/src/Resolvers/RequestQueryStringPartialsResolver.php
@@ -40,9 +40,9 @@ class RequestQueryStringPartialsResolver
 
         $partials = new PartialsCollection();
 
-        $partialStrings = is_array($request->get($parameter))
-            ? $request->get($parameter)
-            : explode(',', $request->get($parameter));
+        $partialStrings = is_array($request->input($parameter))
+            ? $request->input($parameter)
+            : explode(',', $request->input($parameter));
 
         foreach ($partialStrings as $partialString) {
             $partial = Partial::create($partialString);


### PR DESCRIPTION
Since Symfony 7.4, the get method is depricated as it can be seen here:
https://github.com/symfony/http-foundation/blob/977a554a34cf8edc95ca351fbecb1bb1ad05cc94/Request.php#L742

This cascades to Laravel's Illuminate\Http\Request as it can be seen here:
https://github.com/laravel/framework/blob/93686c3b428bdc0d3a1ec7c2d7024869252b3e28/src/Illuminate/Http/Request.php#L427-L440

This fixes the depreciation warning.