### PR TITLE
Fix deprecation warning for ReflectionProperty::getDefaultValue()

### DIFF
--- a/src/Support/Factories/DataPropertyFactory.php
+++ b/src/Support/Factories/DataPropertyFactory.php
@@ -61,7 +61,7 @@ class DataPropertyFactory
 
         if (! $reflectionProperty->isPromoted()) {
             $hasDefaultValue = $reflectionProperty->hasDefaultValue();
-            $defaultValue = $reflectionProperty->getDefaultValue();
+            $defaultValue = $hasDefaultValue ? $reflectionProperty->getDefaultValue() : null;
         }
 
         if ($hasDefaultValue && $defaultValue instanceof Optional) {


### PR DESCRIPTION
Only call getDefaultValue() when hasDefaultValue() returns true to avoid the PHP deprecation warning when accessing properties without default values.

Closes #1134