### PR TITLE
Drop PHP 8.1 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        php: [8.2, 8.3, 8.4, 8.5]
         laravel: [10.*, 11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         include:
@@ -20,10 +20,6 @@ jobs:
           - laravel: 12.*
             testbench: ^10.9
         exclude:
-          - php: 8.1
-            laravel: 11.*
-          - php: 8.1
-            laravel: 12.*
           - php: 8.2
             laravel: 12.*
           - php: 8.4

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require" : {
-        "php" : "^8.1",
+        "php" : "^8.2",
         "illuminate/contracts" : "^10.0|^11.0|^12.0",
         "phpdocumentor/reflection" : "^6.0",
         "spatie/laravel-package-tools" : "^1.9.0",


### PR DESCRIPTION
## Summary
- Remove PHP 8.1 from test matrix
- Update composer.json minimum PHP version to ^8.2

## Reason
Pest 2.36.1+ requires PHP 8.2, making PHP 8.1 incompatible with the test suite. The current CI is failing because:

```
pestphp/pest[v2.36.1, ..., 2.x-dev, v3.8.0, ..., 3.x-dev] require php ^8.2.0
```

This change allows all tests (including PHP 8.5) to run successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)