### PR TITLE
Fix deprecation warning for 'SplObjectStorage::attach'

### DIFF
--- a/src/Concerns/ContextableData.php
+++ b/src/Concerns/ContextableData.php
@@ -33,7 +33,7 @@ trait ContextableData
                 }
 
                 foreach ($this->includeProperties() as $key => $value) {
-                    $includePartials->attach(Partial::fromMethodDefinedKeyAndValue($key, $value));
+                    $includePartials->offsetSet(Partial::fromMethodDefinedKeyAndValue($key, $value));
                 }
 
                 if (! empty($this->excludeProperties())) {
@@ -41,7 +41,7 @@ trait ContextableData
                 }
 
                 foreach ($this->excludeProperties() as $key => $value) {
-                    $excludePartials->attach(Partial::fromMethodDefinedKeyAndValue($key, $value));
+                    $excludePartials->offsetSet(Partial::fromMethodDefinedKeyAndValue($key, $value));
                 }
 
                 if (! empty($this->onlyProperties())) {
@@ -49,7 +49,7 @@ trait ContextableData
                 }
 
                 foreach ($this->onlyProperties() as $key => $value) {
-                    $onlyPartials->attach(Partial::fromMethodDefinedKeyAndValue($key, $value));
+                    $onlyPartials->offsetSet(Partial::fromMethodDefinedKeyAndValue($key, $value));
                 }
 
                 if (! empty($this->exceptProperties())) {
@@ -57,7 +57,7 @@ trait ContextableData
                 }
 
                 foreach ($this->exceptProperties() as $key => $value) {
-                    $exceptPartials->attach(Partial::fromMethodDefinedKeyAndValue($key, $value));
+                    $exceptPartials->offsetSet(Partial::fromMethodDefinedKeyAndValue($key, $value));
                 }
             }
 

--- a/src/Resolvers/RequestQueryStringPartialsResolver.php
+++ b/src/Resolvers/RequestQueryStringPartialsResolver.php
@@ -57,7 +57,7 @@ class RequestQueryStringPartialsResolver
                 continue;
             }
 
-            $partials->attach(new Partial($partialSegments, permanent: false, condition: null));
+            $partials->offsetSet(new Partial($partialSegments, permanent: false, condition: null));
         }
 
         return $partials;

--- a/src/Support/Partials/ForwardsToPartialsDefinition.php
+++ b/src/Support/Partials/ForwardsToPartialsDefinition.php
@@ -21,7 +21,7 @@ trait ForwardsToPartialsDefinition
         $partialsCollection = $this->getPartialsContainer()->includePartials ??= new PartialsCollection();
 
         foreach ($includes as $include) {
-            $partialsCollection->attach(Partial::create($include));
+            $partialsCollection->offsetSet(Partial::create($include));
         }
 
         return $this;
@@ -32,7 +32,7 @@ trait ForwardsToPartialsDefinition
         $partialsCollection = $this->getPartialsContainer()->includePartials ??= new PartialsCollection();
 
         foreach ($includes as $include) {
-            $partialsCollection->attach(Partial::create($include, permanent: true));
+            $partialsCollection->offsetSet(Partial::create($include, permanent: true));
         }
 
         return $this;
@@ -43,7 +43,7 @@ trait ForwardsToPartialsDefinition
         $partialsCollection = $this->getPartialsContainer()->excludePartials ??= new PartialsCollection();
 
         foreach ($excludes as $exclude) {
-            $partialsCollection->attach(Partial::create($exclude));
+            $partialsCollection->offsetSet(Partial::create($exclude));
         }
 
         return $this;
@@ -54,7 +54,7 @@ trait ForwardsToPartialsDefinition
         $partialsCollection = $this->getPartialsContainer()->excludePartials ??= new PartialsCollection();
 
         foreach ($excludes as $exclude) {
-            $partialsCollection->attach(Partial::create($exclude, permanent: true));
+            $partialsCollection->offsetSet(Partial::create($exclude, permanent: true));
         }
 
         return $this;
@@ -65,7 +65,7 @@ trait ForwardsToPartialsDefinition
         $partialsCollection = $this->getPartialsContainer()->onlyPartials ??= new PartialsCollection();
 
         foreach ($only as $onlyDefinition) {
-            $partialsCollection->attach(Partial::create($onlyDefinition));
+            $partialsCollection->offsetSet(Partial::create($onlyDefinition));
         }
 
         return $this;
@@ -76,7 +76,7 @@ trait ForwardsToPartialsDefinition
         $partialsCollection = $this->getPartialsContainer()->onlyPartials ??= new PartialsCollection();
 
         foreach ($only as $onlyDefinition) {
-            $partialsCollection->attach(Partial::create($onlyDefinition, permanent: true));
+            $partialsCollection->offsetSet(Partial::create($onlyDefinition, permanent: true));
         }
 
         return $this;
@@ -87,7 +87,7 @@ trait ForwardsToPartialsDefinition
         $partialsCollection = $this->getPartialsContainer()->exceptPartials ??= new PartialsCollection();
 
         foreach ($except as $exceptDefinition) {
-            $partialsCollection->attach(Partial::create($exceptDefinition));
+            $partialsCollection->offsetSet(Partial::create($exceptDefinition));
         }
 
         return $this;
@@ -98,7 +98,7 @@ trait ForwardsToPartialsDefinition
         $partialsCollection = $this->getPartialsContainer()->exceptPartials ??= new PartialsCollection();
 
         foreach ($except as $exceptDefinition) {
-            $partialsCollection->attach(Partial::create($exceptDefinition, permanent: true));
+            $partialsCollection->offsetSet(Partial::create($exceptDefinition, permanent: true));
         }
 
         return $this;
@@ -109,9 +109,9 @@ trait ForwardsToPartialsDefinition
         $partialsCollection = $this->getPartialsContainer()->includePartials ??= new PartialsCollection();
 
         if (is_callable($condition)) {
-            $partialsCollection->attach(Partial::createConditional($include, $condition, permanent: $permanent));
+            $partialsCollection->offsetSet(Partial::createConditional($include, $condition, permanent: $permanent));
         } elseif ($condition === true) {
-            $partialsCollection->attach(Partial::create($include, permanent: $permanent));
+            $partialsCollection->offsetSet(Partial::create($include, permanent: $permanent));
         }
 
         return $this;
@@ -122,9 +122,9 @@ trait ForwardsToPartialsDefinition
         $partialsCollection = $this->getPartialsContainer()->excludePartials ??= new PartialsCollection();
 
         if (is_callable($condition)) {
-            $partialsCollection->attach(Partial::createConditional($exclude, $condition, permanent: $permanent));
+            $partialsCollection->offsetSet(Partial::createConditional($exclude, $condition, permanent: $permanent));
         } elseif ($condition === true) {
-            $partialsCollection->attach(Partial::create($exclude, permanent: $permanent));
+            $partialsCollection->offsetSet(Partial::create($exclude, permanent: $permanent));
         }
 
         return $this;
@@ -135,9 +135,9 @@ trait ForwardsToPartialsDefinition
         $partialsCollection = $this->getPartialsContainer()->onlyPartials ??= new PartialsCollection();
 
         if (is_callable($condition)) {
-            $partialsCollection->attach(Partial::createConditional($only, $condition, permanent: $permanent));
+            $partialsCollection->offsetSet(Partial::createConditional($only, $condition, permanent: $permanent));
         } elseif ($condition === true) {
-            $partialsCollection->attach(Partial::create($only, permanent: $permanent));
+            $partialsCollection->offsetSet(Partial::create($only, permanent: $permanent));
         }
 
         return $this;
@@ -148,9 +148,9 @@ trait ForwardsToPartialsDefinition
         $partialsCollection = $this->getPartialsContainer()->exceptPartials ??= new PartialsCollection();
 
         if (is_callable($condition)) {
-            $partialsCollection->attach(Partial::createConditional($except, $condition, permanent: $permanent));
+            $partialsCollection->offsetSet(Partial::createConditional($except, $condition, permanent: $permanent));
         } elseif ($condition === true) {
-            $partialsCollection->attach(Partial::create($except, permanent: $permanent));
+            $partialsCollection->offsetSet(Partial::create($except, permanent: $permanent));
         }
 
         return $this;

--- a/src/Support/Partials/PartialsCollection.php
+++ b/src/Support/Partials/PartialsCollection.php
@@ -15,7 +15,7 @@ class PartialsCollection extends SplObjectStorage implements Stringable
         $collection = new self();
 
         foreach ($partials as $partial) {
-            $collection->attach($partial);
+            $collection->offsetSet($partial);
         }
 
         return $collection;
@@ -69,7 +69,7 @@ class PartialsCollection extends SplObjectStorage implements Stringable
         $collection = new self();
 
         foreach ($this as $partial) {
-            $collection->attach(clone $partial);
+            $collection->offsetSet(clone $partial);
         }
 
         return $collection;

--- a/src/Support/Transformation/DataContext.php
+++ b/src/Support/Transformation/DataContext.php
@@ -59,7 +59,7 @@ class DataContext
                 $partial = $decoupledPartialResolver->execute($partial);
 
                 if ($partial !== null) {
-                    $this->includePartials->attach($partial);
+                    $this->includePartials->offsetSet($partial);
                 }
             }
         }
@@ -71,7 +71,7 @@ class DataContext
                 $partial = $decoupledPartialResolver->execute($partial);
 
                 if ($partial !== null) {
-                    $this->excludePartials->attach($partial);
+                    $this->excludePartials->offsetSet($partial);
                 }
             }
         }
@@ -83,7 +83,7 @@ class DataContext
                 $partial = $decoupledPartialResolver->execute($partial);
 
                 if ($partial !== null) {
-                    $this->onlyPartials->attach($partial);
+                    $this->onlyPartials->offsetSet($partial);
                 }
             }
         }
@@ -95,7 +95,7 @@ class DataContext
                 $partial = $decoupledPartialResolver->execute($partial);
 
                 if ($partial !== null) {
-                    $this->exceptPartials->attach($partial);
+                    $this->exceptPartials->offsetSet($partial);
                 }
             }
         }
@@ -112,11 +112,11 @@ class DataContext
 
         foreach ($partials as $partial) {
             if ($partial->isRequired($data)) {
-                $requiredPartials->attach($partial->reset());
+                $requiredPartials->offsetSet($partial->reset());
             }
 
             if (! $partial->permanent) {
-                $partialsToDetach->attach($partial);
+                $partialsToDetach->offsetSet($partial);
             }
         }
 

--- a/src/Support/Transformation/TransformationContext.php
+++ b/src/Support/Transformation/TransformationContext.php
@@ -43,7 +43,7 @@ class TransformationContext implements Stringable
         }
 
         foreach ($partials as $partial) {
-            $this->includePartials->attach($partial);
+            $this->includePartials->offsetSet($partial);
         }
     }
 
@@ -54,7 +54,7 @@ class TransformationContext implements Stringable
         }
 
         foreach ($partials as $partial) {
-            $this->excludePartials->attach($partial);
+            $this->excludePartials->offsetSet($partial);
         }
     }
 
@@ -65,7 +65,7 @@ class TransformationContext implements Stringable
         }
 
         foreach ($partials as $partial) {
-            $this->onlyPartials->attach($partial);
+            $this->onlyPartials->offsetSet($partial);
         }
     }
 
@@ -76,7 +76,7 @@ class TransformationContext implements Stringable
         }
 
         foreach ($partials as $partial) {
-            $this->exceptPartials->attach($partial);
+            $this->exceptPartials->offsetSet($partial);
         }
     }
 

--- a/src/Support/Transformation/TransformationContextFactory.php
+++ b/src/Support/Transformation/TransformationContextFactory.php
@@ -45,7 +45,7 @@ class TransformationContextFactory
 
             foreach ($this->includePartials as $include) {
                 if ($include->isRequired($data)) {
-                    $includePartials->attach($include->reset());
+                    $includePartials->offsetSet($include->reset());
                 }
             }
         }
@@ -57,7 +57,7 @@ class TransformationContextFactory
 
             foreach ($this->excludePartials as $exclude) {
                 if ($exclude->isRequired($data)) {
-                    $excludePartials->attach($exclude->reset());
+                    $excludePartials->offsetSet($exclude->reset());
                 }
             }
         }
@@ -69,7 +69,7 @@ class TransformationContextFactory
 
             foreach ($this->onlyPartials as $only) {
                 if ($only->isRequired($data)) {
-                    $onlyPartials->attach($only->reset());
+                    $onlyPartials->offsetSet($only->reset());
                 }
             }
         }
@@ -81,7 +81,7 @@ class TransformationContextFactory
 
             foreach ($this->exceptPartials as $except) {
                 if ($except->isRequired($data)) {
-                    $exceptPartials->attach($except->reset());
+                    $exceptPartials->offsetSet($except->reset());
                 }
             }
         }


### PR DESCRIPTION
`SplObjectStorage::attach` has been deprecated as of PHP 8.5 (see [SplObjectStorage::attach](https://www.php.net/manual/en/splobjectstorage.attach.php)). This triggers the following the warning:

```php
Method SplObjectStorage::attach() is deprecated since 8.5, use method SplObjectStorage::offsetSet() instead in vendor\spatie\laravel-data\src\Support\Transformation\DataContext.php on line 119
```

Since `attach` is an alias of `offsetSet` (see PHP docs), this PR replaces all `SplObjectStorage::attach` calls with `SplObjectStorage::offsetSet` 

Closes #1126