### PR TITLE
Fix NormalizedModel not resolving non-snake-cased model attributes

### DIFF
--- a/src/Normalizers/Normalized/NormalizedModel.php
+++ b/src/Normalizers/Normalized/NormalizedModel.php
@@ -24,11 +24,25 @@ class NormalizedModel implements Normalized
 
     public function getProperty(string $name, DataProperty $dataProperty): mixed
     {
-        $propertyName = $this->model::$snakeAttributes ? Str::snake($name) : $name;
+        $propertyName = $name;
 
-        $value = array_key_exists($propertyName, $this->properties)
-            ? $this->properties[$propertyName]
-            : $this->fetchNewProperty($propertyName, $dataProperty);
+        if (array_key_exists($propertyName, $this->properties)) {
+            $value = $this->properties[$propertyName];
+        } else {
+            $value = $this->fetchNewProperty($propertyName, $dataProperty);
+
+            if ($value instanceof UnknownProperty && $this->model::$snakeAttributes) {
+                $snakeName = Str::snake($name);
+
+                if ($snakeName !== $name) {
+                    $value = $this->fetchNewProperty($snakeName, $dataProperty);
+
+                    if (! $value instanceof UnknownProperty) {
+                        $propertyName = $snakeName;
+                    }
+                }
+            }
+        }
 
         if ($value === null && ! $dataProperty->type->isNullable) {
             return UnknownProperty::create();


### PR DESCRIPTION
Fixes #1148

When `$snakeAttributes` is true (the default), `NormalizedModel::getProperty()` was unconditionally snake-casing the property name before looking it up via `getAttribute()`. This broke models that have PascalCase or camelCase column names — e.g. a model with `MyField` would get looked up as `my_field`, returning null.

This changes the lookup to try the original property name first, and only fall back to the snake_case version when the original name isn't found. This matches v3 behavior where `toArray()` handled attribute access directly.