### PR TITLE
Revert validateAndCreate change that broke prepareForPipeline

### DIFF
--- a/src/Concerns/ValidateableData.php
+++ b/src/Concerns/ValidateableData.php
@@ -36,11 +36,7 @@ trait ValidateableData
 
     public static function validateAndCreate(Arrayable|array $payload): static
     {
-        static::validate($payload);
-
-        return static::factory()
-            ->withoutValidation()
-            ->from($payload);
+        return static::factory()->alwaysValidate()->from($payload);
     }
 
     public static function withValidator(Validator $validator): void

--- a/src/Resolvers/DataFromSomethingResolver.php
+++ b/src/Resolvers/DataFromSomethingResolver.php
@@ -9,7 +9,6 @@ use Spatie\LaravelData\Exceptions\CannotCreateAbstractClass;
 use Spatie\LaravelData\Normalizers\Normalized\Normalized;
 use Spatie\LaravelData\Optional;
 use Spatie\LaravelData\Support\Creation\CreationContext;
-use Spatie\LaravelData\Support\Creation\ValidationStrategy;
 use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelData\Support\ResolvedDataPipeline;
 
@@ -129,7 +128,7 @@ class DataFromSomethingResolver
         $pipeline = $this->dataConfig->getResolvedDataPipeline($class);
 
         foreach ($payloads as $payload) {
-            if ($payload instanceof Request && ($creationContext->validationStrategy !== ValidationStrategy::Disabled)) {
+            if ($payload instanceof Request) {
                 // Solely for the purpose of validation
                 $pipeline->execute($payload, $creationContext);
             }

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -2504,42 +2504,6 @@ it('can validate a payload for a data object and create one using a magic from m
     assertFalse(true, 'We should not end up here');
 });
 
-it('can validate and create a data object with magic method that does not contain a request param', function () {
-    $dataClass = new class () extends Data {
-        public string $string;
-
-        public static function fromArray(array $data): self
-        {
-            $self = new self();
-
-            $self->string = strtoupper($data['string']);
-
-            return $self;
-
-        }
-    };
-
-    $data = $dataClass::validateAndCreate(
-        ['string' => 'hello world'],
-    );
-
-    expect($data)
-        ->string->toBe('HELLO WORLD')
-        ->string->not()->toBe('hello world');
-
-    try {
-        SimpleData::validateAndCreate([]);
-    } catch (ValidationException $exception) {
-        expect($exception->errors())->toMatchArray([
-            'string' => [__('validation.required', ['attribute' => 'string'])],
-        ]);
-
-        return;
-    }
-
-    assertFalse(true, 'We should not end up here');
-});
-
 it('can the validation rules for a data object', function () {
     expect(MultiData::getValidationRules([]))->toEqual([
         'first' => ['required', 'string'],


### PR DESCRIPTION
## Summary

- Reverts the change from #1096 that separated validation from the creation pipeline in `validateAndCreate`
- Fixes #1115 where `prepareForPipeline` no longer ran before validation

The original change was made to fix #1058 (validation not running with custom `fromX()` methods), but magic methods bypassing the pipeline is by design and documented. The fix caused a bigger regression where `prepareForPipeline` stopped working before validation.