### PR TITLE
Inline data specific rules and fix wildcard collection rule overrides

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -193,12 +193,6 @@ parameters:
 			path: src/Resolvers/DataValidationMessagesAndAttributesResolver.php
 
 		-
-			message: '#^Parameter \#1 \$callback of method Illuminate\\Container\\Container\:\:call\(\) expects \(callable\(\)\: mixed\)\|string, array\{class\-string, ''rules''\} given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Resolvers/DataValidationRulesResolver.php
-
-		-
 			message: '#^Parameter \#1 \$callback of method Illuminate\\Container\\Container\:\:call\(\) expects \(callable\(\)\: mixed\)\|string, array\{class\-string\<Spatie\\LaravelData\\Contracts\\BaseData&Spatie\\LaravelData\\Contracts\\ValidateableData\>, ''stopOnFirstFailure''\} given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Resolvers/DataValidationRulesResolver.php
+++ b/src/Resolvers/DataValidationRulesResolver.php
@@ -49,13 +49,48 @@ class DataValidationRulesResolver
                 continue;
             }
 
-            if ($dataProperty->type->kind->isDataObject() || $dataProperty->type->kind->isDataCollectable()) {
-                $this->resolveDataSpecificRules(
+            $isOptionalAndEmpty = $dataProperty->type->isOptional && Arr::has($fullPayload, $propertyPath->get()) === false;
+            $isNullableAndEmpty = $dataProperty->type->isNullable && Arr::get($fullPayload, $propertyPath->get()) === null;
+
+            if ($dataProperty->type->kind->isDataRelated() && ($isOptionalAndEmpty || $isNullableAndEmpty)) {
+                $this->resolveToplevelRules(
                     $dataProperty,
                     $fullPayload,
                     $path,
                     $propertyPath,
                     $dataRules
+                );
+
+                continue;
+            }
+
+            if ($dataProperty->type->kind->isDataObject()) {
+                $this->resolveToplevelRules(
+                    $dataProperty,
+                    $fullPayload,
+                    $path,
+                    $propertyPath,
+                    $dataRules
+                );
+
+                $this->execute(
+                    $dataProperty->type->dataClass,
+                    $fullPayload,
+                    $propertyPath,
+                    $dataRules,
+                );
+
+                continue;
+            }
+
+            if ($dataProperty->type->kind->isDataCollectable()) {
+                $this->resolveDataCollectionSpecificRules(
+                    $dataClass,
+                    $dataProperty,
+                    $fullPayload,
+                    $path,
+                    $propertyPath,
+                    $dataRules,
                 );
 
                 continue;
@@ -102,75 +137,8 @@ class DataValidationRulesResolver
         return false;
     }
 
-    protected function resolveDataSpecificRules(
-        DataProperty $dataProperty,
-        array $fullPayload,
-        ValidationPath $path,
-        ValidationPath $propertyPath,
-        DataRules $dataRules,
-    ): void {
-        $isOptionalAndEmpty = $dataProperty->type->isOptional && Arr::has($fullPayload, $propertyPath->get()) === false;
-        $isNullableAndEmpty = $dataProperty->type->isNullable && Arr::get($fullPayload, $propertyPath->get()) === null;
-
-        if ($isOptionalAndEmpty || $isNullableAndEmpty) {
-            $this->resolveToplevelRules(
-                $dataProperty,
-                $fullPayload,
-                $path,
-                $propertyPath,
-                $dataRules
-            );
-
-            return;
-        }
-
-        if ($dataProperty->type->kind->isDataObject()) {
-            $this->resolveDataObjectSpecificRules(
-                $dataProperty,
-                $fullPayload,
-                $path,
-                $propertyPath,
-                $dataRules
-            );
-
-            return;
-        }
-
-        if ($dataProperty->type->kind->isDataCollectable()) {
-            $this->resolveDataCollectionSpecificRules(
-                $dataProperty,
-                $fullPayload,
-                $path,
-                $propertyPath,
-                $dataRules
-            );
-        }
-    }
-
-    protected function resolveDataObjectSpecificRules(
-        DataProperty $dataProperty,
-        array $fullPayload,
-        ValidationPath $path,
-        ValidationPath $propertyPath,
-        DataRules $dataRules,
-    ): void {
-        $this->resolveToplevelRules(
-            $dataProperty,
-            $fullPayload,
-            $path,
-            $propertyPath,
-            $dataRules
-        );
-
-        $this->execute(
-            $dataProperty->type->dataClass,
-            $fullPayload,
-            $propertyPath,
-            $dataRules,
-        );
-    }
-
     protected function resolveDataCollectionSpecificRules(
+        DataClass $dataClass,
         DataProperty $dataProperty,
         array $fullPayload,
         ValidationPath $path,
@@ -194,7 +162,7 @@ class DataValidationRulesResolver
 
         $itemDataClass = $this->dataConfig->getDataClass($dataProperty->type->dataClass);
 
-        if (! $itemDataClass->hasDynamicValidationRules) {
+        if (! $itemDataClass->hasDynamicValidationRules && ! $dataClass->hasDynamicValidationRules) {
             $this->resolveStaticCollectionRules(
                 $itemDataClass,
                 $collectionPayload,
@@ -297,7 +265,7 @@ class DataValidationRulesResolver
         DataRules $dataRules,
         array $withoutValidationProperties
     ): void {
-        if (! method_exists($class->name, 'rules')) {
+        if (! $class->hasDynamicValidationRules) {
             return;
         }
 

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -938,6 +938,35 @@ it('can overwrite collection class rules', function () {
         ]);
 });
 
+it('can overwrite collection item rules with wildcard rules', function () {
+    // https://github.com/spatie/laravel-data/issues/1121
+    $dataClass = new class () extends Data {
+        /** @var array<SimpleData> */
+        public array $years;
+
+        public static function rules(): array
+        {
+            return [
+                'years' => ['required', 'array'],
+                'years.*' => ['date_format:Y', 'required'],
+            ];
+        }
+    };
+
+    DataValidationAsserter::for($dataClass)
+        ->assertOk(['years' => ['2025']])
+        ->assertErrors(['years' => ['not-a-year']])
+        ->assertRules([
+            'years' => ['required', 'array'],
+        ], payload: [])
+        ->assertRules([
+            'years' => ['required', 'array'],
+            'years.0' => ['date_format:Y', 'required'],
+        ], payload: [
+            'years' => ['2025'],
+        ]);
+});
+
 /**
  * Complex Examples
  */


### PR DESCRIPTION
## Summary

We had a `resolveDataSpecificRules` method that was essentially a routing function, checking if a property was optional/nullable, a data object, or a data collectable and then dispatching to the right resolver. Since `$dataClass` is already available in the loop, we can inline all of that and pass `hasDynamicValidationRules` directly where it's needed.

This also fixes an issue (#1121) where wildcard rules on collections (like `years.*`) defined in a `rules()` method weren't being applied. The problem was that the parent's `hasDynamicValidationRules` flag wasn't propagated to the collection resolver, so it took the static rules path and ignored the overwritten rules entirely. Now that `$dataClass` is passed directly, this works as expected.

- Inlined `resolveDataSpecificRules` and `resolveDataObjectSpecificRules` into the main loop
- Pass `$dataClass` directly to `resolveDataCollectionSpecificRules` so `hasDynamicValidationRules` is available
- Removed stale PHPStan baseline entry
- Added test for wildcard collection rule overrides (fixes #1121)