### PR TITLE
Add required validation rule to bool properties

### DIFF
--- a/src/RuleInferrers/BuiltInTypesRuleInferrer.php
+++ b/src/RuleInferrers/BuiltInTypesRuleInferrer.php
@@ -10,7 +10,6 @@ use Spatie\LaravelData\Attributes\Validation\Numeric;
 use Spatie\LaravelData\Attributes\Validation\StringType;
 use Spatie\LaravelData\Support\DataProperty;
 use Spatie\LaravelData\Support\Validation\PropertyRules;
-use Spatie\LaravelData\Support\Validation\RequiringRule;
 use Spatie\LaravelData\Support\Validation\ValidationContext;
 
 class BuiltInTypesRuleInferrer implements RuleInferrer
@@ -29,8 +28,6 @@ class BuiltInTypesRuleInferrer implements RuleInferrer
         }
 
         if ($property->type->type->acceptsType('bool')) {
-            $rules->removeType(RequiringRule::class);
-
             $rules->add(new BooleanType());
         }
 

--- a/src/RuleInferrers/RequiredRuleInferrer.php
+++ b/src/RuleInferrers/RequiredRuleInferrer.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\LaravelData\RuleInferrers;
 
-use Spatie\LaravelData\Attributes\Validation\BooleanType;
 use Spatie\LaravelData\Attributes\Validation\Nullable;
 use Spatie\LaravelData\Attributes\Validation\Present;
 use Spatie\LaravelData\Attributes\Validation\Required;
@@ -32,10 +31,6 @@ class RequiredRuleInferrer implements RuleInferrer
         }
 
         if ($property->type->kind->isDataCollectable() && $rules->hasType(Present::class)) {
-            return false;
-        }
-
-        if ($rules->hasType(BooleanType::class)) {
             return false;
         }
 

--- a/tests/RuleInferrers/RequiredRuleInferrerTest.php
+++ b/tests/RuleInferrers/RequiredRuleInferrerTest.php
@@ -84,7 +84,7 @@ it("won't add a required rule when a property already contains a required object
 });
 
 it(
-    "won't add a required rule when a property already contains a boolean rule",
+    "will add a required rule when a property contains a boolean rule",
     function () {
         $dataProperty = getProperty(new class () extends Data {
             public string $string;
@@ -97,7 +97,7 @@ it(
         );
 
         expect(app(RuleDenormalizer::class)->execute($rules->all(), ValidationPath::create()))
-            ->toEqualCanonicalizing([new BooleanType()]);
+            ->toEqualCanonicalizing(['required', 'boolean']);
     }
 );
 

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -135,8 +135,10 @@ it('can validate a bool', function () {
 
     DataValidationAsserter::for($dataClass)
         ->assertOk(['property' => true])
+        ->assertOk(['property' => false])
+        ->assertErrors([])
         ->assertRules([
-            'property' => ['boolean'],
+            'property' => ['required', 'boolean'],
         ]);
 });
 
@@ -273,12 +275,6 @@ it('will never add extra require rules when not required', function () {
     ]);
 
     DataValidationAsserter::for(new class () extends Data {
-        public bool $property;
-    })->assertRules([
-        'property' => ['boolean'],
-    ]);
-
-    DataValidationAsserter::for(new class () extends Data {
         #[RequiredWith('other')]
         public string $property;
     })->assertRules([
@@ -304,7 +300,7 @@ it('is possible to have multiple required rules', function () {
     })->assertRules([
         'property' => ['string', 'required_unless:is_required', 'required_with:make_required'],
         'make_required' => ['required', 'string'],
-        'is_required' => ['boolean'],
+        'is_required' => ['required', 'boolean'],
     ]);
 })->skip('Add a new ruleinferrer to rule them all and make these cases better');
 
@@ -439,7 +435,7 @@ it('can write custom rules based upon payloads', function () {
     DataValidationAsserter::for($dataClass)
         ->assertRules(
             rules: [
-                'strict' => ['boolean'],
+                'strict' => ['required', 'boolean'],
                 'property' => ['in:strict'],
                 'mapped_property' => ['in:strict'],
             ],
@@ -449,7 +445,7 @@ it('can write custom rules based upon payloads', function () {
         )
         ->assertRules(
             rules: [
-                'strict' => ['boolean'],
+                'strict' => ['required', 'boolean'],
                 'property' => ['required', 'string'],
                 'mapped_property' => ['required', 'string'],
             ],
@@ -597,7 +593,7 @@ test('can use a reference to another field in data', function () {
         ])
         ->assertRules(
             rules: [
-                'check_string' => ['boolean'],
+                'check_string' => ['required', 'boolean'],
                 'string' => ['string', 'required_if:check_string,1'],
             ],
             payload: [
@@ -621,7 +617,7 @@ test('can use a reference to another field in nested data', function () {
         ->assertRules(
             rules: [
                 'nested' => ['required', 'array'],
-                'nested.check_string' => ['boolean'],
+                'nested.check_string' => ['required', 'boolean'],
                 'nested.string' => ['string', 'required_if:nested.check_string,1'],
             ],
             payload: [
@@ -650,7 +646,7 @@ test('can use a reference to another field in a collection', function () {
         ->assertRules(
             rules: [
                 'collection' => ['present', 'array'],
-                'collection.0.check_string' => ['boolean'],
+                'collection.0.check_string' => ['required', 'boolean'],
                 'collection.0.string' => ['string', 'required_if:collection.0.check_string,1'],
             ],
             payload: [
@@ -685,7 +681,7 @@ test('can use a reference to another field in a collection with nested data', fu
             rules: [
                 'collection' => ['present', 'array'],
                 'collection.0.nested' => ['required', 'array'],
-                'collection.0.nested.check_string' => ['boolean'],
+                'collection.0.nested.check_string' => ['required', 'boolean'],
                 'collection.0.nested.string' => ['string', 'required_if:collection.0.nested.check_string,1'],
             ],
             payload: [
@@ -720,7 +716,7 @@ it('can reference to the root validated object in nested data', function () {
         ])
         ->assertRules(
             rules: [
-                'check_string' => ['boolean'],
+                'check_string' => ['required', 'boolean'],
                 'nested' => ['required', 'array'],
                 'nested.string' => ['string', 'required_if:check_string,1'],
             ],


### PR DESCRIPTION
Up until now, `bool` typed properties didn't get the `required` validation rule inferred. This was an intentional decision from way back when most forms were plain HTML. An unchecked checkbox doesn't send a value at all, so `required|boolean` would fail for unchecked checkboxes.

The thing is, this created some pretty weird behavior. When you had a non-nullable `bool` property without a default value and the field was missing from the payload:

- `validate([])` would pass silently (no validation error)
- `validateAndCreate([])` with constructor promoted properties would throw `CannotCreateData` instead of a `ValidationException`
- `validateAndCreate([])` without constructor promotion would silently create an object with an uninitialized typed `bool` property:

```php
class SettingsData extends Data
{
    public bool $is_active;
}

$data = SettingsData::validateAndCreate([]);
// No exception, but...
$data->is_active; // TypeError: Typed property SettingsData::$is_active must not be accessed before initialization
```

That's something we don't want. You'd expect a proper validation error, not a 500 or a broken object.

So we've removed the special bool handling from `BuiltInTypesRuleInferrer` and `RequiredRuleInferrer`. A `bool` property now gets `['required', 'boolean']` as its inferred rules, just like `string` gets `['required', 'string']`.

This is technically a breaking change, but only for code that was already broken. There's no scenario where a missing non-nullable, non-default `bool` property worked correctly before. It either threw an exception or created an object you couldn't safely use.

If you're using `bool` properties where the field might not always be present (like old school HTML checkboxes), you can resolve this by adding a default value:

```php
public bool $is_active = false;
```

Properties with a default value skip validation entirely when the field is missing, so this is a quick fix.

Nullable and Optional bool properties are not affected by this change. They keep working exactly as before:

```php
public ?bool $property;        // ['nullable', 'boolean'] — unchanged
public bool|Optional $property; // ['sometimes', 'boolean'] — unchanged
public bool $property = false;  // no rules when missing — unchanged
```

Fixes #1152
Fixes #681