### PR TITLE
Include lazy properties when storing data via Eloquent casts

### DIFF
--- a/src/Support/EloquentCasts/DataCollectionEloquentCast.php
+++ b/src/Support/EloquentCasts/DataCollectionEloquentCast.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Crypt;
 use Spatie\LaravelData\Contracts\BaseData;
 use Spatie\LaravelData\Contracts\BaseDataCollectable;
+use Spatie\LaravelData\Contracts\IncludeableData;
 use Spatie\LaravelData\Contracts\TransformableData;
 use Spatie\LaravelData\DataCollection;
 use Spatie\LaravelData\Exceptions\CannotCastData;
@@ -90,6 +91,10 @@ class DataCollectionEloquentCast implements CastsAttributes
             if ($isAbstractClassCast && $item instanceof TransformableData) {
                 $class = get_class($item);
 
+                if ($item instanceof IncludeableData) {
+                    $item->include('*');
+                }
+
                 return [
                     'type' => $this->dataConfig->morphMap->getDataClassAlias($class) ?? $class,
                     'data' => json_decode(json: $item->toJson(), associative: true, flags: JSON_THROW_ON_ERROR),
@@ -106,6 +111,10 @@ class DataCollectionEloquentCast implements CastsAttributes
         }
 
         $dataCollection = new ($this->dataCollectionClass)($this->dataClass, $data);
+
+        if ($dataCollection instanceof IncludeableData) {
+            $dataCollection->include('*');
+        }
 
         $dataCollection = $dataCollection->toJson();
 

--- a/src/Support/EloquentCasts/DataCollectionEloquentCast.php
+++ b/src/Support/EloquentCasts/DataCollectionEloquentCast.php
@@ -112,9 +112,7 @@ class DataCollectionEloquentCast implements CastsAttributes
 
         $dataCollection = new ($this->dataCollectionClass)($this->dataClass, $data);
 
-        if ($dataCollection instanceof IncludeableData) {
-            $dataCollection->include('*');
-        }
+        $dataCollection->include('*');
 
         $dataCollection = $dataCollection->toJson();
 

--- a/src/Support/EloquentCasts/DataEloquentCast.php
+++ b/src/Support/EloquentCasts/DataEloquentCast.php
@@ -5,6 +5,7 @@ namespace Spatie\LaravelData\Support\EloquentCasts;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\Facades\Crypt;
 use Spatie\LaravelData\Contracts\BaseData;
+use Spatie\LaravelData\Contracts\IncludeableData;
 use Spatie\LaravelData\Contracts\TransformableData;
 use Spatie\LaravelData\Exceptions\CannotCastData;
 use Spatie\LaravelData\Support\DataConfig;
@@ -73,6 +74,10 @@ class DataEloquentCast implements CastsAttributes
 
         if (! $value instanceof TransformableData) {
             throw CannotCastData::shouldBeTransformableData($model::class, $key);
+        }
+
+        if ($value instanceof IncludeableData) {
+            $value->include('*');
         }
 
         $value = $isAbstractClassCast

--- a/tests/Fakes/Models/DummyModelWithCasts.php
+++ b/tests/Fakes/Models/DummyModelWithCasts.php
@@ -7,13 +7,16 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Spatie\LaravelData\DataCollection;
 use Spatie\LaravelData\Tests\Fakes\AbstractData\AbstractData;
+use Spatie\LaravelData\Tests\Fakes\LazyData;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
 
 class DummyModelWithCasts extends Model
 {
     protected $casts = [
         'data' => SimpleData::class,
+        'lazy_data' => LazyData::class,
         'data_collection' => DataCollection::class.':'.SimpleData::class,
+        'lazy_data_collection' => DataCollection::class.':'.LazyData::class,
         'abstract_data' => AbstractData::class,
         'abstract_collection' => DataCollection::class . ':' . AbstractData::class,
     ];
@@ -26,7 +29,9 @@ class DummyModelWithCasts extends Model
             $blueprint->increments('id');
 
             $blueprint->text('data')->nullable();
+            $blueprint->text('lazy_data')->nullable();
             $blueprint->text('data_collection')->nullable();
+            $blueprint->text('lazy_data_collection')->nullable();
             $blueprint->text('abstract_data')->nullable();
             $blueprint->text('abstract_collection')->nullable();
         });

--- a/tests/Support/EloquentCasts/DataCollectionEloquentCastTest.php
+++ b/tests/Support/EloquentCasts/DataCollectionEloquentCastTest.php
@@ -11,6 +11,7 @@ use Spatie\LaravelData\Tests\Fakes\AbstractData\AbstractDataA;
 use Spatie\LaravelData\Tests\Fakes\AbstractData\AbstractDataB;
 use Spatie\LaravelData\Tests\Fakes\AbstractPropertyMorphableData;
 use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
+use Spatie\LaravelData\Tests\Fakes\LazyData;
 use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithCasts;
 use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithCustomCollectionCasts;
 use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithDefaultCasts;
@@ -215,6 +216,22 @@ it('can load and save an abstract property-morphable data collection', function 
     expect($model->data_collection[1])
         ->toBeInstanceOf(PropertyMorphableDataB::class)
         ->b->toBe('bar');
+});
+
+it('can save a data collection with lazy properties which get resolved', function () {
+    DummyModelWithCasts::create([
+        'lazy_data_collection' => LazyData::collect([
+            LazyData::fromString('Hello'),
+            LazyData::fromString('World'),
+        ], DataCollection::class),
+    ]);
+
+    assertDatabaseHas(DummyModelWithCasts::class, [
+        'lazy_data_collection' => json_encode([
+            ['name' => 'Hello'],
+            ['name' => 'World'],
+        ]),
+    ]);
 });
 
 it('can correctly detect if the attribute is dirty', function () {

--- a/tests/Support/EloquentCasts/DataEloquentCastTest.php
+++ b/tests/Support/EloquentCasts/DataEloquentCastTest.php
@@ -13,6 +13,7 @@ use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelData\Tests\Fakes\AbstractData\AbstractDataA;
 use Spatie\LaravelData\Tests\Fakes\AbstractData\AbstractDataB;
 use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
+use Spatie\LaravelData\Tests\Fakes\LazyData;
 use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithCasts;
 use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithDefaultCasts;
 use Spatie\LaravelData\Tests\Fakes\Models\DummyModelWithEncryptedCasts;
@@ -309,6 +310,16 @@ it('can update a model where the cast is initially null', function () {
 
     assertDatabaseHas(DummyModelWithCasts::class, [
         'data' => json_encode(['string' => 'Test']),
+    ]);
+});
+
+it('can save a data object with lazy properties which get resolved', function () {
+    DummyModelWithCasts::create([
+        'lazy_data' => LazyData::fromString('Test'),
+    ]);
+
+    assertDatabaseHas(DummyModelWithCasts::class, [
+        'lazy_data' => json_encode(['name' => 'Test']),
     ]);
 });
 


### PR DESCRIPTION
## Summary

- Lazy properties were silently dropped when saving a Data object through an Eloquent cast, because `toJson()` excludes lazy properties that haven't been explicitly included
- Calls `include('*')` before serialization in both `DataEloquentCast` and `DataCollectionEloquentCast` so all lazy properties are persisted to the database
- `RelationalLazy` and `ConditionalLazy` still respect their own inclusion logic, so this won't force-load relationships

Fixes #1153