### PR TITLE
Fix CannotSetComputedValue for optional computed properties

### DIFF
--- a/src/Resolvers/DataFromArrayResolver.php
+++ b/src/Resolvers/DataFromArrayResolver.php
@@ -55,6 +55,13 @@ class DataFromArrayResolver
                 continue; // Nullable properties get assigned null by default
             }
 
+            if ($property->computed
+                && $property->type->isOptional
+                && $properties[$property->name] instanceof Optional
+            ) {
+                continue; // Optional properties get assigned Optional by default
+            }
+
             if ($property->computed) {
                 if (! config('data.features.ignore_exception_when_trying_to_set_computed_property_value')) {
                     throw CannotSetComputedValue::create($property);

--- a/tests/CreationTest.php
+++ b/tests/CreationTest.php
@@ -790,6 +790,32 @@ it('can have a nullable computed value', function () {
         ->upper_name->toBeNull(); // Case conflicts with DefaultsPipe, ignoring it for now
 });
 
+it('can have an optional computed value', function () {
+    $dataObject = new class ('') extends Data {
+        #[Computed]
+        public string|Optional|null $upper_name;
+
+        public function __construct(
+            public string|Optional $name = new Optional(),
+        ) {
+            $this->upper_name = $name instanceof Optional ? null : strtoupper($name);
+        }
+    };
+
+    config()->set('data.features.ignore_exception_when_trying_to_set_computed_property_value', false);
+
+    expect($dataObject::from(['name' => 'Ruben']))
+        ->name->toBe('Ruben')
+        ->upper_name->toBe('RUBEN');
+
+    expect($dataObject::from([]))
+        ->name->toBeInstanceOf(Optional::class)
+        ->upper_name->toBeNull();
+
+    expect(fn () => $dataObject::from(['name' => 'Ruben', 'upper_name' => 'RUBEN']))
+        ->toThrow(CannotSetComputedValue::class);
+});
+
 it('throws a readable exception message when the constructor fails', function (
     array $data,
     string $message,


### PR DESCRIPTION
## Summary
- When a computed property is both `Optional` and nullable, `CannotSetComputedValue` was thrown even when the property wasn't provided in the payload
- The `DefaultValuesDataPipe` injects an `Optional` value for missing optional properties, and `DataFromArrayResolver` mistakenly treated this as a user provided value
- Added a check mirroring the existing nullable computed property handling to also allow `Optional` defaults through

Fixes #1173