### PR TITLE
Support Inertia v3 by falling back to OptionalProp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev" : {
         "fakerphp/faker" : "^1.14",
         "friendsofphp/php-cs-fixer" : "^3.0",
-        "inertiajs/inertia-laravel" : "^2.0",
+        "inertiajs/inertia-laravel" : "^2.0|^3.0",
         "livewire/livewire" : "^3.0|^4.0",
         "mockery/mockery" : "^1.6",
         "nesbot/carbon" : "^2.63|^3.0",

--- a/src/Support/Lazy/InertiaLazy.php
+++ b/src/Support/Lazy/InertiaLazy.php
@@ -4,6 +4,7 @@ namespace Spatie\LaravelData\Support\Lazy;
 
 use Closure;
 use Inertia\LazyProp;
+use Inertia\OptionalProp;
 
 class InertiaLazy extends ConditionalLazy
 {
@@ -13,8 +14,13 @@ class InertiaLazy extends ConditionalLazy
         parent::__construct(fn () => true, $value);
     }
 
-    public function resolve(): LazyProp
+    public function resolve(): LazyProp|OptionalProp
     {
-        return new LazyProp($this->value);
+        // Prefer LazyProp on Inertia v2 to preserve consumer instanceof checks; LazyProp was removed in v3.
+        if (class_exists(LazyProp::class)) {
+            return new LazyProp($this->value);
+        }
+
+        return new OptionalProp($this->value);
     }
 }

--- a/tests/CreationTest.php
+++ b/tests/CreationTest.php
@@ -13,6 +13,7 @@ use Illuminate\Validation\ValidationException;
 use Inertia\DeferProp;
 use Inertia\Inertia;
 use Inertia\LazyProp;
+use Inertia\OptionalProp;
 
 use function Pest\Laravel\postJson;
 
@@ -1466,8 +1467,10 @@ it('can use auto lazy to construct an inertia lazy', function () {
 
     $data = $dataClass::from(['string' => 'Hello World']);
 
+    $expected = class_exists(LazyProp::class) ? LazyProp::class : OptionalProp::class;
+
     expect($data->string)->toBeInstanceOf(InertiaLazy::class);
-    expect($data->toArray()['string'])->toBeInstanceOf(LazyProp::class);
+    expect($data->toArray()['string'])->toBeInstanceOf($expected);
 })->skip('Re-enable test after Inertia supports Laravel 12');
 
 it('can use auto lazy to construct a closure lazy', function () {

--- a/tests/Resolvers/VisibleDataFieldsResolverTest.php
+++ b/tests/Resolvers/VisibleDataFieldsResolverTest.php
@@ -3,6 +3,7 @@
 use Inertia\DeferProp;
 use Inertia\Inertia;
 use Inertia\LazyProp;
+use Inertia\OptionalProp;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Attributes\Hidden;
 use Spatie\LaravelData\Data;
@@ -215,7 +216,9 @@ it('always transforms lazy inertia data to inertia lazy props', function () {
         }
     };
 
-    expect($dataClass::create('Freek')->toArray()['name'])->toBeInstanceOf(LazyProp::class);
+    $expected = class_exists(LazyProp::class) ? LazyProp::class : OptionalProp::class;
+
+    expect($dataClass::create('Freek')->toArray()['name'])->toBeInstanceOf($expected);
 })->skip('Re-enable test after Inertia supports Laravel 12');
 
 it('always transforms deferred inertia data to inertia deferred props', function () {

--- a/tests/Support/Lazy/InertiaLazyTest.php
+++ b/tests/Support/Lazy/InertiaLazyTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Inertia\LazyProp;
+use Inertia\OptionalProp;
+use Spatie\LaravelData\Support\Lazy\InertiaLazy;
+
+it('resolves to a LazyProp on Inertia v2', function () {
+    $lazy = new InertiaLazy(fn () => 'value');
+
+    expect($lazy->resolve())->toBeInstanceOf(LazyProp::class);
+})->skip(! class_exists(LazyProp::class), 'Requires Inertia v2 (LazyProp).');
+
+it('resolves to an OptionalProp on Inertia v3', function () {
+    $lazy = new InertiaLazy(fn () => 'value');
+
+    expect($lazy->resolve())->toBeInstanceOf(OptionalProp::class);
+})->skip(class_exists(LazyProp::class), 'Requires Inertia v3 (LazyProp removed).');
+
+it('resolves to either LazyProp or OptionalProp depending on Inertia version', function () {
+    $lazy = new InertiaLazy(fn () => 'value');
+
+    $resolved = $lazy->resolve();
+
+    expect($resolved)->toBeInstanceOf(
+        class_exists(LazyProp::class) ? LazyProp::class : OptionalProp::class
+    );
+});


### PR DESCRIPTION
Inertia v3 removed `LazyProp`. `Lazy::inertia` now returns `OptionalProp` when `LazyProp` is unavailable, preserving v2 behavior for consumer instanceof checks.

Bumps `inertiajs/inertia-laravel` to `^2.0|^3.0`.