### PR TITLE
Add AutoWhenAppendedLazy attribute and related tests

### DIFF
--- a/src/Attributes/AutoWhenAppendedLazy.php
+++ b/src/Attributes/AutoWhenAppendedLazy.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Spatie\LaravelData\Attributes;
+
+use Attribute;
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\LaravelData\Attributes\AutoLazy;
+use Spatie\LaravelData\Lazy;
+use Spatie\LaravelData\Support\DataProperty;
+use Spatie\LaravelData\Support\Lazy\ConditionalLazy;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class AutoWhenAppendedLazy extends AutoLazy
+{
+    public function __construct(
+        protected ?string $accessor = null,
+    ) {
+    }
+
+    public function build(Closure $castValue, mixed $payload, DataProperty $property, mixed $value): ConditionalLazy
+    {
+        $accessor = $this->forAccessor($property);
+
+        return Lazy::when(
+            fn () => $payload instanceof Model && in_array($accessor, $payload->getAppends()),
+            fn () => $castValue($payload->getAttribute($accessor))
+        );
+    }
+
+    public function forAccessor(DataProperty $property): ?string
+    {
+        return $this->accessor ?? $property->name;
+    }
+}

--- a/src/DataPipes/DefaultValuesDataPipe.php
+++ b/src/DataPipes/DefaultValuesDataPipe.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelData\DataPipes;
 
 use Illuminate\Database\Eloquent\Model;
+use Spatie\LaravelData\Attributes\AutoWhenAppendedLazy;
 use Spatie\LaravelData\Attributes\AutoWhenLoadedLazy;
 use Spatie\LaravelData\Lazy;
 use Spatie\LaravelData\Optional;
@@ -35,7 +36,7 @@ class DefaultValuesDataPipe implements DataPipe
             }
 
             if ($property->autoLazy
-                && $property->autoLazy instanceof AutoWhenLoadedLazy
+                && ($property->autoLazy instanceof AutoWhenLoadedLazy || $property->autoLazy instanceof AutoWhenAppendedLazy)
                 && $payload instanceof Model
             ) {
                 $properties[$name] = 'tbd'; // will be populated in cast pipe later on with the auto lazy value

--- a/tests/CreationTest.php
+++ b/tests/CreationTest.php
@@ -21,6 +21,7 @@ use Spatie\LaravelData\Attributes\AutoClosureLazy;
 use Spatie\LaravelData\Attributes\AutoInertiaDeferred;
 use Spatie\LaravelData\Attributes\AutoInertiaLazy;
 use Spatie\LaravelData\Attributes\AutoLazy;
+use Spatie\LaravelData\Attributes\AutoWhenAppendedLazy;
 use Spatie\LaravelData\Attributes\AutoWhenLoadedLazy;
 use Spatie\LaravelData\Attributes\Computed;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
@@ -1552,6 +1553,57 @@ it('can use auto lazy to construct a data object with property promotion', funct
         ->toBeArray()
         ->toHaveCount(2)
         ->each()->toBeInstanceOf(FakeNestedModelData::class);
+});
+
+it('can use auto lazy to construct a when appended lazy', function () {
+    $dataClass = new class () extends Data {
+        #[AutoWhenAppendedLazy]
+        public string|Lazy $accessor;
+    };
+
+    $model = FakeModel::factory()->create();
+
+    expect($dataClass::from($model)->all())->toBeEmpty();
+
+    $model->append('accessor');
+
+    expect($dataClass::from($model)->all()['accessor'])
+        ->toEqual("accessor_{$model->string}");
+});
+
+it('can use auto lazy to construct a when appended lazy with a manual defined accessor', function () {
+    $dataClass = new class () extends Data {
+        #[AutoWhenAppendedLazy('accessor')]
+        public string|Lazy $custom_name;
+    };
+
+    $model = FakeModel::factory()->create();
+
+    expect($dataClass::from($model)->all())->toBeEmpty();
+
+    $model->append('accessor');
+
+    expect($dataClass::from($model)->all()['custom_name'])
+        ->toEqual("accessor_{$model->string}");
+});
+
+it('can use auto lazy to construct a data object with property promotion and when appended lazy', function () {
+    $dataClass = new class ('') extends Data {
+        public function __construct(
+            #[AutoWhenAppendedLazy]
+            public string|Lazy $accessor
+        ) {
+        }
+    };
+
+    $model = FakeModel::factory()->create();
+
+    expect($dataClass::from($model)->all())->toBeEmpty();
+
+    $model->append('accessor');
+
+    expect($dataClass::from($model)->all()['accessor'])
+        ->toEqual("accessor_{$model->string}");
 });
 
 it('can create a data object with inertia deferred properties', function () {

--- a/tests/Support/DataPropertyTest.php
+++ b/tests/Support/DataPropertyTest.php
@@ -3,6 +3,7 @@
 use Spatie\LaravelData\Attributes\AutoClosureLazy;
 use Spatie\LaravelData\Attributes\AutoInertiaLazy;
 use Spatie\LaravelData\Attributes\AutoLazy;
+use Spatie\LaravelData\Attributes\AutoWhenAppendedLazy;
 use Spatie\LaravelData\Attributes\AutoWhenLoadedLazy;
 use Spatie\LaravelData\Attributes\Computed;
 use Spatie\LaravelData\Attributes\Hidden;
@@ -236,6 +237,13 @@ it('can check if a property is auto-lazy', function () {
         })->autoLazy
     )->toBeInstanceOf(AutoWhenLoadedLazy::class);
 
+    expect(
+        resolveHelper(new class () {
+            #[AutoWhenAppendedLazy('accessor')]
+            public string|Lazy $property;
+        })->autoLazy
+    )->toBeInstanceOf(AutoWhenAppendedLazy::class);
+    
     expect(
         resolveHelper(new class () {
             #[AutoClosureLazy]


### PR DESCRIPTION
Add attribute to support creating lazy properties for appended properties like accessors. Now accessor properties tagged with `AutoWhenAppendedLazy` attribute won't always be included when creating from a model unless explicitly appended.