### PR TITLE
Allow float values for Min, Max and Size validation attributes

### DIFF
--- a/src/Attributes/Validation/Max.php
+++ b/src/Attributes/Validation/Max.php
@@ -8,7 +8,7 @@ use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Max extends StringValidationAttribute
 {
-    public function __construct(protected int|ExternalReference $value)
+    public function __construct(protected int|float|ExternalReference $value)
     {
     }
 

--- a/src/Attributes/Validation/Min.php
+++ b/src/Attributes/Validation/Min.php
@@ -8,7 +8,7 @@ use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Min extends StringValidationAttribute
 {
-    public function __construct(protected int|ExternalReference $value)
+    public function __construct(protected int|float|ExternalReference $value)
     {
     }
 

--- a/src/Attributes/Validation/Size.php
+++ b/src/Attributes/Validation/Size.php
@@ -8,7 +8,7 @@ use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Size extends StringValidationAttribute
 {
-    public function __construct(protected int|ExternalReference $size)
+    public function __construct(protected int|float|ExternalReference $size)
     {
     }
 

--- a/tests/Datasets/RulesDataset.php
+++ b/tests/Datasets/RulesDataset.php
@@ -367,6 +367,11 @@ dataset('attributes', function () {
     );
 
     yield fixature(
+        attribute: new Max(10.5),
+        expected: 'max:10.5',
+    );
+
+    yield fixature(
         attribute: new MaxDigits(10),
         expected: 'max_digits:10',
     );
@@ -374,6 +379,11 @@ dataset('attributes', function () {
     yield fixature(
         attribute: new Min(10),
         expected: 'min:10',
+    );
+
+    yield fixature(
+        attribute: new Min(0.01),
+        expected: 'min:0.01',
     );
 
     yield fixature(
@@ -429,6 +439,11 @@ dataset('attributes', function () {
     yield fixature(
         attribute: new Size(10),
         expected: 'size:10',
+    );
+
+    yield fixature(
+        attribute: new Size(0.5),
+        expected: 'size:0.5',
     );
 
     yield fixature(


### PR DESCRIPTION
## Summary

The `Min`, `Max` and `Size` validation attribute constructors typed their value as `int|ExternalReference`. Since these classes don't declare strict types, PHP silently coerced floats to int (e.g. `#[Min(0.01)]` became `min:0`, letting `0` pass validation). Laravel's underlying validator accepts numeric values including floats for these rules.

Widened the parameter types to `int|float|ExternalReference`, mirroring `MultipleOf` which already supported floats. Digit-count rules (`Digits`, `MinDigits`, `MaxDigits`, `DigitsBetween`) and `Password` length stay `int`.

Added float fixtures to `RulesDataset` covering both rule rendering and round-trip parsing.

Closes #1183