### PR TITLE
Run rules() overrides regardless of property defaults

### DIFF
--- a/src/Resolvers/DataValidationRulesResolver.php
+++ b/src/Resolvers/DataValidationRulesResolver.php
@@ -38,14 +38,19 @@ class DataValidationRulesResolver
     ): array {
         $dataClass = $this->dataClassFromValidationPayloadResolver->execute($class, $fullPayload, $path);
 
-        $withoutValidationProperties = [];
+        $overwrittenRules = $this->resolveOverwrittenRules($dataClass, $fullPayload, $path);
 
         foreach ($dataClass->properties as $dataProperty) {
             $propertyPath = $path->property($dataProperty->inputMappedName ?? $dataProperty->name);
 
-            if ($this->shouldSkipPropertyValidation($dataProperty, $fullPayload, $propertyPath)) {
-                $withoutValidationProperties[] = $dataProperty->name;
+            if ($dataProperty->validate === false) {
+                continue;
+            }
 
+            if ($dataProperty->hasDefaultValue
+                && Arr::has($fullPayload, $propertyPath->get()) === false
+                && ! array_key_exists($dataProperty->name, $overwrittenRules)
+            ) {
                 continue;
             }
 
@@ -110,31 +115,14 @@ class DataValidationRulesResolver
             $dataRules->add($propertyPath, $rules);
         }
 
-        $this->resolveOverwrittenRules(
-            $dataClass,
-            $fullPayload,
+        $this->applyOverwrittenRules(
+            $overwrittenRules,
+            $dataClass->attributes->has(MergeValidationRules::class),
             $path,
             $dataRules,
-            $withoutValidationProperties
         );
 
         return $dataRules->rules;
-    }
-
-    protected function shouldSkipPropertyValidation(
-        DataProperty $dataProperty,
-        array $fullPayload,
-        ValidationPath $propertyPath,
-    ): bool {
-        if ($dataProperty->validate === false) {
-            return true;
-        }
-
-        if ($dataProperty->hasDefaultValue && Arr::has($fullPayload, $propertyPath->get()) === false) {
-            return true;
-        }
-
-        return false;
     }
 
     protected function resolveDataCollectionSpecificRules(
@@ -262,11 +250,9 @@ class DataValidationRulesResolver
         DataClass $class,
         array $fullPayload,
         ValidationPath $path,
-        DataRules $dataRules,
-        array $withoutValidationProperties
-    ): void {
+    ): array {
         if (! $class->hasDynamicValidationRules) {
-            return;
+            return [];
         }
 
         $validationContext = new ValidationContext(
@@ -275,14 +261,16 @@ class DataValidationRulesResolver
             $path
         );
 
-        $overwrittenRules = app()->call([$class->name, 'rules'], ['context' => $validationContext]);
-        $shouldMergeRules = $class->attributes->has(MergeValidationRules::class);
+        return app()->call([$class->name, 'rules'], ['context' => $validationContext]);
+    }
 
+    protected function applyOverwrittenRules(
+        array $overwrittenRules,
+        bool $shouldMergeRules,
+        ValidationPath $path,
+        DataRules $dataRules,
+    ): void {
         foreach ($overwrittenRules as $key => $rules) {
-            if (in_array($key, $withoutValidationProperties)) {
-                continue;
-            }
-
             $rules = collect(Arr::wrap($rules))
                 ->map(fn (mixed $rule) => $this->ruleDenormalizer->execute($rule, $path))
                 ->flatten()

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -2670,7 +2670,7 @@ it('wont validate default values when they are not provided', function () {
         ], ['default' => 'something']);
 });
 
-it('wont validate default values when they are not provided and rules are overwritten', function () {
+it('will validate default values when rules are overwritten', function () {
     $dataClass = new class () extends Data {
         public string $default = 'Hello World';
 
@@ -2683,11 +2683,13 @@ it('wont validate default values when they are not provided and rules are overwr
     };
 
     DataValidationAsserter::for($dataClass)
-        ->assertOk([])
+        ->assertErrors([])
         ->assertOk(['default' => 'Hi there in this world'])
         ->assertErrors(['default' => 'minimal'])
         ->assertErrors(['default' => null])
-        ->assertRules([], payload: [])
+        ->assertRules([
+            'default' => ['required', 'string', 'min:10'],
+        ], payload: [])
         ->assertRules([
             'default' => ['required', 'string', 'min:10'],
         ], ['default' => 'something']);


### PR DESCRIPTION
## Summary

Properties with a default value were silently dropping rules declared in the `rules()` method when the property was missing from the payload. Conditional rules like `required`, `required_if`, and `prohibited_if` never fired in this case, which broke the documented intent of `rules()`.

The skip in `DataValidationRulesResolver::shouldSkipPropertyValidation` was added in 60fbafc to prevent auto-generated rules from rejecting empty payloads on data classes with all-default properties (issue #441). That fix was correct for auto-rules, but it also short-circuited explicit overrides via `$withoutValidationProperties`, which was an unintended side effect.

## What changed

- `resolveOverwrittenRules` now runs upfront and returns the rule array. The result is threaded into the property loop so the default-value skip only applies when no override exists for that property.
- `applyOverwrittenRules` (renamed from the second half of the old method) writes the pre-resolved rules at the end. No more `$withoutValidationProperties` filter.
- `#[WithoutValidation]` no longer suppresses overrides for the same key. This restores pre-2023 behavior and matches the package's "if you write rules(), you own them" stance.

## Behavior change

Anyone relying on the old "default + missing payload silently drops `rules()` entries" behavior will now see those rules fire. The previous behavior was tested under `wont validate default values when they are not provided and rules are overwritten`, which is updated to `will validate default values when rules are overwritten` to reflect the corrected semantics.

Closes #1079