### PR TITLE
Fix #1188 by calculating promoted property default values from ancestors constructors

### DIFF
--- a/src/Support/Factories/DataClassFactory.php
+++ b/src/Support/Factories/DataClassFactory.php
@@ -5,7 +5,6 @@ namespace Spatie\LaravelData\Support\Factories;
 use Illuminate\Support\Collection;
 use ReflectionClass;
 use ReflectionMethod;
-use ReflectionParameter;
 use ReflectionProperty;
 use Spatie\LaravelData\Attributes\AutoLazy;
 use Spatie\LaravelData\Contracts\AppendableData;

--- a/src/Support/Factories/DataClassFactory.php
+++ b/src/Support/Factories/DataClassFactory.php
@@ -154,17 +154,23 @@ class DataClassFactory
             return $reflectionClass->getDefaultProperties();
         }
 
-        $values = collect($constructorReflectionMethod->getParameters())
-            ->filter(fn (ReflectionParameter $parameter) => $parameter->isPromoted() && $parameter->isDefaultValueAvailable())
-            ->mapWithKeys(fn (ReflectionParameter $parameter) => [
-                $parameter->name => $parameter->getDefaultValue(),
-            ])
-            ->toArray();
+        // Promoted properties store their default on the constructor parameter, not the
+        // property declaration, so they are invisible to getDefaultProperties(). Walk up from
+        // the concrete class collecting them; first definition wins so closer ancestors take priority.
+        $promotedDefaults = [];
+        $class = $reflectionClass;
+        $constructor = $constructorReflectionMethod;
+        do {
+            foreach ($constructor?->getParameters() ?? [] as $parameter) {
+                if ($parameter->isPromoted() && $parameter->isDefaultValueAvailable() && ! array_key_exists($parameter->name, $promotedDefaults)) {
+                    $promotedDefaults[$parameter->name] = $parameter->getDefaultValue();
+                }
+            }
+            $class = $class->getParentClass();
+            $constructor = $class ? $class->getConstructor() : null;
+        } while ($class);
 
-        return array_merge(
-            $reflectionClass->getDefaultProperties(),
-            $values
-        );
+        return array_merge($reflectionClass->getDefaultProperties(), $promotedDefaults);
     }
 
     /**

--- a/tests/Support/Factories/DataClassFactoryTest.php
+++ b/tests/Support/Factories/DataClassFactoryTest.php
@@ -8,7 +8,8 @@ use Spatie\LaravelData\Support\DataProperty;
 use Spatie\LaravelData\Support\Factories\DataClassFactory;
 
 it('can create a data class with defaults from promoted properties', function () {
-    class PromotedPropertyData extends Data {
+    class PromotedPropertyData extends Data
+    {
         public function __construct(
             public string $promotedProperty = 'hello',
             protected string $protectedPromotedProperty = 'hello',
@@ -30,7 +31,8 @@ it('can create a data class with defaults from promoted properties', function ()
 });
 
 it('can create a data class with defaults from inherited promoted properties', function () {
-    abstract class ParentNestedPromotedPropertyData extends Data {
+    abstract class ParentNestedPromotedPropertyData extends Data
+    {
         public function __construct(
             public string $promotedProperty = 'hello',
             public string $promotedPropertyWithOverride = 'hello',
@@ -38,7 +40,8 @@ it('can create a data class with defaults from inherited promoted properties', f
         }
     }
 
-    class NestedPromotedPropertyData extends ParentNestedPromotedPropertyData {
+    class NestedPromotedPropertyData extends ParentNestedPromotedPropertyData
+    {
         public function __construct(
             string $promotedProperty = 'hello from child',
             public string $promotedPropertyWithOverride = 'hello with override from child',

--- a/tests/Support/Factories/DataClassFactoryTest.php
+++ b/tests/Support/Factories/DataClassFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Support\Factories;
+
+use ReflectionClass;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Support\DataProperty;
+use Spatie\LaravelData\Support\Factories\DataClassFactory;
+
+it('can create a data class with defaults from promoted properties', function () {
+    class PromotedPropertyData extends Data {
+        public function __construct(
+            public string $promotedProperty = 'hello',
+            protected string $protectedPromotedProperty = 'hello',
+            string $property = 'hello',
+        ) {
+        }
+    }
+
+    $factory = app(DataClassFactory::class);
+    $dataClass = $factory->build(new ReflectionClass(PromotedPropertyData::class));
+
+    expect($dataClass->properties['promotedProperty'] ?? null)
+        ->toBeInstanceOf(DataProperty::class)
+        ->toHaveProperty('defaultValue', 'hello');
+
+    expect($dataClass->properties)
+        ->not()
+        ->toHaveProperty('protectedPromotedProperty');
+});
+
+it('can create a data class with defaults from inherited promoted properties', function () {
+    abstract class ParentNestedPromotedPropertyData extends Data {
+        public function __construct(
+            public string $promotedProperty = 'hello',
+            public string $promotedPropertyWithOverride = 'hello',
+        ) {
+        }
+    }
+
+    class NestedPromotedPropertyData extends ParentNestedPromotedPropertyData {
+        public function __construct(
+            string $promotedProperty = 'hello from child',
+            public string $promotedPropertyWithOverride = 'hello with override from child',
+        ) {
+            parent::__construct($promotedProperty, $promotedPropertyWithOverride);
+        }
+    }
+
+    $factory = app(DataClassFactory::class);
+    $dataClass = $factory->build(new ReflectionClass(NestedPromotedPropertyData::class));
+
+    expect($dataClass->properties['promotedProperty'] ?? null)
+        ->toBeInstanceOf(DataProperty::class)
+        ->toHaveProperty('defaultValue', 'hello');
+
+    expect($dataClass->properties['promotedPropertyWithOverride'] ?? null)
+        ->toBeInstanceOf(DataProperty::class)
+        ->toHaveProperty('defaultValue', 'hello with override from child');
+});


### PR DESCRIPTION
Fix #1188 by capturing default values from promoted properties in ancestors constructors.

See that [Github issue](https://github.com/spatie/laravel-data/issues/1188) for more details of why this functionality is required.

While it is technically possible to override the value passed into the constructor e.g.

```php
public function __construct(
    string $example = 'a different value to the parent default',
) {
    parent::__construct(example: $example);
}
```

This would quickly become very complicated to support as the constructor can execute arbitrary code and the parameters could have different names/orders etc.

I think it's a reasonable trade-off that we only consider the value at the time of _promotion_. This still allows the child to override the parent class default by promoting again (by adding `public`) e.g.

```php
public function __construct(
    public string $example = 'a different value to the parent default',
) {
    parent::__construct(example: $example);
}
```