### PR TITLE
Allow multiple conditional requiring rules

### DIFF
--- a/src/Support/Validation/PropertyRules.php
+++ b/src/Support/Validation/PropertyRules.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelData\Support\Validation;
 
 use Illuminate\Support\Arr;
+use Spatie\LaravelData\Attributes\Validation\Required;
 
 class PropertyRules
 {
@@ -21,7 +22,7 @@ class PropertyRules
 
     public function add(ValidationRule ...$rules): static
     {
-        $this->removeType(...$rules);
+        $this->removeDuplicateRules(...$rules);
 
         array_push($this->rules, ...$rules);
 
@@ -30,7 +31,7 @@ class PropertyRules
 
     public function prepend(ValidationRule ...$rules): static
     {
-        $this->removeType(...$rules);
+        $this->removeDuplicateRules(...$rules);
 
         $this->rules = Arr::prepend($this->rules, ...$rules);
 
@@ -48,6 +49,33 @@ class PropertyRules
                 }
 
                 if ($rule instanceof $class) {
+                    unset($this->rules[$i]);
+
+                    continue 2;
+                }
+            }
+        }
+
+        $this->rules = array_values($this->rules);
+
+        return $this;
+    }
+
+    protected function removeDuplicateRules(ValidationRule ...$rules): static
+    {
+        foreach ($this->rules as $i => $rule) {
+            foreach ($rules as $newRule) {
+                if ($newRule instanceof RequiringRule && ! $newRule instanceof Required) {
+                    if ($rule instanceof Required) {
+                        unset($this->rules[$i]);
+
+                        continue 2;
+                    }
+
+                    continue;
+                }
+
+                if ($rule instanceof $newRule) {
                     unset($this->rules[$i]);
 
                     continue 2;

--- a/tests/Support/Validation/PropertyRulesTest.php
+++ b/tests/Support/Validation/PropertyRulesTest.php
@@ -3,7 +3,10 @@
 use Spatie\LaravelData\Attributes\Validation\Min;
 use Spatie\LaravelData\Attributes\Validation\Prohibited;
 use Spatie\LaravelData\Attributes\Validation\Required;
+use Spatie\LaravelData\Attributes\Validation\RequiredUnless;
+use Spatie\LaravelData\Attributes\Validation\RequiredWith;
 use Spatie\LaravelData\Support\Validation\PropertyRules;
+use Spatie\LaravelData\Support\Validation\RequiringRule;
 
 it('can add rules', function () {
     $collection = PropertyRules::create()
@@ -35,6 +38,38 @@ it('can remove rules by class', function () {
     $collection = PropertyRules::create()
         ->add(new Min(10))
         ->removeType(Min::class);
+
+    expect($collection->all())->toEqual([]);
+});
+
+it('can add multiple conditional requiring rules', function () {
+    $collection = PropertyRules::create()
+        ->add(new RequiredUnless('requires_a', false))
+        ->add(new RequiredWith('b'))
+        ->add(new RequiredWith('c'));
+
+    expect($collection->all())->toEqual([
+        new RequiredUnless('requires_a', false),
+        new RequiredWith('b'),
+        new RequiredWith('c'),
+    ]);
+});
+
+it('will only keep one plain required rule', function () {
+    $collection = PropertyRules::create()
+        ->add(new Required())
+        ->add(new Required());
+
+    expect($collection->all())->toEqual([
+        new Required(),
+    ]);
+});
+
+it('can remove all requiring rules by interface', function () {
+    $collection = PropertyRules::create()
+        ->add(new RequiredUnless('requires_a', false))
+        ->add(new RequiredWith('b'))
+        ->removeType(RequiringRule::class);
 
     expect($collection->all())->toEqual([]);
 });

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -291,18 +291,18 @@ it('will never add extra require rules when not required', function () {
 
 it('is possible to have multiple required rules', function () {
     DataValidationAsserter::for(new class () extends Data {
-        #[RequiredUnless('is_required', false), RequiredWith('make_required')]
+        #[RequiredUnless('is_required', 'false'), RequiredWith('make_required')]
         public string $property;
 
         public string $make_required;
 
         public bool $is_required;
     })->assertRules([
-        'property' => ['string', 'required_unless:is_required', 'required_with:make_required'],
+        'property' => ['string', 'required_unless:is_required,false', 'required_with:make_required'],
         'make_required' => ['required', 'string'],
         'is_required' => ['required', 'boolean'],
     ]);
-})->skip('Add a new ruleinferrer to rule them all and make these cases better');
+});
 
 it('will take care of mapping', function () {
     DataValidationAsserter::for(new class () extends Data {


### PR DESCRIPTION
Fixes #647.

`PropertyRules::add()` currently deduplicates all `RequiringRule` implementations as a group. That means adding `RequiredWith` after `RequiredUnless`, or adding more than one `RequiredWith`, drops the earlier conditional required rules even though Laravel supports combining them.

This changes add/prepend deduplication so conditional requiring rules can accumulate, while generated/plain `Required` is still removed when an explicit conditional requiring rule is added. Explicit `removeType(RequiringRule::class)` still clears all requiring rules.

Tests:
- `php -l src\Support\Validation\PropertyRules.php`
- `php -l tests\Support\Validation\PropertyRulesTest.php`
- `php -l tests\ValidationTest.php`
- `php vendor\bin\pest tests\Support\Validation\PropertyRulesTest.php --no-coverage`
- `php vendor\bin\pest tests\ValidationTest.php --filter "multiple required rules" --no-coverage`
- `php vendor\bin\php-cs-fixer fix --dry-run --diff --allow-risky=yes --config=.php-cs-fixer.dist.php src\Support\Validation\PropertyRules.php tests\Support\Validation\PropertyRulesTest.php tests\ValidationTest.php`
- `php vendor\bin\phpstan analyse src\Support\Validation\PropertyRules.php --memory-limit=1G`

Local note: the full `tests\ValidationTest.php` file gets past the new regression, but one unrelated existing test fails on this Windows/PHP setup with phpDocumentor rejecting an anonymous-class FQSEN path.