### PR TITLE
Ignore original names for validated mapped input

### DIFF
--- a/src/DataPipes/MapPropertiesDataPipe.php
+++ b/src/DataPipes/MapPropertiesDataPipe.php
@@ -2,8 +2,10 @@
 
 namespace Spatie\LaravelData\DataPipes;
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Spatie\LaravelData\Support\Creation\CreationContext;
+use Spatie\LaravelData\Support\Creation\ValidationStrategy;
 use Spatie\LaravelData\Support\DataClass;
 use Spatie\LaravelData\Support\DataProperty;
 
@@ -25,6 +27,10 @@ class MapPropertiesDataPipe implements DataPipe
             }
 
             if (! Arr::has($properties, $dataProperty->inputMappedName)) {
+                if ($this->shouldRemoveUnmappedPropertyName($payload, $properties, $creationContext, $dataProperty)) {
+                    unset($properties[$dataProperty->name]);
+                }
+
                 continue;
             }
 
@@ -38,6 +44,20 @@ class MapPropertiesDataPipe implements DataPipe
         }
 
         return $properties;
+    }
+
+    protected function shouldRemoveUnmappedPropertyName(
+        mixed $payload,
+        array $properties,
+        CreationContext $creationContext,
+        DataProperty $dataProperty
+    ): bool {
+        if (! array_key_exists($dataProperty->name, $properties)) {
+            return false;
+        }
+
+        return $creationContext->validationStrategy === ValidationStrategy::Always
+            || ($creationContext->validationStrategy === ValidationStrategy::OnlyRequests && $payload instanceof Request);
     }
 
     protected function addPropertyMappingToCreationContext(

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -28,6 +28,7 @@ use Spatie\LaravelData\Attributes\MergeValidationRules;
 use Spatie\LaravelData\Attributes\PropertyForMorph;
 use Spatie\LaravelData\Attributes\Validation\ArrayType;
 use Spatie\LaravelData\Attributes\Validation\Bail;
+use Spatie\LaravelData\Attributes\Validation\Between;
 use Spatie\LaravelData\Attributes\Validation\BooleanType;
 use Spatie\LaravelData\Attributes\Validation\Exists;
 use Spatie\LaravelData\Attributes\Validation\In;
@@ -391,6 +392,20 @@ it('will take care of mapping', function () {
                 'data_collection_cased_property' => [[]],
             ],
         ]);
+});
+
+it('will not use original property names for mapped properties during validated creation', function () {
+    $dataClass = new class () extends Data {
+        #[Between(1, 200)]
+        #[MapInputName('page.size')]
+        public int $size = 10;
+    };
+
+    expect($dataClass::from(['size' => 300])->size)->toBe(300);
+    expect($dataClass::validateAndCreate(['size' => 300])->size)->toBe(10);
+    expect($dataClass::validateAndCreate(['page' => ['size' => 100]])->size)->toBe(100);
+    expect(fn () => $dataClass::validateAndCreate(['page' => ['size' => 300]]))
+        ->toThrow(ValidationException::class);
 });
 
 it('can disable validation', function () {


### PR DESCRIPTION
Fixes #1019.

This prevents mapped input properties from falling back to the original PHP property name when validated creation is being used. Without this, an input like `['size' => 300]` can bypass validation rules defined for the mapped input name `page.size` and still hydrate the property.

The change only removes the unmapped original property during validation-backed creation, so existing unvalidated `from()` behavior continues to accept the original property name.

Tests run:

- `php vendor/bin/php-cs-fixer fix --dry-run --diff --allow-risky=yes --config=.php-cs-fixer.dist.php src/DataPipes/MapPropertiesDataPipe.php tests/ValidationTest.php`
- `php vendor/bin/phpstan analyse src/DataPipes/MapPropertiesDataPipe.php --memory-limit=1G`
- `php vendor/bin/pest tests/ValidationTest.php --filter "original property names" --no-coverage`
- `php vendor/bin/pest tests/MappingTest.php --no-coverage`

Not run: full `tests/ValidationTest.php` on my Windows/PHP 8.3 setup, because it hits an unrelated phpDocumentor FQSEN parsing issue in `it can overwrite collection item rules with wildcard rules`.