### PR TITLE
Add support to deserialize readonly properties

### DIFF
--- a/src/Resolvers/DataFromArrayResolver.php
+++ b/src/Resolvers/DataFromArrayResolver.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelData\Resolvers;
 
 use ArgumentCountError;
+use ReflectionProperty;
 use Spatie\LaravelData\Contracts\BaseData;
 use Spatie\LaravelData\Exceptions\CannotCreateData;
 use Spatie\LaravelData\Exceptions\CannotSetComputedValue;
@@ -35,7 +36,6 @@ class DataFromArrayResolver
         foreach ($dataClass->properties as $property) {
             if (
                 $property->isPromoted
-                || $property->isReadonly
                 || ! array_key_exists($property->name, $properties)
             ) {
                 continue;
@@ -68,6 +68,14 @@ class DataFromArrayResolver
                 }
 
                 continue; // Ignore the value being passed into the computed property and let it be recalculated
+            }
+
+            if ($property->isReadonly) {
+                if (! isset($data->{$property->name})) {
+                    (new ReflectionProperty($property->className, $property->name))->setValue($data, $properties[$property->name]);
+                }
+
+                continue;
             }
 
             $data->{$property->name} = $properties[$property->name];

--- a/tests/CreationTest.php
+++ b/tests/CreationTest.php
@@ -80,6 +80,10 @@ use Spatie\LaravelData\Tests\Fakes\PropertyMorphableDataB;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
 use Spatie\LaravelData\Tests\Fakes\SimpleDataWithoutConstructor;
 use Spatie\LaravelData\Tests\Fakes\SimpleDataWithPropertyHooks;
+use Spatie\LaravelData\Tests\Stubs\ArtistType;
+use Spatie\LaravelData\Tests\Stubs\Contract;
+use Spatie\LaravelData\Tests\Stubs\Musician;
+use Spatie\LaravelData\Tests\Stubs\Singer;
 
 it('can use default types to create data objects', function () {
     $data = ComplicatedData::from([
@@ -1839,5 +1843,62 @@ describe('property-morphable creation tests', function () {
         expect(fn () => AbstractPropertyMorphableData::from([
             'variant' => 'c',
         ]))->toThrow(CannotCreateAbstractClass::class);
+    });
+
+    it('will allow property-morphable data with readonly properties to be created', function () {
+        $contract = Contract::from([
+            'label' => ['name' => 'PIAS', 'country' => 'US'],
+            'artist' => ['type' => 'singer', 'name' => 'Rick Astley', 'voice' => 'tenor'],
+        ]);
+
+        expect($contract->artist)
+            ->toBeInstanceOf(Singer::class)
+            ->type->toEqual(ArtistType::Singer)
+            ->name->toEqual('Rick Astley')
+            ->voice->toEqual('tenor');
+
+        expect($contract->label)
+            ->name->toEqual('PIAS')
+            ->country->toEqual('US');
+
+        $contract = Contract::from([
+            'label' => ['name' => 'EMI', 'country' => 'UK'],
+            'artist' => ['type' => 'musician', 'name' => 'Freddie Mercury', 'instrument' => 'piano'],
+        ]);
+
+        expect($contract->artist)
+            ->toBeInstanceOf(Musician::class)
+            ->type->toEqual(ArtistType::Musician)
+            ->name->toEqual('Freddie Mercury')
+            ->instrument->toEqual('piano');
+    });
+
+    it('will allow property-morphable data with readonly properties to be created from JSON', function () {
+
+        $json = <<<JSON
+        {
+          "label": {
+            "name": "PIAS",
+            "country": "US"
+          },
+          "artist": {
+            "type": "singer",
+            "name": "Rick Astley",
+            "voice": "tenor"
+          }
+        }
+        JSON;
+
+        $contract = Contract::from($json);
+
+        expect($contract->artist)
+            ->toBeInstanceOf(Singer::class)
+            ->type->toEqual(ArtistType::Singer)
+            ->name->toEqual('Rick Astley')
+            ->voice->toEqual('tenor');
+
+        expect($contract->label)
+            ->name->toEqual('PIAS')
+            ->country->toEqual('US');
     });
 });

--- a/tests/Stubs/ArtistType.php
+++ b/tests/Stubs/ArtistType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\LaravelData\Tests\Stubs;
+
+enum ArtistType: string
+{
+    case Singer = 'singer';
+    case Musician = 'musician';
+}

--- a/tests/Stubs/Contract.php
+++ b/tests/Stubs/Contract.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\LaravelData\Tests\Stubs;
+
+use Spatie\LaravelData\Data;
+
+final class Contract extends Data
+{
+    public readonly RecordLabel $label;
+    public readonly Person $artist;
+}

--- a/tests/Stubs/Musician.php
+++ b/tests/Stubs/Musician.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\LaravelData\Tests\Stubs;
+
+class Musician extends Person
+{
+    public readonly string $instrument;
+}

--- a/tests/Stubs/Person.php
+++ b/tests/Stubs/Person.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\LaravelData\Tests\Stubs;
+
+use Spatie\LaravelData\Attributes\PropertyForMorph;
+use Spatie\LaravelData\Contracts\PropertyMorphableData;
+use Spatie\LaravelData\Data;
+
+abstract class Person extends Data implements PropertyMorphableData
+{
+    #[PropertyForMorph]
+    public readonly ArtistType $type;
+
+    public readonly string $name;
+
+    public static function morph(array $properties): ?string
+    {
+        return match ($properties['type']) {
+            ArtistType::Singer => Singer::class,
+            ArtistType::Musician => Musician::class,
+        };
+    }
+}

--- a/tests/Stubs/RecordLabel.php
+++ b/tests/Stubs/RecordLabel.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\LaravelData\Tests\Stubs;
+
+use Spatie\LaravelData\Data;
+
+final class RecordLabel extends Data
+{
+    public readonly string $name;
+    public readonly string $country;
+}

--- a/tests/Stubs/Singer.php
+++ b/tests/Stubs/Singer.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\LaravelData\Tests\Stubs;
+
+final class Singer extends Person
+{
+    public readonly string $voice;
+}


### PR DESCRIPTION
The PR is a proposal to allow deserialization of readonly properties.

### Motivation
I'm currently handling a project that has integrations with external services. Using the library allows to create objects from the data and encapsulate specific login into it, which is very valuable.

However, the limitation of not being able to deserialize into readonly properties, especially in a context that heavily relies on `#[PropertyForMorph]` for polymorphic types (like `Person` in the case of this PR), poses some challenges that readonly properties would cover nicely.

Therefore, I decided to open this PR as I believe there is use cases in which leveraging readonly properties.

