### PR TITLE
Fix validation of keyed collections with dotted array keys

### DIFF
--- a/src/Resolvers/DataValidationRulesResolver.php
+++ b/src/Resolvers/DataValidationRulesResolver.php
@@ -178,7 +178,7 @@ class DataValidationRulesResolver
         DataRules $dataRules,
     ): void {
         foreach ($collectionPayload as $key => $value) {
-            $itemPath = $propertyPath->property($key);
+            $itemPath = $propertyPath->property(str_replace('.', '\.', $key));
 
             if (! is_array($value)) {
                 $dataRules->add($itemPath, ['array']);

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -856,6 +856,35 @@ it('will validate a nullable collection', function () {
         ]);
 });
 
+it('will validate a keyed collection whose keys contain dots', function () {
+    $dataClass = new class () extends Data {
+        /** @var array<string, SimpleData> */
+        #[DataCollectionOf(SimpleData::class)]
+        public array $collection;
+    };
+
+    DataValidationAsserter::for($dataClass)
+        ->assertOk([
+            'collection' => [
+                'key.with.dots' => ['string' => 'Never Gonna'],
+                'another.key' => ['string' => 'Give You Up'],
+            ],
+        ])
+        ->assertErrors([
+            'collection' => [
+                'key.with.dots' => ['other_string' => 'Hello World'],
+            ],
+        ])
+        ->assertRules([
+            'collection' => ['present', 'array'],
+            'collection.key\.with\.dots.string' => ['required', 'string'],
+        ], [
+            'collection' => [
+                'key.with.dots' => [],
+            ],
+        ]);
+});
+
 it('will validate an optional collection', function () {
     $dataClass = new class () extends Data {
         #[DataCollectionOf(SimpleData::class)]


### PR DESCRIPTION
Fixes #1198

When a keyed collection (`array<string, ChildData>`) has array keys containing literal dots, validation reports the fields as missing. The static rules path added in #1043 builds the rule key from the raw array key, so `key.with.dots` gets treated as nested path segments (`items.key.with.dots.string`) instead of one key.

This escapes the dots in the collection key so the rule key becomes `items.key\.with\.dots.string`, matching how the dynamic `Rule::forEach` path already handles it.
