### PR TITLE
Add chainable responseStatus method and defaultResponseStatus support

### DIFF
--- a/docs/as-a-resource/from-data-to-resource.md
+++ b/docs/as-a-resource/from-data-to-resource.md
@@ -182,6 +182,34 @@ SongData::empty(except: ['name']); // Will return the `artist` property
 
 When a resource is being returned from a controller, the status code of the response will automatically be set to `201 CREATED` when Laravel data detects that the request's method is `POST`.  In all other cases, `200 OK` will be returned.
 
+It is possible to set the status code of the response on a specific data instance:
+
+```php
+SongData::from(Song::first())->responseStatus(202);
+```
+
+This also works on data collections:
+
+```php
+SongData::collect(Song::all(), DataCollection::class)->responseStatus(202);
+```
+
+A default status code can be set for all responses of a data class by implementing the `defaultResponseStatus` method:
+
+```php
+class SongData extends Data
+{
+    // ...
+
+    public function defaultResponseStatus(): int
+    {
+        return 202;
+    }
+}
+```
+
+A status code set on a specific data instance always takes precedence over the default status code of the data class.
+
 ## Resource classes
 
 To make it a bit more clear that a data object is a resource, you can use the `Resource` class instead of the `Data` class:

--- a/src/Concerns/ContextableData.php
+++ b/src/Concerns/ContextableData.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelData\Concerns;
 
 use Spatie\LaravelData\Contracts\IncludeableData as IncludeableDataContract;
+use Spatie\LaravelData\Contracts\ResponsableData as ResponsableDataContract;
 use Spatie\LaravelData\Contracts\WrappableData as WrappableDataContract;
 use Spatie\LaravelData\Support\Partials\Partial;
 use Spatie\LaravelData\Support\Partials\PartialsCollection;
@@ -20,6 +21,11 @@ trait ContextableData
             $wrap = match (true) {
                 method_exists($this, 'defaultWrap') => new Wrap(WrapType::Defined, $this->defaultWrap()),
                 default => new Wrap(WrapType::UseGlobal),
+            };
+
+            $responseStatus = match (true) {
+                method_exists($this, 'defaultResponseStatus') => $this->defaultResponseStatus(),
+                default => null,
             };
 
             $includePartials = null;
@@ -67,6 +73,7 @@ trait ContextableData
                 $onlyPartials,
                 $exceptPartials,
                 $this instanceof WrappableDataContract ? $wrap : new Wrap(WrapType::UseGlobal),
+                $this instanceof ResponsableDataContract ? $responseStatus : null,
             );
         }
 

--- a/src/Concerns/ResponsableData.php
+++ b/src/Concerns/ResponsableData.php
@@ -63,8 +63,19 @@ trait ResponsableData
         );
     }
 
+    public function responseStatus(int $statusCode): static
+    {
+        $this->getDataContext()->responseStatus = $statusCode;
+
+        return $this;
+    }
+
     protected function calculateResponseStatus(Request $request): int
     {
+        if ($this->getDataContext()->responseStatus !== null) {
+            return $this->getDataContext()->responseStatus;
+        }
+
         return $request->isMethod(Request::METHOD_POST) ? Response::HTTP_CREATED : Response::HTTP_OK;
     }
 

--- a/src/Contracts/ResponsableData.php
+++ b/src/Contracts/ResponsableData.php
@@ -13,6 +13,8 @@ interface ResponsableData extends Responsable
      */
     public function toResponse($request);
 
+    public function responseStatus(int $statusCode);
+
     public static function allowedRequestIncludes(): ?array;
 
     public static function allowedRequestExcludes(): ?array;

--- a/src/Support/Transformation/DataContext.php
+++ b/src/Support/Transformation/DataContext.php
@@ -15,6 +15,7 @@ class DataContext
         public ?PartialsCollection $onlyPartials,
         public ?PartialsCollection $exceptPartials,
         public ?Wrap $wrap = null,
+        public ?int $responseStatus = null,
     ) {
     }
 
@@ -133,6 +134,7 @@ class DataContext
             'onlyPartials' => $this->onlyPartials?->toSerializedArray(),
             'exceptPartials' => $this->exceptPartials?->toSerializedArray(),
             'wrap' => $this->wrap?->toSerializedArray(),
+            'responseStatus' => $this->responseStatus,
         ];
     }
 
@@ -154,6 +156,7 @@ class DataContext
             wrap: $content['wrap']
                 ? Wrap::fromSerializedArray($content['wrap'])
                 : null,
+            responseStatus: $content['responseStatus'] ?? null,
         );
     }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -11,6 +11,7 @@ use function Pest\Laravel\postJson;
 
 use Spatie\LaravelData\Attributes\WithoutValidation;
 use Spatie\LaravelData\Data;
+use Spatie\LaravelData\DataCollection;
 use Spatie\LaravelData\Tests\Fakes\SimpleData;
 use Spatie\LaravelData\Tests\Fakes\SimpleDataWithExplicitValidationRuleAttributeData;
 
@@ -65,6 +66,67 @@ it('is possible to overwrite the status response code', function () {
     ])
         ->assertStatus(301)
         ->assertJson(['string' => 'Hello']);
+});
+
+it('can set a response status code on a data instance', function () {
+    Route::post('/example-route', function () {
+        return SimpleData::from(request()->input('string'))->responseStatus(202);
+    });
+
+    postJson('/example-route', [
+        'string' => 'Hello',
+    ])
+        ->assertStatus(202)
+        ->assertJson(['string' => 'Hello']);
+});
+
+it('can define a default response status code on a data class', function () {
+    Route::post('/example-route', function () {
+        return new class (request()->input('string')) extends SimpleData {
+            public function defaultResponseStatus(): int
+            {
+                return 202;
+            }
+        };
+    });
+
+    postJson('/example-route', [
+        'string' => 'Hello',
+    ])
+        ->assertStatus(202)
+        ->assertJson(['string' => 'Hello']);
+});
+
+it('will prefer a response status code set on a data instance over a default response status code', function () {
+    Route::post('/example-route', function () {
+        $data = new class (request()->input('string')) extends SimpleData {
+            public function defaultResponseStatus(): int
+            {
+                return 202;
+            }
+        };
+
+        return $data->responseStatus(418);
+    });
+
+    postJson('/example-route', [
+        'string' => 'Hello',
+    ])
+        ->assertStatus(418)
+        ->assertJson(['string' => 'Hello']);
+});
+
+it('can set a response status code on a data collection', function () {
+    Route::post('/example-route', function () {
+        return SimpleData::collect(['Hello', 'World'], DataCollection::class)->responseStatus(202);
+    });
+
+    postJson('/example-route')
+        ->assertStatus(202)
+        ->assertJson([
+            ['string' => 'Hello'],
+            ['string' => 'World'],
+        ]);
 });
 
 it('can fail validation', function () {

--- a/tests/Support/Transformation/DataContextTest.php
+++ b/tests/Support/Transformation/DataContextTest.php
@@ -22,6 +22,7 @@ it('can serialize and deserialize a data context', function () {
         onlyPartials: null,
         exceptPartials: null,
         wrap: new Wrap(type: WrapType::Defined, key: 'key'),
+        responseStatus: 202,
     );
 
     $serializable = $context->toSerializedArray();
@@ -38,7 +39,8 @@ it('can serialize and deserialize a data context', function () {
         ->excludePartials->toBeNull()
         ->onlyPartials->toBeNull()
         ->exceptPartials->toBeNull()
-        ->wrap->toEqual($context->wrap);
+        ->wrap->toEqual($context->wrap)
+        ->responseStatus->toBe(202);
 
     $partials = $deserialized->includePartials->toArray();
     $expectedPartials = $context->includePartials->toArray();


### PR DESCRIPTION
This PR adds the ability to customize the HTTP status code of the response a data object produces, without leaving the data object's fluent API.

Since #291, `calculateResponseStatus()` returns 201 CREATED for POST requests and 200 OK otherwise. Sometimes that guess is not what we need: a POST that queues work for later should answer `202 Accepted`, a POST-based search endpoint answers `200 OK`. Correcting it per call site forces an early type-drop from `Data` to `Response`:

```php
// Before: converted to a response manually, losing the Data type
return UserData::from($user)
    ->toResponse($request)
    ->setStatusCode(202);
```

This was previously proposed in #891 and closed because it added a status property to every data object. This PR stores the status on the `DataContext` instead, where `wrap()` already keeps its per-instance response state, so data objects gain no new properties:

```php
// After: stays a Data object all the way down
return UserData::from($user)->responseStatus(202);
```

A class-level default can be set with a `defaultResponseStatus` method, mirroring `defaultWrap`:

```php
class UserData extends Data
{
    public function defaultResponseStatus(): int
    {
        return 202;
    }
}
```

A status chained on the instance wins over the class default, which wins over the POST heuristic.