### PR TITLE
Capture promoted property defaults declared in ancestor constructors

### DIFF
--- a/src/Support/Factories/DataClassFactory.php
+++ b/src/Support/Factories/DataClassFactory.php
@@ -5,7 +5,6 @@ namespace Spatie\LaravelData\Support\Factories;
 use Illuminate\Support\Collection;
 use ReflectionClass;
 use ReflectionMethod;
-use ReflectionParameter;
 use ReflectionProperty;
 use Spatie\LaravelData\Attributes\AutoLazy;
 use Spatie\LaravelData\Contracts\AppendableData;

--- a/src/Support/Factories/DataClassFactory.php
+++ b/src/Support/Factories/DataClassFactory.php
@@ -154,17 +154,23 @@ class DataClassFactory
             return $reflectionClass->getDefaultProperties();
         }
 
-        $values = collect($constructorReflectionMethod->getParameters())
-            ->filter(fn (ReflectionParameter $parameter) => $parameter->isPromoted() && $parameter->isDefaultValueAvailable())
-            ->mapWithKeys(fn (ReflectionParameter $parameter) => [
-                $parameter->name => $parameter->getDefaultValue(),
-            ])
-            ->toArray();
+        // Promoted properties store their default on the constructor parameter, not the
+        // property declaration, so they are invisible to getDefaultProperties(). Walk up from
+        // the concrete class collecting them; first definition wins so closer ancestors take priority.
+        $promotedDefaults = [];
+        $class = $reflectionClass;
+        $constructor = $constructorReflectionMethod;
+        do {
+            foreach ($constructor?->getParameters() ?? [] as $parameter) {
+                if ($parameter->isPromoted() && $parameter->isDefaultValueAvailable() && ! array_key_exists($parameter->name, $promotedDefaults)) {
+                    $promotedDefaults[$parameter->name] = $parameter->getDefaultValue();
+                }
+            }
+            $class = $class->getParentClass();
+            $constructor = $class ? $class->getConstructor() : null;
+        } while ($class);
 
-        return array_merge(
-            $reflectionClass->getDefaultProperties(),
-            $values
-        );
+        return array_merge($reflectionClass->getDefaultProperties(), $promotedDefaults);
     }
 
     /**

--- a/tests/Support/Factories/DataClassFactoryTest.php
+++ b/tests/Support/Factories/DataClassFactoryTest.php
@@ -8,7 +8,8 @@ use Spatie\LaravelData\Support\DataProperty;
 use Spatie\LaravelData\Support\Factories\DataClassFactory;
 
 it('can create a data class with defaults from promoted properties', function () {
-    class PromotedPropertyData extends Data {
+    class PromotedPropertyData extends Data
+    {
         public function __construct(
             public string $promotedProperty = 'hello',
             protected string $protectedPromotedProperty = 'hello',
@@ -30,7 +31,8 @@ it('can create a data class with defaults from promoted properties', function ()
 });
 
 it('can create a data class with defaults from inherited promoted properties', function () {
-    abstract class ParentNestedPromotedPropertyData extends Data {
+    abstract class ParentNestedPromotedPropertyData extends Data
+    {
         public function __construct(
             public string $promotedProperty = 'hello',
             public string $promotedPropertyWithOverride = 'hello',
@@ -38,7 +40,8 @@ it('can create a data class with defaults from inherited promoted properties', f
         }
     }
 
-    class NestedPromotedPropertyData extends ParentNestedPromotedPropertyData {
+    class NestedPromotedPropertyData extends ParentNestedPromotedPropertyData
+    {
         public function __construct(
             string $promotedProperty = 'hello from child',
             public string $promotedPropertyWithOverride = 'hello with override from child',

--- a/tests/Support/Factories/DataClassFactoryTest.php
+++ b/tests/Support/Factories/DataClassFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Spatie\LaravelData\Tests\Support\Factories;
+
+use ReflectionClass;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Support\DataProperty;
+use Spatie\LaravelData\Support\Factories\DataClassFactory;
+
+it('can create a data class with defaults from promoted properties', function () {
+    class PromotedPropertyData extends Data {
+        public function __construct(
+            public string $promotedProperty = 'hello',
+            protected string $protectedPromotedProperty = 'hello',
+            string $property = 'hello',
+        ) {
+        }
+    }
+
+    $factory = app(DataClassFactory::class);
+    $dataClass = $factory->build(new ReflectionClass(PromotedPropertyData::class));
+
+    expect($dataClass->properties['promotedProperty'] ?? null)
+        ->toBeInstanceOf(DataProperty::class)
+        ->toHaveProperty('defaultValue', 'hello');
+
+    expect($dataClass->properties)
+        ->not()
+        ->toHaveProperty('protectedPromotedProperty');
+});
+
+it('can create a data class with defaults from inherited promoted properties', function () {
+    abstract class ParentNestedPromotedPropertyData extends Data {
+        public function __construct(
+            public string $promotedProperty = 'hello',
+            public string $promotedPropertyWithOverride = 'hello',
+        ) {
+        }
+    }
+
+    class NestedPromotedPropertyData extends ParentNestedPromotedPropertyData {
+        public function __construct(
+            string $promotedProperty = 'hello from child',
+            public string $promotedPropertyWithOverride = 'hello with override from child',
+        ) {
+            parent::__construct($promotedProperty, $promotedPropertyWithOverride);
+        }
+    }
+
+    $factory = app(DataClassFactory::class);
+    $dataClass = $factory->build(new ReflectionClass(NestedPromotedPropertyData::class));
+
+    expect($dataClass->properties['promotedProperty'] ?? null)
+        ->toBeInstanceOf(DataProperty::class)
+        ->toHaveProperty('defaultValue', 'hello');
+
+    expect($dataClass->properties['promotedPropertyWithOverride'] ?? null)
+        ->toBeInstanceOf(DataProperty::class)
+        ->toHaveProperty('defaultValue', 'hello with override from child');
+});

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -3382,3 +3382,96 @@ describe('property-morphable validation tests', function () {
             ]);
     });
 });
+
+describe('property-morphable data inheriting a default value', function () {
+    abstract class TestMorphableDefaultValueData extends Data implements PropertyMorphableData
+    {
+        public function __construct(
+            #[PropertyForMorph]
+            public string $type,
+            public bool $example_bool = true,
+        ) {
+        }
+
+        public static function morph(array $properties): ?string
+        {
+            return match ($properties['type'] ?? null) {
+                'inherited' => TestInheritedMorphableDefaultValueData::class,
+                'promoted' => TestPromotedMorphableDefaultValueData::class,
+                default => null,
+            };
+        }
+    }
+
+    class TestInheritedMorphableDefaultValueData extends TestMorphableDefaultValueData
+    {
+        public function __construct(bool $example_bool = true)
+        {
+            parent::__construct(type: 'inherited', example_bool: $example_bool);
+        }
+    }
+
+    class TestPromotedMorphableDefaultValueData extends TestMorphableDefaultValueData
+    {
+        public function __construct(public bool $example_bool = true)
+        {
+            parent::__construct(type: 'promoted', example_bool: $example_bool);
+        }
+    }
+
+    it('can validate a child promoting the inherited property', function () {
+        expect(TestPromotedMorphableDefaultValueData::validate(['type' => 'promoted']))
+            ->toEqual(['type' => 'promoted']);
+    });
+
+    it('can validate a child not promoting the inherited property', function () {
+        expect(TestInheritedMorphableDefaultValueData::validate(['type' => 'inherited']))
+            ->toEqual(['type' => 'inherited']);
+    });
+});
+
+describe('plain data inheriting a default value', function () {
+    it('can validate a child not promoting the inherited property', function () {
+        abstract class TestBaseDefaultValueData extends Data
+        {
+            public function __construct(
+                public bool $some_flag = true,
+            ) {
+            }
+        }
+
+        class TestInheritedDefaultValueData extends TestBaseDefaultValueData
+        {
+            public function __construct(bool $some_flag = true)
+            {
+                parent::__construct(some_flag: $some_flag);
+            }
+        }
+
+        expect(TestInheritedDefaultValueData::validate([]))
+            ->toEqual([]);
+    });
+});
+
+describe('plain data inheriting a string default value', function () {
+    it('can validate a child not promoting the inherited property', function () {
+        abstract class TestBaseStringDefaultData extends Data
+        {
+            public function __construct(
+                public string $some_string = 'default',
+            ) {
+            }
+        }
+
+        class TestInheritedStringDefaultData extends TestBaseStringDefaultData
+        {
+            public function __construct(string $some_string = 'default')
+            {
+                parent::__construct(some_string: $some_string);
+            }
+        }
+
+        expect(TestInheritedStringDefaultData::validate([]))
+            ->toEqual([]);
+    });
+});


### PR DESCRIPTION
Fixes #1188. Supersedes #1189 — the two fix commits are @bentleyo's, unchanged apart from being rebased onto main. He offered to hand it over in https://github.com/spatie/laravel-data/pull/1189#issuecomment-5235418338, so the tests are mine and the fix is his.

When a parent declares a promoted constructor property with a default and a child redeclares the same parameter without promoting it, the default never reaches the data class. `resolveDefaultValues()` only looked at the constructor of the class being built, and only at promoted parameters. `getDefaultProperties()` can't see it either, because a promoted property carries its default on the constructor parameter, not on the property declaration. `hasDefaultValue` stays `false`, so `DataValidationRulesResolver` doesn't skip the property when it's missing from the payload, and `RequiredRuleInferrer` marks it required.

The fix walks up the ancestor constructors collecting promoted defaults, first definition wins, so a child can still override by promoting again. Only the value at the point of promotion counts — a child that passes something else to `parent::__construct()` isn't tracked, since constructors can run arbitrary code.

Two things that seem worth knowing before this merges.

The issue describes a 4.22.0 regression, and for bool properties that's exactly right: #1177 removed the two guards that had kept bools out of `required`, which is correct on its own but uncovered this. For other scalar types the same shape has been failing far longer. A `string` version of the same two classes throws `The some string field is required.` on 4.19.0, on main, and on everything I tried in between. So this doesn't only restore 4.21 behaviour for bools, it changes validation for plain string properties in that shape too. I'd expect int and float to go the same way, though string is the only one I actually ran.

The other report in #1188, from Patabugen, is a different bug and this PR doesn't fix it. That one is a plain property with a default plus a `rules()` override, where `hasDefaultValue` is already `true`. It breaks on the `$overwrittenRules` check added in #1187, so it starts at 4.23.0 rather than 4.22.0. That behaviour looks deliberate — #1187 was made in response to #1079, which asked for the opposite — but the report probably wants its own issue instead of being closed along with this one.

The tests are four validation-level cases: the morph scenario from the issue, its promoted sibling as a control, and the same thing on plain `Data` with a bool and with a string. They're in the first commit, red, and green from the second commit on. The `DataClassFactoryTest` in @bentleyo's commit covers the factory side.
