### PR TITLE
fix: pacify PHP 8.2 typed property guards in validation attributes & Uncastable singleton

### DIFF
--- a/src/Attributes/Validation/ArrayType.php
+++ b/src/Attributes/Validation/ArrayType.php
@@ -9,7 +9,7 @@ use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class ArrayType extends StringValidationAttribute
 {
-    protected array $keys;
+    protected array $keys = [];
 
     public function __construct(array|string|ExternalReference ...$keys)
     {

--- a/src/Attributes/Validation/Email.php
+++ b/src/Attributes/Validation/Email.php
@@ -17,7 +17,7 @@ class Email extends StringValidationAttribute
     public const SpoofCheckValidation = 'spoof';
     public const FilterEmailValidation = 'filter';
 
-    protected array $modes;
+    protected array $modes = [];
 
     public function __construct(array|string|ExternalReference ...$modes)
     {

--- a/src/Attributes/Validation/MimeTypes.php
+++ b/src/Attributes/Validation/MimeTypes.php
@@ -9,7 +9,7 @@ use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class MimeTypes extends StringValidationAttribute
 {
-    protected array $mimeTypes;
+    protected array $mimeTypes = [];
 
     public function __construct(string|array|ExternalReference ...$mimeTypes)
     {

--- a/src/Attributes/Validation/Mimes.php
+++ b/src/Attributes/Validation/Mimes.php
@@ -9,7 +9,7 @@ use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Mimes extends StringValidationAttribute
 {
-    protected array $mimes;
+    protected array $mimes = [];
 
     public function __construct(string|array|ExternalReference ...$mimes)
     {

--- a/src/Attributes/Validation/NotIn.php
+++ b/src/Attributes/Validation/NotIn.php
@@ -15,7 +15,7 @@ class NotIn extends ObjectValidationAttribute
 {
     protected ?BaseNotIn $rule = null;
 
-    protected array $values;
+    protected array $values = [];
 
     public function __construct(array|Arrayable|string|UnitEnum|BaseNotIn|ExternalReference ...$values)
     {

--- a/src/Attributes/Validation/Prohibits.php
+++ b/src/Attributes/Validation/Prohibits.php
@@ -9,7 +9,7 @@ use Spatie\LaravelData\Support\Validation\References\FieldReference;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Prohibits extends StringValidationAttribute
 {
-    protected array $fields;
+    protected array $fields = [];
 
     public function __construct(array|string|FieldReference ...$fields)
     {

--- a/src/Attributes/Validation/RequiredWith.php
+++ b/src/Attributes/Validation/RequiredWith.php
@@ -10,7 +10,7 @@ use Spatie\LaravelData\Support\Validation\RequiringRule;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class RequiredWith extends StringValidationAttribute implements RequiringRule
 {
-    protected array $fields;
+    protected array $fields = [];
 
     public function __construct(array|string|FieldReference ...$fields)
     {

--- a/src/Attributes/Validation/RequiredWithAll.php
+++ b/src/Attributes/Validation/RequiredWithAll.php
@@ -10,7 +10,7 @@ use Spatie\LaravelData\Support\Validation\RequiringRule;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class RequiredWithAll extends StringValidationAttribute implements RequiringRule
 {
-    protected array $fields;
+    protected array $fields = [];
 
     public function __construct(array|string|FieldReference ...$fields)
     {

--- a/src/Attributes/Validation/RequiredWithout.php
+++ b/src/Attributes/Validation/RequiredWithout.php
@@ -10,7 +10,7 @@ use Spatie\LaravelData\Support\Validation\RequiringRule;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class RequiredWithout extends StringValidationAttribute implements RequiringRule
 {
-    protected array $fields;
+    protected array $fields = [];
 
     public function __construct(array|string|FieldReference ...$fields)
     {

--- a/src/Attributes/Validation/RequiredWithoutAll.php
+++ b/src/Attributes/Validation/RequiredWithoutAll.php
@@ -10,7 +10,7 @@ use Spatie\LaravelData\Support\Validation\RequiringRule;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class RequiredWithoutAll extends StringValidationAttribute implements RequiringRule
 {
-    protected array $fields;
+    protected array $fields = [];
 
     public function __construct(array|string|FieldReference ...$fields)
     {

--- a/src/Attributes/Validation/Url.php
+++ b/src/Attributes/Validation/Url.php
@@ -9,7 +9,7 @@ use Spatie\LaravelData\Support\Validation\References\ExternalReference;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class Url extends StringValidationAttribute
 {
-    protected array $protocols;
+    protected array $protocols = [];
 
     public function __construct(
         string|array|ExternalReference ...$protocols

--- a/src/Casts/Uncastable.php
+++ b/src/Casts/Uncastable.php
@@ -4,7 +4,7 @@ namespace Spatie\LaravelData\Casts;
 
 class Uncastable
 {
-    public static Uncastable $instance;
+    private static ?self $instance = null;
 
     private function __construct()
     {

--- a/tests/Attributes/Validation/ValidationAttributeTest.php
+++ b/tests/Attributes/Validation/ValidationAttributeTest.php
@@ -1,8 +1,19 @@
 <?php
 
 use Carbon\CarbonImmutable;
+use Spatie\LaravelData\Attributes\Validation\ArrayType;
+use Spatie\LaravelData\Attributes\Validation\Email;
+use Spatie\LaravelData\Attributes\Validation\Mimes;
+use Spatie\LaravelData\Attributes\Validation\MimeTypes;
+use Spatie\LaravelData\Attributes\Validation\Prohibits;
+use Spatie\LaravelData\Attributes\Validation\RequiredWith;
+use Spatie\LaravelData\Attributes\Validation\RequiredWithAll;
+use Spatie\LaravelData\Attributes\Validation\RequiredWithout;
+use Spatie\LaravelData\Attributes\Validation\RequiredWithoutAll;
 use Spatie\LaravelData\Attributes\Validation\StringType;
 use Spatie\LaravelData\Attributes\Validation\StringValidationAttribute;
+use Spatie\LaravelData\Attributes\Validation\Ulid;
+use Spatie\LaravelData\Attributes\Validation\Url;
 use Spatie\LaravelData\Tests\Fakes\Enums\DummyBackedEnum;
 
 it('can get a string representation of rules', function () {
@@ -79,4 +90,29 @@ it('can normalize values', function ($input, $output) {
          [DummyBackedEnum::FOO, DummyBackedEnum::BOO],
         'foo,boo',
     ];
+});
+
+it('can use Ulid attribute on constructor promoted parameters', function () {
+    $class = new class ('01ARZ3NDEKTSV4RRFFQ69G5FAV') {
+        public function __construct(
+            #[Ulid]
+            public string $id,
+        ) {
+        }
+    };
+
+    expect($class->id)->toBe('01ARZ3NDEKTSV4RRFFQ69G5FAV');
+});
+
+it('can initialize validation attributes with default parameters without uninitialized property errors', function () {
+    expect((new RequiredWith())->parameters())->toBe([[]])
+        ->and((new RequiredWithout())->parameters())->toBe([[]])
+        ->and((new RequiredWithAll())->parameters())->toBe([[]])
+        ->and((new RequiredWithoutAll())->parameters())->toBe([[]])
+        ->and((new Prohibits())->parameters())->toBe([[]])
+        ->and((new Url())->parameters())->toBe([])
+        ->and((new ArrayType())->parameters())->toBe([])
+        ->and((new Mimes())->parameters())->toBe([[]])
+        ->and((new MimeTypes())->parameters())->toBe([[]])
+        ->and((new Email())->parameters())->toBe(['rfc']);
 });


### PR DESCRIPTION
### Summary

- **Validation Attributes**: Initialize default `protected array $fields = [];` across 11 validation attributes (`ArrayType`, `Email`, `Mimes`, `MimeTypes`, `NotIn`, `Prohibits`, `RequiredWith`, `RequiredWithAll`, `RequiredWithout`, `RequiredWithoutAll`, `Url`) to prevent PHP 8.2 `Error: Typed property must not be accessed before initialization` during reflection introspection.
- **Uncastable**: Convert `Uncastable::$instance` to `private static ?self $instance = null` so PHP 8.2 stops crying when inspecting uncastable types before first instantiation.

Includes Pest unit tests for default attribute parameter instantiation.