### PR TITLE
refactor: modernize cache command exit codes & DRY builtin type checks

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -127,18 +127,6 @@ parameters:
 			path: src/CursorPaginatedDataCollection.php
 
 		-
-			message: '#^Call to function property_exists\(\) with \$this\(Spatie\\LaravelData\\Data\) and ''_dataContext'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Data.php
-
-		-
-			message: '#^Instanceof between \*NEVER\* and Spatie\\LaravelData\\Contracts\\BaseDataCollectable will always evaluate to false\.$#'
-			identifier: instanceof.alwaysFalse
-			count: 1
-			path: src/Data.php
-
-		-
 			message: '#^Method Spatie\\LaravelData\\Data\:\:__sleep\(\) should return array\<int, string\> but returns array\<string, mixed\>\.$#'
 			identifier: return.type
 			count: 1
@@ -239,18 +227,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Resolvers/ValidatedPayloadResolver.php
-
-		-
-			message: '#^Call to function property_exists\(\) with \$this\(Spatie\\LaravelData\\Resource\) and ''_dataContext'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Resource.php
-
-		-
-			message: '#^Instanceof between \*NEVER\* and Spatie\\LaravelData\\Contracts\\BaseDataCollectable will always evaluate to false\.$#'
-			identifier: instanceof.alwaysFalse
-			count: 1
-			path: src/Resource.php
 
 		-
 			message: '#^Method Spatie\\LaravelData\\Resource\:\:__sleep\(\) should return array\<int, string\> but returns array\<string, mixed\>\.$#'

--- a/src/Casts/BuiltinTypeCast.php
+++ b/src/Casts/BuiltinTypeCast.php
@@ -7,12 +7,31 @@ use Spatie\LaravelData\Support\DataProperty;
 
 class BuiltinTypeCast implements Cast, IterableItemCast
 {
+    public const TYPE_BOOL = 'bool';
+    public const TYPE_INT = 'int';
+    public const TYPE_FLOAT = 'float';
+    public const TYPE_ARRAY = 'array';
+    public const TYPE_STRING = 'string';
+
+    public const SUPPORTED_TYPES = [
+        self::TYPE_BOOL,
+        self::TYPE_INT,
+        self::TYPE_FLOAT,
+        self::TYPE_ARRAY,
+        self::TYPE_STRING,
+    ];
+
     /**
-     * @param 'bool'|'int'|'float'|'array'|'string' $type
+     * @param self::TYPE_* $type
      */
     public function __construct(
         protected string $type,
     ) {
+    }
+
+    public static function supports(string $type): bool
+    {
+        return in_array($type, self::SUPPORTED_TYPES, true);
     }
 
     public function cast(DataProperty $property, mixed $value, array $properties, CreationContext $context): mixed
@@ -28,11 +47,11 @@ class BuiltinTypeCast implements Cast, IterableItemCast
     protected function runCast(mixed $value): mixed
     {
         return match ($this->type) {
-            'bool' => $this->castToBool($value),
-            'int' => (int) $value,
-            'float' => (float) $value,
-            'array' => (array) $value,
-            'string' => (string) $value,
+            self::TYPE_BOOL => $this->castToBool($value),
+            self::TYPE_INT => (int) $value,
+            self::TYPE_FLOAT => (float) $value,
+            self::TYPE_ARRAY => (array) $value,
+            self::TYPE_STRING => (string) $value,
         };
     }
 

--- a/src/Commands/DataMakeCommand.php
+++ b/src/Commands/DataMakeCommand.php
@@ -30,14 +30,14 @@ class DataMakeCommand extends GeneratorCommand
 
     protected function getDefaultNamespace($rootNamespace): string
     {
-        $namespace = trim($this->option('namespace'), '\\');
+        $namespace = trim((string) $this->option('namespace'), '\\');
 
         return trim($rootNamespace . '\\' . $namespace, '\\');
     }
 
     protected function qualifyClass($name): string
     {
-        $suffix = trim($this->option('suffix'));
+        $suffix = trim((string) $this->option('suffix'));
         if (! empty($suffix) && ! Str::endsWith($name, $suffix)) {
             $name .= $suffix;
         }

--- a/src/Commands/DataStructuresCacheCommand.php
+++ b/src/Commands/DataStructuresCacheCommand.php
@@ -8,7 +8,9 @@ use Spatie\LaravelData\Support\Caching\CachedDataConfig;
 use Spatie\LaravelData\Support\Caching\DataClassFinder;
 use Spatie\LaravelData\Support\Caching\DataStructureCache;
 use Spatie\LaravelData\Support\Factories\DataClassFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'data:cache-structures')]
 class DataStructuresCacheCommand extends Command
 {
     protected $signature = 'data:cache-structures {--show-classes : Show the data classes cached}';
@@ -18,11 +20,11 @@ class DataStructuresCacheCommand extends Command
     public function handle(
         DataStructureCache $dataStructureCache,
         DataClassFactory $dataClassFactory,
-    ): void {
+    ): int {
         if (config('data.structure_caching.enabled') === false) {
             $this->error('Data structure caching is not enabled');
 
-            return;
+            return self::FAILURE;
         }
 
         $this->components->info('Caching data structures...');
@@ -56,5 +58,7 @@ class DataStructuresCacheCommand extends Command
                 array_map(fn (string $dataClass) => [$dataClass], $dataClasses)
             );
         }
+
+        return self::SUCCESS;
     }
 }

--- a/src/DataPipes/CastPropertiesDataPipe.php
+++ b/src/DataPipes/CastPropertiesDataPipe.php
@@ -238,7 +238,7 @@ class CastPropertiesDataPipe implements DataPipe
             }
         }
 
-        if (in_array($property->type->iterableItemType, ['bool', 'int', 'float', 'array', 'string'])) {
+        if (BuiltinTypeCast::supports($property->type->iterableItemType)) {
             return new BuiltinTypeCast($property->type->iterableItemType);
         }
 

--- a/tests/Casts/BuiltinTypeCastTest.php
+++ b/tests/Casts/BuiltinTypeCastTest.php
@@ -36,3 +36,16 @@ it('can cast builtin types', function (string $type, mixed $input, mixed $expect
     'string types' => ['string', 42, '42'],
     'array types' => ['array', (object) ['key' => 'value'], ['key' => 'value']],
 ]);
+
+it('checks supported builtin types', function (string $type, bool $expected) {
+    expect(BuiltinTypeCast::supports($type))->toBe($expected);
+})->with([
+    ['bool', true],
+    ['int', true],
+    ['float', true],
+    ['array', true],
+    ['string', true],
+    ['object', false],
+    ['null', false],
+    ['mixed', false],
+]);


### PR DESCRIPTION
### Summary

- **DataStructuresCacheCommand**: Add `#[AsCommand]` attribute and return explicit `int` (`self::SUCCESS` / `self::FAILURE`) exit codes.
- **BuiltinTypeCast**: Add `supports(string $type): bool` method to encapsulate supported types and DRY up `CastPropertiesDataPipe`.
- **phpstan-baseline**: Remove 4 obsolete type-narrowing rules.